### PR TITLE
feat(desktop): model selection, settings layout, sidebar improvements

### DIFF
--- a/apps/desktop/electron/app-store-composer.ts
+++ b/apps/desktop/electron/app-store-composer.ts
@@ -1,5 +1,5 @@
 import { sessionKey } from "@pi-gui/pi-sdk-driver";
-import type { SessionRef } from "@pi-gui/session-driver";
+import type { SessionConfig, SessionRef } from "@pi-gui/session-driver";
 import type { ComposerImageAttachment, DesktopAppState, WorkspaceSessionTarget } from "../src/desktop-state";
 import { toSessionRef } from "./app-store-utils";
 import {
@@ -153,6 +153,7 @@ export async function setSessionModel(
 
   return store.withErrorHandling(async () => {
     await store.driver.setSessionModel(sessionRef, { provider, modelId });
+    syncSessionConfig(store, key, { provider, modelId });
     return finishComposerCommand(store, sessionRef, key, `Model set to ${provider}:${modelId}`);
   });
 }
@@ -166,6 +167,7 @@ export async function setSessionThinkingLevel(
   const key = sessionKey(sessionRef);
   return store.withErrorHandling(async () => {
     await store.driver.setSessionThinkingLevel(sessionRef, thinkingLevel);
+    syncSessionConfig(store, key, { thinkingLevel });
     return finishComposerCommand(store, sessionRef, key, `Thinking set to ${thinkingLevel}`);
   });
 }
@@ -231,6 +233,12 @@ export async function sendMessageToSession(
   }
 }
 
+/** Eagerly merge config fields so finishComposerCommand sees them before the async sessionUpdated event arrives. */
+function syncSessionConfig(store: AppStoreInternals, key: string, patch: Partial<SessionConfig>): void {
+  const current = store.sessionState.sessionConfigBySession.get(key) ?? {};
+  store.sessionState.sessionConfigBySession.set(key, { ...current, ...patch });
+}
+
 async function runComposerCommand(
   store: AppStoreInternals,
   sessionRef: SessionRef,
@@ -252,11 +260,13 @@ async function runComposerCommand(
       provider: parsed.provider,
       modelId: parsed.modelId,
     });
+    syncSessionConfig(store, key, { provider: parsed.provider, modelId: parsed.modelId });
     return finishComposerCommand(store, sessionRef, key, `Model set to ${parsed.provider}:${parsed.modelId}`);
   }
 
   if (parsed.type === "thinking") {
     await store.driver.setSessionThinkingLevel(sessionRef, parsed.thinkingLevel);
+    syncSessionConfig(store, key, { thinkingLevel: parsed.thinkingLevel });
     return finishComposerCommand(store, sessionRef, key, `Thinking set to ${parsed.thinkingLevel}`);
   }
 

--- a/apps/desktop/electron/app-store-persistence.ts
+++ b/apps/desktop/electron/app-store-persistence.ts
@@ -10,6 +10,7 @@ export interface PersistedUiState {
   readonly composerDraftsBySession?: Record<string, string>;
   readonly notificationPreferences?: NotificationPreferences;
   readonly lastViewedAtBySession?: Record<string, string>;
+  readonly workspaceOrder?: readonly string[];
 }
 
 export interface LegacyPersistedUiState extends PersistedUiState {
@@ -30,6 +31,7 @@ export async function readPersistedUiState(uiStateFilePath: string): Promise<Leg
       composerDraftsBySession: parsed.composerDraftsBySession,
       notificationPreferences: parsed.notificationPreferences,
       lastViewedAtBySession: parsed.lastViewedAtBySession,
+      workspaceOrder: Array.isArray(parsed.workspaceOrder) ? parsed.workspaceOrder : undefined,
       composerAttachmentsBySession: parsed.composerAttachmentsBySession,
       transcripts: parsed.transcripts,
     };

--- a/apps/desktop/electron/app-store-worktree.ts
+++ b/apps/desktop/electron/app-store-worktree.ts
@@ -110,12 +110,18 @@ export async function startThread(store: AppStoreInternals, input: StartThreadIn
     store.sessionState.transcriptCache.set(key, []);
     store.sessionState.loadedTranscriptKeys.add(key);
     store.updateSessionConfig(session.ref, session.config);
-    await store.ensureSessionSubscribed(session.ref);
-    if (prompt) {
-      await sendMessageToSession(store, session.ref, prompt, []);
+
+    if (input.provider && input.modelId) {
+      await store.driver.setSessionModel(session.ref, { provider: input.provider, modelId: input.modelId });
+    }
+    if (input.thinkingLevel) {
+      await store.driver.setSessionThinkingLevel(session.ref, input.thinkingLevel);
     }
 
-    return store.refreshState({
+    await store.ensureSessionSubscribed(session.ref);
+
+    // Navigate to thread view immediately so streaming deltas render live
+    const state = await store.refreshState({
       selectedWorkspaceId: session.ref.workspaceId,
       selectedSessionId: session.ref.sessionId,
       composerDraft: "",
@@ -123,6 +129,16 @@ export async function startThread(store: AppStoreInternals, input: StartThreadIn
       refreshWorktrees: input.environment === "new-worktree",
       activeView: "threads",
     });
+
+    // Fire message in background — assistantDelta events flow through
+    // handleSessionEvent → emit() and update React while on the thread view
+    if (prompt) {
+      void sendMessageToSession(store, session.ref, prompt, []).catch((error) => {
+        void store.withError(error);
+      });
+    }
+
+    return state;
   });
 }
 

--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -148,6 +148,20 @@ export class DesktopAppStore implements AppStoreInternals {
     return workspace.removeWorkspace(this, workspaceId);
   }
 
+  async reorderWorkspaces(order: readonly string[]): Promise<DesktopAppState> {
+    await this.initialize();
+    const primaryIds = new Set(this.state.workspaces.filter((w) => w.kind === "primary").map((w) => w.id));
+    const sanitized = [...new Set(order)].filter((id) => primaryIds.has(id));
+    this.state = {
+      ...this.state,
+      workspaceOrder: sanitized,
+      lastError: undefined,
+      revision: this.state.revision + 1,
+    };
+    await this.persistUiState();
+    return this.emit();
+  }
+
   async selectWorkspace(workspaceId: string): Promise<DesktopAppState> {
     return workspace.selectWorkspace(this, workspaceId);
   }
@@ -371,6 +385,7 @@ export class DesktopAppStore implements AppStoreInternals {
           ...persisted.notificationPreferences,
         },
         lastViewedAtBySession: persisted.lastViewedAtBySession ?? {},
+        workspaceOrder: persisted.workspaceOrder ?? [],
       };
       await this.migrateLegacyPersistence(persisted);
       this.sessionState.lastViewedAtBySession.clear();
@@ -510,6 +525,7 @@ export class DesktopAppStore implements AppStoreInternals {
       sessionCommandsBySession: mapToRecord(this.sessionState.sessionCommandsBySession),
       sessionExtensionUiBySession: this.serializeSessionExtensionUiState(),
       lastViewedAtBySession: mapToRecord(this.sessionState.lastViewedAtBySession),
+      workspaceOrder: this.state.workspaceOrder,
       composerDraft: this.resolveComposerDraft(selectedWorkspaceId, selectedSessionId, options.composerDraft),
       composerAttachments: this.resolveComposerAttachments(selectedWorkspaceId, selectedSessionId),
       lastError: this.resolveSelectedSessionError(selectedWorkspaceId, selectedSessionId, options.clearLastError),
@@ -923,6 +939,7 @@ export class DesktopAppStore implements AppStoreInternals {
       composerDraftsBySession: mapToRecord(this.sessionState.composerDraftsBySession),
       notificationPreferences: this.state.notificationPreferences,
       lastViewedAtBySession: mapToRecord(this.sessionState.lastViewedAtBySession),
+      workspaceOrder: this.state.workspaceOrder.length > 0 ? this.state.workspaceOrder : undefined,
     };
 
     await writePersistedUiState(this.uiStateFilePath, payload);

--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -615,9 +615,23 @@ export class DesktopAppStore implements AppStoreInternals {
     }
 
     const unsubscribe = this.driver.subscribe(sessionRef, (event) => {
-      void this.handleSessionEvent(event);
+      void this.handleSessionEvent(event, key);
     });
     this.sessionState.sessionSubscriptions.set(key, unsubscribe);
+  }
+
+  private migrateSessionSubscriptionKey(sourceKey: string, targetKey: string): void {
+    if (sourceKey === targetKey || this.sessionState.sessionSubscriptions.has(targetKey)) {
+      return;
+    }
+
+    const unsubscribe = this.sessionState.sessionSubscriptions.get(sourceKey);
+    if (!unsubscribe) {
+      return;
+    }
+
+    this.sessionState.sessionSubscriptions.delete(sourceKey);
+    this.sessionState.sessionSubscriptions.set(targetKey, unsubscribe);
   }
 
   async cancelPendingDialogsForSession(sessionRef: SessionRef): Promise<void> {
@@ -759,8 +773,11 @@ export class DesktopAppStore implements AppStoreInternals {
     }
   }
 
-  private async handleSessionEvent(event: SessionDriverEvent): Promise<void> {
+  private async handleSessionEvent(event: SessionDriverEvent, subscriptionKey = sessionKey(event.sessionRef)): Promise<void> {
     const key = sessionKey(event.sessionRef);
+    if (subscriptionKey !== key) {
+      this.migrateSessionSubscriptionKey(subscriptionKey, key);
+    }
     const knownSession = this.sessionFromState(event.sessionRef);
     if (
       !knownSession &&
@@ -769,15 +786,20 @@ export class DesktopAppStore implements AppStoreInternals {
         event.type === "runCompleted" ||
         event.type === "hostUiRequest")
     ) {
+      const selectedKey =
+        this.state.selectedWorkspaceId && this.state.selectedSessionId
+          ? sessionKey({
+              workspaceId: this.state.selectedWorkspaceId,
+              sessionId: this.state.selectedSessionId,
+            })
+          : undefined;
+      const shouldFollowSessionMutation = subscriptionKey !== key && selectedKey === subscriptionKey;
       await this.refreshState({
         selectedWorkspaceId:
           this.state.selectedWorkspaceId === event.sessionRef.workspaceId
             ? event.sessionRef.workspaceId
             : this.state.selectedWorkspaceId,
-        selectedSessionId:
-          this.state.selectedWorkspaceId === event.sessionRef.workspaceId
-            ? event.sessionRef.sessionId
-            : this.state.selectedSessionId,
+        selectedSessionId: shouldFollowSessionMutation ? event.sessionRef.sessionId : this.state.selectedSessionId,
         clearLastError: true,
       });
     }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -149,6 +149,7 @@ app.whenReady().then(async () => {
     store.renameWorkspace(workspaceId, displayName),
   );
   ipcMain.handle(desktopIpc.removeWorkspace, (_event, workspaceId: string) => store.removeWorkspace(workspaceId));
+  ipcMain.handle(desktopIpc.reorderWorkspaces, (_event, order: readonly string[]) => store.reorderWorkspaces(order));
   ipcMain.handle(desktopIpc.openWorkspaceInFinder, async (_event, workspaceId: string) => {
     const workspacePath = store.getWorkspacePath(workspaceId);
     if (!workspacePath) {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -46,6 +46,8 @@ contextBridge.exposeInMainWorld("piApp", {
     ipcRenderer.invoke(desktopIpc.renameWorkspace, workspaceId, displayName) as Promise<DesktopAppState>,
   removeWorkspace: (workspaceId: string) =>
     ipcRenderer.invoke(desktopIpc.removeWorkspace, workspaceId) as Promise<DesktopAppState>,
+  reorderWorkspaces: (workspaceOrder: readonly string[]) =>
+    ipcRenderer.invoke(desktopIpc.reorderWorkspaces, workspaceOrder) as Promise<DesktopAppState>,
   openWorkspaceInFinder: (workspaceId: string) =>
     ipcRenderer.invoke(desktopIpc.openWorkspaceInFinder, workspaceId) as Promise<void>,
   createWorktree: (input: CreateWorktreeInput) =>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -52,6 +52,9 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@types/node": "^22.13.0",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -220,6 +220,17 @@ export default function App() {
   const newThreadWorkspace =
     rootWorkspaceOptions.find((entry) => entry.id === newThreadRootWorkspaceId) ?? rootWorkspaceOptions[0];
   const newThreadRuntime = newThreadWorkspace ? snapshot?.runtimeByWorkspace[newThreadWorkspace.id] : undefined;
+  const newThreadDefaultEnabled = (() => {
+    const rt = newThreadRuntime;
+    if (!rt?.settings.defaultProvider || !rt?.settings.defaultModelId) return false;
+    const model = rt.models.find(
+      (m) => m.providerId === rt.settings.defaultProvider && m.modelId === rt.settings.defaultModelId,
+    );
+    if (!model?.available) return false;
+    const patterns = rt.settings.enabledModelPatterns;
+    if (patterns.length === 0) return true;
+    return patterns.includes(`${model.providerId}/${model.modelId}`);
+  })();
   const newThreadTargetWorkspace = useMemo(
     () =>
       newThreadTargetWorkspaceId
@@ -240,7 +251,7 @@ export default function App() {
   const persistedComposerDraft = snapshot?.composerDraft ?? "";
   const threadGroups = useMemo(
     () => (snapshot ? buildThreadGroups(snapshot) : []),
-    [snapshot?.workspaces, snapshot?.worktreesByWorkspace],
+    [snapshot?.workspaces, snapshot?.worktreesByWorkspace, snapshot?.workspaceOrder],
   );
   const resetNewThreadWorktreeTarget = () => {
     setNewThreadEnvironment("local");
@@ -792,8 +803,8 @@ export default function App() {
     }
     const modelConfig = {
       prompt: newThreadPrompt,
-      provider: newThreadProvider ?? newThreadRuntime?.settings.defaultProvider,
-      modelId: newThreadModelId ?? newThreadRuntime?.settings.defaultModelId,
+      provider: newThreadProvider ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultProvider : undefined),
+      modelId: newThreadModelId ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultModelId : undefined),
       thinkingLevel: newThreadThinkingLevel ?? newThreadRuntime?.settings.defaultThinkingLevel,
     };
     const input: StartThreadInput =
@@ -1057,8 +1068,8 @@ export default function App() {
               environment={newThreadEnvironment}
               currentWorktreeName={newThreadTargetWorkspace?.kind === "worktree" ? newThreadTargetWorkspace.name : undefined}
               prompt={newThreadPrompt}
-              provider={newThreadProvider ?? newThreadRuntime?.settings.defaultProvider}
-              modelId={newThreadModelId ?? newThreadRuntime?.settings.defaultModelId}
+              provider={newThreadProvider ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultProvider : undefined)}
+              modelId={newThreadModelId ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultModelId : undefined)}
               thinkingLevel={newThreadThinkingLevel ?? newThreadRuntime?.settings.defaultThinkingLevel}
               onChangePrompt={setNewThreadPrompt}
               onSelectEnvironment={setNewThreadEnvironment}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -821,6 +821,7 @@ export default function App() {
             environment: newThreadEnvironment,
             ...modelConfig,
           };
+    wsMenu.expandWorkspace(newThreadRootWorkspaceId);
     void updateSnapshot(api, setSnapshot, () =>
       api.startThread(input),
     ).then(() => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -787,7 +787,7 @@ export default function App() {
   };
 
   const handleStartThread = () => {
-    if (!newThreadRootWorkspaceId) {
+    if (!newThreadRootWorkspaceId || !newThreadPrompt.trim()) {
       return;
     }
     const modelConfig = {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -121,6 +121,9 @@ export default function App() {
   const [newThreadEnvironment, setNewThreadEnvironment] = useState<NewThreadEnvironment>("local");
   const [newThreadTargetWorkspaceId, setNewThreadTargetWorkspaceId] = useState("");
   const [newThreadPrompt, setNewThreadPrompt] = useState("");
+  const [newThreadProvider, setNewThreadProvider] = useState<string | undefined>();
+  const [newThreadModelId, setNewThreadModelId] = useState<string | undefined>();
+  const [newThreadThinkingLevel, setNewThreadThinkingLevel] = useState<string | undefined>();
   const [themeMode, setThemeMode] = useState<"system" | "light" | "dark">("system");
   const [dockExpandedBySession, setDockExpandedBySession] = useState<Record<string, boolean>>({});
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
@@ -214,6 +217,9 @@ export default function App() {
   const settingsRuntime = settingsWorkspace ? snapshot?.runtimeByWorkspace[settingsWorkspace.id] : undefined;
   const skillsRuntime = skillsWorkspace ? snapshot?.runtimeByWorkspace[skillsWorkspace.id] : undefined;
   const extensionsRuntime = extensionsWorkspace ? snapshot?.runtimeByWorkspace[extensionsWorkspace.id] : undefined;
+  const newThreadWorkspace =
+    rootWorkspaceOptions.find((entry) => entry.id === newThreadRootWorkspaceId) ?? rootWorkspaceOptions[0];
+  const newThreadRuntime = newThreadWorkspace ? snapshot?.runtimeByWorkspace[newThreadWorkspace.id] : undefined;
   const newThreadTargetWorkspace = useMemo(
     () =>
       newThreadTargetWorkspaceId
@@ -528,6 +534,9 @@ export default function App() {
 
   const handleSelectNewThreadWorkspace = (workspaceId: string) => {
     setNewThreadRootWorkspaceId(workspaceId);
+    setNewThreadProvider(undefined);
+    setNewThreadModelId(undefined);
+    setNewThreadThinkingLevel(undefined);
     if (isWorktreeForRoot(newThreadTargetWorkspace, workspaceId)) {
       return;
     }
@@ -781,6 +790,12 @@ export default function App() {
     if (!newThreadRootWorkspaceId) {
       return;
     }
+    const modelConfig = {
+      prompt: newThreadPrompt,
+      provider: newThreadProvider ?? newThreadRuntime?.settings.defaultProvider,
+      modelId: newThreadModelId ?? newThreadRuntime?.settings.defaultModelId,
+      thinkingLevel: newThreadThinkingLevel ?? newThreadRuntime?.settings.defaultThinkingLevel,
+    };
     const input: StartThreadInput =
       newThreadEnvironment === "current-worktree"
         ? newThreadTargetWorkspaceId
@@ -788,22 +803,25 @@ export default function App() {
               rootWorkspaceId: newThreadRootWorkspaceId,
               environment: "current-worktree",
               targetWorkspaceId: newThreadTargetWorkspaceId,
-              prompt: newThreadPrompt,
+              ...modelConfig,
             }
           : {
               rootWorkspaceId: newThreadRootWorkspaceId,
               environment: "local",
-              prompt: newThreadPrompt,
+              ...modelConfig,
             }
         : {
             rootWorkspaceId: newThreadRootWorkspaceId,
             environment: newThreadEnvironment,
-            prompt: newThreadPrompt,
+            ...modelConfig,
           };
     void updateSnapshot(api, setSnapshot, () =>
       api.startThread(input),
     ).then(() => {
       setNewThreadPrompt("");
+      setNewThreadProvider(undefined);
+      setNewThreadModelId(undefined);
+      setNewThreadThinkingLevel(undefined);
       resetNewThreadWorktreeTarget();
     });
   };
@@ -1035,19 +1053,18 @@ export default function App() {
             <NewThreadView
               workspaces={rootWorkspaceOptions}
               selectedWorkspaceId={newThreadRootWorkspaceId || rootWorkspaceOptions[0]?.id || ""}
-              runtime={
-                (() => {
-                  const workspace =
-                    rootWorkspaceOptions.find((entry) => entry.id === newThreadRootWorkspaceId) ?? rootWorkspaceOptions[0];
-                  return workspace ? snapshot.runtimeByWorkspace[workspace.id] : undefined;
-                })()
-              }
+              runtime={newThreadRuntime}
               environment={newThreadEnvironment}
               currentWorktreeName={newThreadTargetWorkspace?.kind === "worktree" ? newThreadTargetWorkspace.name : undefined}
               prompt={newThreadPrompt}
+              provider={newThreadProvider ?? newThreadRuntime?.settings.defaultProvider}
+              modelId={newThreadModelId ?? newThreadRuntime?.settings.defaultModelId}
+              thinkingLevel={newThreadThinkingLevel ?? newThreadRuntime?.settings.defaultThinkingLevel}
               onChangePrompt={setNewThreadPrompt}
               onSelectEnvironment={setNewThreadEnvironment}
               onSelectWorkspace={handleSelectNewThreadWorkspace}
+              onSetModel={(provider, modelId) => { setNewThreadProvider(provider); setNewThreadModelId(modelId); }}
+              onSetThinking={setNewThreadThinkingLevel}
               onSubmit={handleStartThread}
             />
           ) : (

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -13,7 +13,7 @@ import {
 import { formatRelativeTime } from "./string-utils";
 import { ComposerPanel } from "./composer-panel";
 import { DiffPanel } from "./diff-panel";
-import type { ComposerSlashCommand } from "./composer-commands";
+import { buildModelOptions, type ComposerSlashCommand } from "./composer-commands";
 import { desktopCommands, getDesktopCommandFromShortcut, type PiDesktopCommand } from "./ipc";
 import { SkillsView } from "./skills-view";
 import { ExtensionsView } from "./extensions-view";
@@ -220,17 +220,12 @@ export default function App() {
   const newThreadWorkspace =
     rootWorkspaceOptions.find((entry) => entry.id === newThreadRootWorkspaceId) ?? rootWorkspaceOptions[0];
   const newThreadRuntime = newThreadWorkspace ? snapshot?.runtimeByWorkspace[newThreadWorkspace.id] : undefined;
-  const newThreadDefaultEnabled = (() => {
-    const rt = newThreadRuntime;
-    if (!rt?.settings.defaultProvider || !rt?.settings.defaultModelId) return false;
-    const model = rt.models.find(
-      (m) => m.providerId === rt.settings.defaultProvider && m.modelId === rt.settings.defaultModelId,
-    );
-    if (!model?.available) return false;
-    const patterns = rt.settings.enabledModelPatterns;
-    if (patterns.length === 0) return true;
-    return patterns.includes(`${model.providerId}/${model.modelId}`);
-  })();
+  const newThreadDefaultEnabled = buildModelOptions(newThreadRuntime).some(
+    (m) => m.providerId === newThreadRuntime?.settings.defaultProvider && m.modelId === newThreadRuntime?.settings.defaultModelId,
+  );
+  const resolvedNewThreadProvider = newThreadProvider ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultProvider : undefined);
+  const resolvedNewThreadModelId = newThreadModelId ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultModelId : undefined);
+  const resolvedNewThreadThinkingLevel = newThreadThinkingLevel ?? newThreadRuntime?.settings.defaultThinkingLevel;
   const newThreadTargetWorkspace = useMemo(
     () =>
       newThreadTargetWorkspaceId
@@ -803,9 +798,9 @@ export default function App() {
     }
     const modelConfig = {
       prompt: newThreadPrompt,
-      provider: newThreadProvider ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultProvider : undefined),
-      modelId: newThreadModelId ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultModelId : undefined),
-      thinkingLevel: newThreadThinkingLevel ?? newThreadRuntime?.settings.defaultThinkingLevel,
+      provider: resolvedNewThreadProvider,
+      modelId: resolvedNewThreadModelId,
+      thinkingLevel: resolvedNewThreadThinkingLevel,
     };
     const input: StartThreadInput =
       newThreadEnvironment === "current-worktree"
@@ -1068,9 +1063,9 @@ export default function App() {
               environment={newThreadEnvironment}
               currentWorktreeName={newThreadTargetWorkspace?.kind === "worktree" ? newThreadTargetWorkspace.name : undefined}
               prompt={newThreadPrompt}
-              provider={newThreadProvider ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultProvider : undefined)}
-              modelId={newThreadModelId ?? (newThreadDefaultEnabled ? newThreadRuntime?.settings.defaultModelId : undefined)}
-              thinkingLevel={newThreadThinkingLevel ?? newThreadRuntime?.settings.defaultThinkingLevel}
+              provider={resolvedNewThreadProvider}
+              modelId={resolvedNewThreadModelId}
+              thinkingLevel={resolvedNewThreadThinkingLevel}
               onChangePrompt={setNewThreadPrompt}
               onSelectEnvironment={setNewThreadEnvironment}
               onSelectWorkspace={handleSelectNewThreadWorkspace}

--- a/apps/desktop/src/composer-commands.ts
+++ b/apps/desktop/src/composer-commands.ts
@@ -344,12 +344,13 @@ export function buildModelOptions(
 
   const enabledPatterns = runtime.settings.enabledModelPatterns;
   const allAvailable = enabledPatterns.length === 0;
+  const enabledSet = allAvailable ? undefined : new Set(enabledPatterns);
 
   return [...runtime.models]
     .filter((model) => {
       if (!model.available) return false;
-      if (allAvailable) return true;
-      return enabledPatterns.includes(`${model.providerId}/${model.modelId}`);
+      if (!enabledSet) return true;
+      return enabledSet.has(`${model.providerId}/${model.modelId}`);
     })
     .sort((left: RuntimeSnapshot["models"][number], right: RuntimeSnapshot["models"][number]) => {
       const providerCompare =

--- a/apps/desktop/src/composer-commands.ts
+++ b/apps/desktop/src/composer-commands.ts
@@ -70,7 +70,7 @@ const INCOMPLETE_COMMAND_MESSAGES: Readonly<Record<string, string>> = {
   "/logout": "Choose a connected provider from the slash menu before sending /logout.",
   "/model": "Choose a provider and model from the slash menu before sending /model.",
   "/name": "Add a thread title after /name.",
-  "/scoped-models": "Open Scoped models from the slash menu or Settings.",
+  "/scoped-models": "Open Enabled models from the slash menu or Settings.",
   "/settings": "Open Settings from the slash menu or Cmd+,.",
   "/thinking": "Choose a reasoning level from the slash menu before sending /thinking.",
 } as const;
@@ -141,8 +141,8 @@ const HOST_ACTION_SLASH_COMMANDS: readonly ComposerSlashCommand[] = [
     kind: "scoped-models",
     command: "/scoped-models",
     template: "/scoped-models",
-    title: "Scoped models",
-    description: "Manage the quick-cycle model shortlist",
+    title: "Enabled models",
+    description: "Choose which models appear in pickers",
     submitMode: "immediate",
     section: "host",
   },
@@ -342,7 +342,15 @@ export function buildModelOptions(
     return [];
   }
 
+  const enabledPatterns = runtime.settings.enabledModelPatterns;
+  const allAvailable = enabledPatterns.length === 0;
+
   return [...runtime.models]
+    .filter((model) => {
+      if (!model.available) return false;
+      if (allAvailable) return true;
+      return enabledPatterns.includes(`${model.providerId}/${model.modelId}`);
+    })
     .sort((left: RuntimeSnapshot["models"][number], right: RuntimeSnapshot["models"][number]) => {
       const providerCompare =
         providerRankForId(runtime.providers, left.providerId) - providerRankForId(runtime.providers, right.providerId);
@@ -354,7 +362,7 @@ export function buildModelOptions(
     .map((model: RuntimeSnapshot["models"][number]) => ({
       value: model.modelId,
       label: `${model.providerName} · ${model.label}`,
-      description: `${model.modelId}${model.available ? "" : " · unavailable"}`,
+      description: model.modelId,
       providerId: model.providerId,
       modelId: model.modelId,
     }));

--- a/apps/desktop/src/composer-panel.tsx
+++ b/apps/desktop/src/composer-panel.tsx
@@ -237,9 +237,13 @@ export function ComposerPanel({
             <div className="composer__bar">
               <div className="composer__hint">
                 {selectedSession.status === "running" ? runningLabel : "Enter to send · Shift+Enter for newline"}
+                {" · "}
                 <ModelSelector
                   runtime={runtime}
-                  session={selectedSession}
+                  provider={selectedSession.config?.provider}
+                  modelId={selectedSession.config?.modelId}
+                  thinkingLevel={selectedSession.config?.thinkingLevel}
+                  disabled={selectedSession.status === "running"}
                   onSetModel={onSetModel}
                   onSetThinking={onSetThinking}
                 />

--- a/apps/desktop/src/desktop-state.ts
+++ b/apps/desktop/src/desktop-state.ts
@@ -94,17 +94,26 @@ export type StartThreadInput =
       readonly rootWorkspaceId: string;
       readonly environment: "local";
       readonly prompt?: string;
+      readonly provider?: string;
+      readonly modelId?: string;
+      readonly thinkingLevel?: string;
     }
   | {
       readonly rootWorkspaceId: string;
       readonly environment: "new-worktree";
       readonly prompt?: string;
+      readonly provider?: string;
+      readonly modelId?: string;
+      readonly thinkingLevel?: string;
     }
   | {
       readonly rootWorkspaceId: string;
       readonly environment: "current-worktree";
       readonly targetWorkspaceId: string;
       readonly prompt?: string;
+      readonly provider?: string;
+      readonly modelId?: string;
+      readonly thinkingLevel?: string;
     };
 
 export interface RemoveWorktreeInput {

--- a/apps/desktop/src/desktop-state.ts
+++ b/apps/desktop/src/desktop-state.ts
@@ -134,6 +134,7 @@ export interface DesktopAppState {
   readonly sessionExtensionUiBySession: Readonly<Record<string, SessionExtensionUiStateRecord>>;
   readonly notificationPreferences: NotificationPreferences;
   readonly lastViewedAtBySession: Readonly<Record<string, string>>;
+  readonly workspaceOrder: readonly string[];
   readonly revision: number;
   readonly lastError?: string;
 }
@@ -166,6 +167,7 @@ export function createEmptyDesktopAppState(): DesktopAppState {
       attentionNeeded: true,
     },
     lastViewedAtBySession: {},
+    workspaceOrder: [],
     revision: 0,
   };
 }

--- a/apps/desktop/src/hooks/use-workspace-menu.tsx
+++ b/apps/desktop/src/hooks/use-workspace-menu.tsx
@@ -33,6 +33,7 @@ export interface WorkspaceMenuState {
   readonly removeWorkspace: (workspace: WorkspaceRecord) => void;
   readonly toggleArchived: (workspaceId: string, open: boolean) => void;
   readonly toggleWorkspaceCollapsed: (workspaceId: string) => void;
+  readonly expandWorkspace: (workspaceId: string) => void;
   readonly createWorktree: (workspaceId: string, fromSessionWorkspaceId?: string, fromSessionId?: string) => void;
   readonly removeWorktree: (workspaceId: string, worktree: WorktreeRecord) => void;
   readonly selectWorkspace: (workspaceId: string) => void;
@@ -150,6 +151,13 @@ export function useWorkspaceMenu(params: UseWorkspaceMenuParams): WorkspaceMenuS
     setCollapsedWorkspaces((current) => ({ ...current, [workspaceId]: !current[workspaceId] }));
   };
 
+  const expandWorkspace = (workspaceId: string) => {
+    setCollapsedWorkspaces((current) => {
+      if (!current[workspaceId]) return current;
+      return { ...current, [workspaceId]: false };
+    });
+  };
+
   const createWorktree = (workspaceId: string, fromSessionWorkspaceId?: string, fromSessionId?: string) => {
     setWorkspaceMenuId(null);
     setEnvironmentMenuOpen(false);
@@ -211,6 +219,7 @@ export function useWorkspaceMenu(params: UseWorkspaceMenuParams): WorkspaceMenuS
     removeWorkspace,
     toggleArchived,
     toggleWorkspaceCollapsed,
+    expandWorkspace,
     createWorktree,
     removeWorktree,
     selectWorkspace,

--- a/apps/desktop/src/hooks/use-workspace-menu.tsx
+++ b/apps/desktop/src/hooks/use-workspace-menu.tsx
@@ -18,6 +18,7 @@ export interface WorkspaceMenuState {
   readonly workspaceRenameDraft: string;
   readonly setWorkspaceRenameDraft: Dispatch<SetStateAction<string>>;
   readonly expandedArchivedByWorkspace: Record<string, boolean>;
+  readonly collapsedWorkspaces: Record<string, boolean>;
   readonly environmentMenuOpen: boolean;
   readonly setEnvironmentMenuOpen: Dispatch<SetStateAction<boolean>>;
   readonly workspaceMenuWrapRef: RefObject<HTMLSpanElement | null>;
@@ -31,6 +32,7 @@ export interface WorkspaceMenuState {
   readonly cancelRename: () => void;
   readonly removeWorkspace: (workspace: WorkspaceRecord) => void;
   readonly toggleArchived: (workspaceId: string, open: boolean) => void;
+  readonly toggleWorkspaceCollapsed: (workspaceId: string) => void;
   readonly createWorktree: (workspaceId: string, fromSessionWorkspaceId?: string, fromSessionId?: string) => void;
   readonly removeWorktree: (workspaceId: string, worktree: WorktreeRecord) => void;
   readonly selectWorkspace: (workspaceId: string) => void;
@@ -44,6 +46,7 @@ export function useWorkspaceMenu(params: UseWorkspaceMenuParams): WorkspaceMenuS
   const [workspaceRenameId, setWorkspaceRenameId] = useState<string | null>(null);
   const [workspaceRenameDraft, setWorkspaceRenameDraft] = useState("");
   const [expandedArchivedByWorkspace, setExpandedArchivedByWorkspace] = useState<Record<string, boolean>>({});
+  const [collapsedWorkspaces, setCollapsedWorkspaces] = useState<Record<string, boolean>>({});
   const [environmentMenuOpen, setEnvironmentMenuOpen] = useState(false);
 
   const workspaceMenuWrapRef = useRef<HTMLSpanElement | null>(null);
@@ -143,6 +146,10 @@ export function useWorkspaceMenu(params: UseWorkspaceMenuParams): WorkspaceMenuS
     setExpandedArchivedByWorkspace((current) => ({ ...current, [workspaceId]: open }));
   };
 
+  const toggleWorkspaceCollapsed = (workspaceId: string) => {
+    setCollapsedWorkspaces((current) => ({ ...current, [workspaceId]: !current[workspaceId] }));
+  };
+
   const createWorktree = (workspaceId: string, fromSessionWorkspaceId?: string, fromSessionId?: string) => {
     setWorkspaceMenuId(null);
     setEnvironmentMenuOpen(false);
@@ -189,6 +196,7 @@ export function useWorkspaceMenu(params: UseWorkspaceMenuParams): WorkspaceMenuS
     workspaceRenameDraft,
     setWorkspaceRenameDraft,
     expandedArchivedByWorkspace,
+    collapsedWorkspaces,
     environmentMenuOpen,
     setEnvironmentMenuOpen,
     workspaceMenuWrapRef,
@@ -202,6 +210,7 @@ export function useWorkspaceMenu(params: UseWorkspaceMenuParams): WorkspaceMenuS
     cancelRename,
     removeWorkspace,
     toggleArchived,
+    toggleWorkspaceCollapsed,
     createWorktree,
     removeWorktree,
     selectWorkspace,

--- a/apps/desktop/src/icons.tsx
+++ b/apps/desktop/src/icons.tsx
@@ -217,6 +217,19 @@ export function WorktreeIcon() {
   );
 }
 
+export function GripIcon() {
+  return (
+    <Icon>
+      <circle cx="8" cy="7" r="1.2" fill="currentColor" />
+      <circle cx="12" cy="7" r="1.2" fill="currentColor" />
+      <circle cx="8" cy="10" r="1.2" fill="currentColor" />
+      <circle cx="12" cy="10" r="1.2" fill="currentColor" />
+      <circle cx="8" cy="13" r="1.2" fill="currentColor" />
+      <circle cx="12" cy="13" r="1.2" fill="currentColor" />
+    </Icon>
+  );
+}
+
 export function DiffIcon() {
   return (
     <Icon>

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -20,6 +20,7 @@ export const desktopIpc = {
   selectWorkspace: "pi-gui:select-workspace",
   renameWorkspace: "pi-gui:rename-workspace",
   removeWorkspace: "pi-gui:remove-workspace",
+  reorderWorkspaces: "pi-gui:reorder-workspaces",
   openWorkspaceInFinder: "pi-gui:open-workspace-in-finder",
   createWorktree: "pi-gui:create-worktree",
   removeWorktree: "pi-gui:remove-worktree",
@@ -111,6 +112,7 @@ export interface PiDesktopApi {
   selectWorkspace(workspaceId: string): Promise<DesktopAppState>;
   renameWorkspace(workspaceId: string, displayName: string): Promise<DesktopAppState>;
   removeWorkspace(workspaceId: string): Promise<DesktopAppState>;
+  reorderWorkspaces(workspaceOrder: readonly string[]): Promise<DesktopAppState>;
   openWorkspaceInFinder(workspaceId: string): Promise<void>;
   createWorktree(input: CreateWorktreeInput): Promise<DesktopAppState>;
   removeWorktree(input: RemoveWorktreeInput): Promise<DesktopAppState>;

--- a/apps/desktop/src/model-selector.tsx
+++ b/apps/desktop/src/model-selector.tsx
@@ -1,25 +1,26 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { RuntimeSnapshot } from "@pi-gui/session-driver/runtime-types";
-import type { SessionRecord } from "./desktop-state";
 import { buildModelOptions, THINKING_OPTIONS, type ComposerModelOption } from "./composer-commands";
 
 interface ModelSelectorProps {
   readonly runtime: RuntimeSnapshot | undefined;
-  readonly session: SessionRecord;
+  readonly provider: string | undefined;
+  readonly modelId: string | undefined;
+  readonly thinkingLevel: string | undefined;
+  readonly disabled?: boolean;
   readonly onSetModel: (provider: string, modelId: string) => void;
   readonly onSetThinking: (level: string) => void;
 }
 
 type OpenDropdown = "none" | "model" | "thinking";
 
-export function ModelSelector({ runtime, session, onSetModel, onSetThinking }: ModelSelectorProps) {
+export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disabled, onSetModel, onSetThinking }: ModelSelectorProps) {
   const [open, setOpen] = useState<OpenDropdown>("none");
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const isRunning = session.status === "running";
 
-  const currentProvider = session.config?.provider;
-  const currentModelId = session.config?.modelId;
-  const currentThinking = session.config?.thinkingLevel;
+  const currentProvider = provider;
+  const currentModelId = modelId;
+  const currentThinking = thinkingLevel;
 
   const groupedModels = useMemo(() => groupByProvider(buildModelOptions(runtime)), [runtime]);
 
@@ -57,10 +58,10 @@ export function ModelSelector({ runtime, session, onSetModel, onSetThinking }: M
           <button
             className="model-selector__badge"
             type="button"
-            disabled={isRunning}
+            disabled={disabled}
             onClick={() => setOpen(open === "model" ? "none" : "model")}
           >
-            {" · "}{currentProvider}:{currentModelId}
+            {currentProvider}:{currentModelId}
           </button>
           {open === "model" ? (
             <div className="model-selector__dropdown" onWheel={(event) => event.stopPropagation()}>
@@ -102,10 +103,10 @@ export function ModelSelector({ runtime, session, onSetModel, onSetThinking }: M
           <button
             className="model-selector__badge"
             type="button"
-            disabled={isRunning}
+            disabled={disabled}
             onClick={() => setOpen(open === "thinking" ? "none" : "thinking")}
           >
-            {" · "}{currentThinking}
+            {currentThinking}
           </button>
           {open === "thinking" ? (
             <div className="model-selector__dropdown" onWheel={(event) => event.stopPropagation()}>

--- a/apps/desktop/src/model-selector.tsx
+++ b/apps/desktop/src/model-selector.tsx
@@ -70,18 +70,14 @@ export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disab
                   <div className="model-selector__group-title">{group.provider}</div>
                   {group.items.map((option) => {
                     const isActive = option.providerId === currentProvider && option.modelId === currentModelId;
-                    const isUnavailable = option.description.includes("unavailable");
                     return (
                       <button
-                        className={`model-selector__item${isActive ? " model-selector__item--active" : ""}${isUnavailable ? " model-selector__item--unavailable" : ""}`}
+                        className={`model-selector__item${isActive ? " model-selector__item--active" : ""}`}
                         key={`${option.providerId}:${option.modelId}`}
                         type="button"
-                        disabled={isUnavailable}
                         onClick={() => {
-                          if (!isUnavailable) {
-                            onSetModel(option.providerId, option.modelId);
-                            setOpen("none");
-                          }
+                          onSetModel(option.providerId, option.modelId);
+                          setOpen("none");
                         }}
                       >
                         <span className="model-selector__item-label">{option.label}</span>

--- a/apps/desktop/src/model-selector.tsx
+++ b/apps/desktop/src/model-selector.tsx
@@ -18,10 +18,6 @@ export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disab
   const [open, setOpen] = useState<OpenDropdown>("none");
   const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const currentProvider = provider;
-  const currentModelId = modelId;
-  const currentThinking = thinkingLevel;
-
   const groupedModels = useMemo(() => groupByProvider(buildModelOptions(runtime)), [runtime]);
 
   useEffect(() => {
@@ -47,13 +43,13 @@ export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disab
     };
   }, [open]);
 
-  if (!currentProvider && !currentModelId && !currentThinking) {
+  if (!provider && !modelId && !thinkingLevel) {
     return null;
   }
 
   return (
     <span className="model-selector" ref={containerRef}>
-      {currentProvider && currentModelId ? (
+      {provider && modelId ? (
         <span className="model-selector__anchor">
           <button
             className="model-selector__badge"
@@ -61,7 +57,7 @@ export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disab
             disabled={disabled}
             onClick={() => setOpen(open === "model" ? "none" : "model")}
           >
-            {currentProvider}:{currentModelId}
+            {provider}:{modelId}
           </button>
           {open === "model" ? (
             <div className="model-selector__dropdown" onWheel={(event) => event.stopPropagation()}>
@@ -69,7 +65,7 @@ export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disab
                 <div key={group.provider}>
                   <div className="model-selector__group-title">{group.provider}</div>
                   {group.items.map((option) => {
-                    const isActive = option.providerId === currentProvider && option.modelId === currentModelId;
+                    const isActive = option.providerId === provider && option.modelId === modelId;
                     return (
                       <button
                         className={`model-selector__item${isActive ? " model-selector__item--active" : ""}`}
@@ -94,7 +90,7 @@ export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disab
           ) : null}
         </span>
       ) : null}
-      {currentThinking ? (
+      {thinkingLevel ? (
         <span className="model-selector__anchor">
           <button
             className="model-selector__badge"
@@ -102,13 +98,13 @@ export function ModelSelector({ runtime, provider, modelId, thinkingLevel, disab
             disabled={disabled}
             onClick={() => setOpen(open === "thinking" ? "none" : "thinking")}
           >
-            {currentThinking}
+            {thinkingLevel}
           </button>
           {open === "thinking" ? (
             <div className="model-selector__dropdown" onWheel={(event) => event.stopPropagation()}>
               <div className="model-selector__group-title">Thinking Level</div>
               {THINKING_OPTIONS.map((option) => {
-                const isActive = option.value === currentThinking;
+                const isActive = option.value === thinkingLevel;
                 return (
                   <button
                     className={`model-selector__item${isActive ? " model-selector__item--active" : ""}`}

--- a/apps/desktop/src/new-thread-view.tsx
+++ b/apps/desktop/src/new-thread-view.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, type KeyboardEvent } from "react";
 import type { RuntimeSnapshot } from "@pi-gui/session-driver/runtime-types";
 import type { NewThreadEnvironment, WorkspaceRecord } from "./desktop-state";
-import { ArrowUpIcon, ModelIcon, ReasoningIcon } from "./icons";
+import { ArrowUpIcon } from "./icons";
+import { ModelSelector } from "./model-selector";
 
 interface NewThreadViewProps {
   readonly workspaces: readonly WorkspaceRecord[];
@@ -10,9 +11,14 @@ interface NewThreadViewProps {
   readonly environment: NewThreadEnvironment;
   readonly currentWorktreeName?: string;
   readonly prompt: string;
+  readonly provider: string | undefined;
+  readonly modelId: string | undefined;
+  readonly thinkingLevel: string | undefined;
   readonly onChangePrompt: (prompt: string) => void;
   readonly onSelectEnvironment: (environment: NewThreadEnvironment) => void;
   readonly onSelectWorkspace: (workspaceId: string) => void;
+  readonly onSetModel: (provider: string, modelId: string) => void;
+  readonly onSetThinking: (level: string) => void;
   readonly onSubmit: () => void;
 }
 
@@ -23,19 +29,18 @@ export function NewThreadView({
   environment,
   currentWorktreeName,
   prompt,
+  provider,
+  modelId,
+  thinkingLevel,
   onChangePrompt,
   onSelectEnvironment,
   onSelectWorkspace,
+  onSetModel,
+  onSetThinking,
   onSubmit,
 }: NewThreadViewProps) {
   const composerRef = useRef<HTMLTextAreaElement | null>(null);
   const workspace = workspaces.find((entry) => entry.id === selectedWorkspaceId) ?? workspaces[0];
-  const modelLabel = runtime?.settings.defaultProvider && runtime?.settings.defaultModelId
-    ? `${runtime.settings.defaultProvider}:${runtime.settings.defaultModelId}`
-    : "Choose model in settings";
-  const thinkingLabel = runtime?.settings.defaultThinkingLevel
-    ? formatThinking(runtime.settings.defaultThinkingLevel)
-    : "Reasoning default";
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
@@ -129,14 +134,14 @@ export function NewThreadView({
                     <span>{currentWorktreeName}</span>
                   </span>
                 ) : null}
-                <span className="new-thread__meta-item">
-                  <ModelIcon />
-                  <span>{modelLabel}</span>
-                </span>
-                <span className="new-thread__meta-item">
-                  <ReasoningIcon />
-                  <span>{thinkingLabel}</span>
-                </span>
+                <ModelSelector
+                  runtime={runtime}
+                  provider={provider}
+                  modelId={modelId}
+                  thinkingLevel={thinkingLevel}
+                  onSetModel={onSetModel}
+                  onSetThinking={onSetThinking}
+                />
               </div>
             </div>
 
@@ -153,8 +158,4 @@ export function NewThreadView({
       </div>
     </section>
   );
-}
-
-function formatThinking(value: string): string {
-  return value === "xhigh" ? "Extra High" : value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/apps/desktop/src/settings-appearance-section.tsx
+++ b/apps/desktop/src/settings-appearance-section.tsx
@@ -1,6 +1,5 @@
 import type { ThemeMode } from "./desktop-state";
-import { SettingsIcon } from "./icons";
-import { SettingsCard } from "./settings-utils";
+import { SettingsGroup, SettingsRow } from "./settings-utils";
 
 interface SettingsAppearanceSectionProps {
   readonly themeMode: ThemeMode;
@@ -15,24 +14,17 @@ const THEME_OPTIONS: { mode: ThemeMode; label: string; description: string }[] =
 
 export function SettingsAppearanceSection({ themeMode, onSetThemeMode }: SettingsAppearanceSectionProps) {
   return (
-    <SettingsCard
-      description="Switch between light and dark themes, or follow your system preference."
-      icon={<SettingsIcon />}
-      title="Theme"
-    >
-      <div className="settings-option-list">
-        {THEME_OPTIONS.map((option) => (
-          <button
-            className={`settings-option${themeMode === option.mode ? " settings-option--active" : ""}`}
-            key={option.mode}
-            type="button"
-            onClick={() => onSetThemeMode(option.mode)}
-          >
-            <div className="settings-option__title">{option.label}</div>
-            <div className="settings-option__meta">{option.description}</div>
-          </button>
-        ))}
-      </div>
-    </SettingsCard>
+    <SettingsGroup title="Theme">
+      {THEME_OPTIONS.map((option) => (
+        <SettingsRow key={option.mode} title={option.label} description={option.description}>
+          <input
+            checked={themeMode === option.mode}
+            name="theme"
+            type="radio"
+            onChange={() => onSetThemeMode(option.mode)}
+          />
+        </SettingsRow>
+      ))}
+    </SettingsGroup>
   );
 }

--- a/apps/desktop/src/settings-general-section.tsx
+++ b/apps/desktop/src/settings-general-section.tsx
@@ -1,20 +1,17 @@
 import type { RuntimeSnapshot } from "@pi-gui/session-driver/runtime-types";
-import type { WorkspaceRecord } from "./desktop-state";
 import { SettingsGroup, SettingsInfoRow, SettingsRow } from "./settings-utils";
 
 interface SettingsGeneralSectionProps {
-  readonly workspace?: WorkspaceRecord;
   readonly runtime?: RuntimeSnapshot;
   readonly onToggleSkillCommands: (enabled: boolean) => void;
 }
 
-export function SettingsGeneralSection({ workspace, runtime, onToggleSkillCommands }: SettingsGeneralSectionProps) {
+export function SettingsGeneralSection({ runtime, onToggleSkillCommands }: SettingsGeneralSectionProps) {
   const connectedCount = runtime?.providers.filter((p) => p.hasAuth).length ?? 0;
 
   return (
     <>
       <SettingsGroup title="General">
-        <SettingsInfoRow label="Workspace" value={workspace?.name ?? "No workspace selected"} />
         <SettingsInfoRow
           label="Connected providers"
           value={connectedCount > 0 ? String(connectedCount) : "None"}
@@ -30,6 +27,7 @@ export function SettingsGeneralSection({ workspace, runtime, onToggleSkillComman
       </SettingsGroup>
 
       <SettingsGroup title="Shortcuts">
+        <SettingsInfoRow label="New thread" value="Cmd+Shift+O" />
         <SettingsInfoRow label="Open settings" value="Cmd+," />
         <SettingsInfoRow label="Send message" value="Enter" />
         <SettingsInfoRow label="New line" value="Shift+Enter" />

--- a/apps/desktop/src/settings-general-section.tsx
+++ b/apps/desktop/src/settings-general-section.tsx
@@ -1,7 +1,6 @@
 import type { RuntimeSnapshot } from "@pi-gui/session-driver/runtime-types";
 import type { WorkspaceRecord } from "./desktop-state";
-import { SettingsIcon, SkillIcon } from "./icons";
-import { SettingsCard, SettingsInfoRow, labelForThinking } from "./settings-utils";
+import { SettingsGroup, SettingsInfoRow, SettingsRow } from "./settings-utils";
 
 interface SettingsGeneralSectionProps {
   readonly workspace?: WorkspaceRecord;
@@ -14,59 +13,27 @@ export function SettingsGeneralSection({ workspace, runtime, onToggleSkillComman
 
   return (
     <>
-      <SettingsCard
-        description="Current workspace defaults and runtime snapshot."
-        icon={<SettingsIcon />}
-        title="General"
-      >
-        <div className="settings-list">
-          <SettingsInfoRow label="Workspace" value={workspace?.name ?? "No workspace selected"} />
-          <SettingsInfoRow
-            label="Default model"
-            value={
-              runtime?.settings.defaultProvider && runtime?.settings.defaultModelId
-                ? `${runtime.settings.defaultProvider}:${runtime.settings.defaultModelId}`
-                : "Not set"
-            }
-          />
-          <SettingsInfoRow
-            label="Reasoning"
-            value={labelForThinking(runtime?.settings.defaultThinkingLevel ?? "medium")}
-          />
-          <SettingsInfoRow
-            label="Connected providers"
-            value={connectedCount > 0 ? String(connectedCount) : "None"}
-          />
-          <SettingsInfoRow label="Discovered skills" value={String(runtime?.skills.length ?? 0)} />
-        </div>
-      </SettingsCard>
-
-      <SettingsCard
-        description="Keep the highest-value controls discoverable without sending people through runtime-specific menus."
-        icon={<SettingsIcon />}
-        title="Shortcuts"
-      >
-        <div className="settings-list">
-          <SettingsInfoRow label="Open settings" value="Cmd+," />
-          <SettingsInfoRow label="Send message" value="Enter" />
-          <SettingsInfoRow label="New line" value="Shift+Enter" />
-        </div>
-      </SettingsCard>
-
-      <SettingsCard
-        description="Keep skill slash commands available in the composer while the full Skills surface stays separate."
-        icon={<SkillIcon />}
-        title="Skill commands"
-      >
-        <label className="settings-toggle">
+      <SettingsGroup title="General">
+        <SettingsInfoRow label="Workspace" value={workspace?.name ?? "No workspace selected"} />
+        <SettingsInfoRow
+          label="Connected providers"
+          value={connectedCount > 0 ? String(connectedCount) : "None"}
+        />
+        <SettingsInfoRow label="Discovered skills" value={String(runtime?.skills.length ?? 0)} />
+        <SettingsRow title="Enable skill slash commands" description="Keep skill slash commands available in the composer.">
           <input
             checked={runtime?.settings.enableSkillCommands ?? true}
             type="checkbox"
             onChange={(event) => onToggleSkillCommands(event.target.checked)}
           />
-          <span>Enable skill slash commands</span>
-        </label>
-      </SettingsCard>
+        </SettingsRow>
+      </SettingsGroup>
+
+      <SettingsGroup title="Shortcuts">
+        <SettingsInfoRow label="Open settings" value="Cmd+," />
+        <SettingsInfoRow label="Send message" value="Enter" />
+        <SettingsInfoRow label="New line" value="Shift+Enter" />
+      </SettingsGroup>
     </>
   );
 }

--- a/apps/desktop/src/settings-models-section.tsx
+++ b/apps/desktop/src/settings-models-section.tsx
@@ -129,10 +129,10 @@ export function SettingsModelsSection({
             ))}
           </div>
           {allImplicitlyEnabled ? (
-            <span className="settings-card__hint">All models enabled by default.</span>
+            <span className="settings-hint">All models enabled by default.</span>
           ) : null}
           {!defaultIsEnabled && defaultProvider && defaultModelId ? (
-            <span className="settings-card__warning">
+            <span className="settings-warning">
               Your default model ({defaultProvider}:{defaultModelId}) is not enabled. Choose a new default above.
             </span>
           ) : null}

--- a/apps/desktop/src/settings-models-section.tsx
+++ b/apps/desktop/src/settings-models-section.tsx
@@ -93,21 +93,6 @@ export function SettingsModelsSection({
               ))}
             </select>
           </label>
-          <div className="settings-pill-row">
-            {enabledAvailableModels.map((model) => {
-              const active = defaultProvider === model.providerId && defaultModelId === model.modelId;
-              return (
-                <button
-                  className={settingsPill(active)}
-                  key={`${model.providerId}:${model.modelId}`}
-                  type="button"
-                  onClick={() => onSetDefaultModel(model.providerId, model.modelId)}
-                >
-                  {model.providerName} · {model.label}
-                </button>
-              );
-            })}
-          </div>
         </div>
       </SettingsCard>
 

--- a/apps/desktop/src/settings-models-section.tsx
+++ b/apps/desktop/src/settings-models-section.tsx
@@ -28,34 +28,36 @@ export function SettingsModelsSection({
   const models = runtime?.models ?? [];
   const providers = runtime?.providers ?? [];
   const availableModels = models.filter((m) => m.available);
-  const connectedProviders = providers.filter((p) => p.hasAuth);
 
-  const activeScopedPatterns =
-    runtime && runtime.settings.enabledModelPatterns.length > 0
-      ? runtime.settings.enabledModelPatterns
-      : availableModels.map((model) => `${model.providerId}/${model.modelId}`);
+  const enabledPatterns = runtime?.settings.enabledModelPatterns ?? [];
+  const allImplicitlyEnabled = enabledPatterns.length === 0;
 
-  const featuredProviderIds = new Set(
-    [
-      runtime?.settings.defaultProvider,
-      ...connectedProviders.map((p) => p.id),
-      "openai-codex",
-      "anthropic",
-    ].filter(Boolean),
-  );
+  const activeScopedPatterns = allImplicitlyEnabled
+    ? availableModels.map((model) => `${model.providerId}/${model.modelId}`)
+    : enabledPatterns;
 
-  const featuredModels = (() => {
-    const seen = new Set<string>();
-    return availableModels.filter((model) => {
-      const key = `${model.providerId}:${model.modelId}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return featuredProviderIds.has(model.providerId);
-    });
-  })();
+  const enabledAvailableModels = availableModels.filter((model) => {
+    if (allImplicitlyEnabled) return true;
+    return activeScopedPatterns.includes(`${model.providerId}/${model.modelId}`);
+  });
 
-  const filteredModels = filterModels(availableModels, modelQuery);
+  const defaultProvider = runtime?.settings.defaultProvider;
+  const defaultModelId = runtime?.settings.defaultModelId;
+  const defaultIsEnabled =
+    defaultProvider && defaultModelId
+      ? enabledAvailableModels.some((m) => m.providerId === defaultProvider && m.modelId === defaultModelId)
+      : false;
+
+  const filteredModels = filterModels(models, modelQuery);
   const filteredScopedModels = filterModels(availableModels, scopedQuery);
+
+  const togglePattern = (pattern: string, checked: boolean) => {
+    const newPatterns = checked
+      ? [...activeScopedPatterns, pattern]
+      : activeScopedPatterns.filter((entry) => entry !== pattern);
+    if (newPatterns.length === 0) return;
+    onSetScopedModelPatterns(newPatterns);
+  };
 
   return (
     <>
@@ -66,12 +68,12 @@ export function SettingsModelsSection({
       >
         <div className="settings-stack">
           <label className="settings-field">
-            <span>Featured models</span>
+            <span>Enabled models</span>
             <select
               className="settings-select"
               value={
-                runtime?.settings.defaultProvider && runtime?.settings.defaultModelId
-                  ? `${runtime.settings.defaultProvider}:${runtime.settings.defaultModelId}`
+                defaultProvider && defaultModelId && defaultIsEnabled
+                  ? `${defaultProvider}:${defaultModelId}`
                   : ""
               }
               onChange={(event) => {
@@ -83,7 +85,7 @@ export function SettingsModelsSection({
               }}
             >
               <option value="">Choose a model</option>
-              {featuredModels.map((model) => (
+              {enabledAvailableModels.map((model) => (
                 <option key={`${model.providerId}:${model.modelId}`} value={`${model.providerId}:${model.modelId}`}>
                   {model.providerName} · {model.label}
                 </option>
@@ -91,10 +93,8 @@ export function SettingsModelsSection({
             </select>
           </label>
           <div className="settings-pill-row">
-            {featuredModels.map((model) => {
-              const active =
-                runtime?.settings.defaultProvider === model.providerId &&
-                runtime?.settings.defaultModelId === model.modelId;
+            {enabledAvailableModels.map((model) => {
+              const active = defaultProvider === model.providerId && defaultModelId === model.modelId;
               return (
                 <button
                   className={settingsPill(active)}
@@ -130,32 +130,36 @@ export function SettingsModelsSection({
       </SettingsCard>
 
       <SettingsCard
-        description="Manage the shortlist used for quick model switching."
+        description="Choose which models appear in pickers throughout the app."
         icon={<SettingsIcon />}
-        title="Scoped models"
+        title="Enabled models"
       >
         <div className="settings-stack">
           <div className="settings-pill-row">
-            {activeScopedPatterns.length > 0 ? (
-              activeScopedPatterns.map((pattern) => (
-                <span className={settingsPill(true)} key={pattern}>
-                  {pattern}
-                </span>
-              ))
-            ) : (
-              <span className="settings-card__empty">No scoped models selected.</span>
-            )}
+            {activeScopedPatterns.map((pattern) => (
+              <span className={settingsPill(true)} key={pattern}>
+                {pattern}
+              </span>
+            ))}
           </div>
+          {allImplicitlyEnabled ? (
+            <span className="settings-card__hint">All models enabled by default.</span>
+          ) : null}
+          {!defaultIsEnabled && defaultProvider && defaultModelId ? (
+            <span className="settings-card__warning">
+              Your default model ({defaultProvider}:{defaultModelId}) is not enabled. Choose a new default above.
+            </span>
+          ) : null}
           <details className="settings-disclosure">
             <summary className="settings-disclosure__summary">
-              <span>Edit shortlist</span>
+              <span>Edit enabled models</span>
               <span>{filteredScopedModels.length}</span>
             </summary>
             <div className="settings-disclosure__body">
               <input
-                aria-label="Search scoped models"
+                aria-label="Search enabled models"
                 className="settings-search"
-                placeholder="Search scoped models"
+                placeholder="Search enabled models"
                 value={scopedQuery}
                 onChange={(event) => setScopedQuery(event.target.value)}
               />
@@ -163,18 +167,15 @@ export function SettingsModelsSection({
                 {filteredScopedModels.map((model) => {
                   const pattern = `${model.providerId}/${model.modelId}`;
                   const enabled = activeScopedPatterns.includes(pattern);
+                  const isLast = enabled && activeScopedPatterns.length <= 1;
                   return (
                     <label className="settings-toggle settings-toggle--row" key={pattern}>
                       <input
                         checked={enabled}
+                        disabled={isLast}
+                        title={isLast ? "At least one model must be enabled" : undefined}
                         type="checkbox"
-                        onChange={(event) =>
-                          onSetScopedModelPatterns(
-                            event.target.checked
-                              ? [...activeScopedPatterns, pattern]
-                              : activeScopedPatterns.filter((entry) => entry !== pattern),
-                          )
-                        }
+                        onChange={(event) => togglePattern(pattern, event.target.checked)}
                       />
                       <span>
                         <strong>{model.providerName}</strong> · {model.label}
@@ -190,9 +191,9 @@ export function SettingsModelsSection({
       </SettingsCard>
 
       <SettingsCard
-        description="Search the full available model inventory without forcing every model into the main controls."
+        description="Browse the full model catalog. Enable models above to use them."
         icon={<ModelIcon />}
-        title="All available models"
+        title="All models"
       >
         <details className="settings-disclosure">
           <summary className="settings-disclosure__summary">
@@ -209,23 +210,34 @@ export function SettingsModelsSection({
             />
             <div className="settings-list">
               {filteredModels.map((model) => {
-                const active =
-                  runtime?.settings.defaultProvider === model.providerId &&
-                  runtime?.settings.defaultModelId === model.modelId;
+                const pattern = `${model.providerId}/${model.modelId}`;
+                const enabled = activeScopedPatterns.includes(pattern);
+                const isLast = enabled && activeScopedPatterns.length <= 1;
                 return (
-                  <button
-                    className={`settings-option ${active ? "settings-option--active" : ""}`}
+                  <div
+                    className="settings-option"
                     key={`${model.providerId}:${model.modelId}`}
-                    type="button"
-                    onClick={() => onSetDefaultModel(model.providerId, model.modelId)}
                   >
                     <span className="settings-option__title">{model.providerName} · {model.label}</span>
                     <span className="settings-option__meta">
                       {model.providerId}:{model.modelId}
                       {model.reasoning ? " · reasoning" : ""}
                       {model.supportsImages ? " · images" : ""}
+                      {!model.available ? " · not logged in" : ""}
                     </span>
-                  </button>
+                    {model.available ? (
+                      <label className="settings-toggle settings-toggle--inline">
+                        <input
+                          checked={enabled}
+                          disabled={isLast}
+                          title={isLast ? "At least one model must be enabled" : undefined}
+                          type="checkbox"
+                          onChange={(event) => togglePattern(pattern, event.target.checked)}
+                        />
+                        <span className="sr-only">Enable</span>
+                      </label>
+                    ) : null}
+                  </div>
                 );
               })}
             </div>

--- a/apps/desktop/src/settings-models-section.tsx
+++ b/apps/desktop/src/settings-models-section.tsx
@@ -35,10 +35,11 @@ export function SettingsModelsSection({
   const activeScopedPatterns = allImplicitlyEnabled
     ? availableModels.map((model) => `${model.providerId}/${model.modelId}`)
     : enabledPatterns;
+  const activeScopedSet = new Set(activeScopedPatterns);
 
   const enabledAvailableModels = availableModels.filter((model) => {
     if (allImplicitlyEnabled) return true;
-    return activeScopedPatterns.includes(`${model.providerId}/${model.modelId}`);
+    return activeScopedSet.has(`${model.providerId}/${model.modelId}`);
   });
 
   const defaultProvider = runtime?.settings.defaultProvider;
@@ -166,7 +167,7 @@ export function SettingsModelsSection({
               <div className="settings-list">
                 {filteredScopedModels.map((model) => {
                   const pattern = `${model.providerId}/${model.modelId}`;
-                  const enabled = activeScopedPatterns.includes(pattern);
+                  const enabled = activeScopedSet.has(pattern);
                   const isLast = enabled && activeScopedPatterns.length <= 1;
                   return (
                     <label className="settings-toggle settings-toggle--row" key={pattern}>
@@ -211,7 +212,7 @@ export function SettingsModelsSection({
             <div className="settings-list">
               {filteredModels.map((model) => {
                 const pattern = `${model.providerId}/${model.modelId}`;
-                const enabled = activeScopedPatterns.includes(pattern);
+                const enabled = activeScopedSet.has(pattern);
                 const isLast = enabled && activeScopedPatterns.length <= 1;
                 return (
                   <div

--- a/apps/desktop/src/settings-models-section.tsx
+++ b/apps/desktop/src/settings-models-section.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import type { RuntimeSettingsSnapshot, RuntimeSnapshot } from "@pi-gui/session-driver/runtime-types";
-import { ModelIcon, ReasoningIcon, SettingsIcon } from "./icons";
 import {
   filterModels,
   labelForThinking,
   settingsPill,
-  SettingsCard,
+  SettingsGroup,
+  SettingsRow,
   THINKING_LEVELS,
 } from "./settings-utils";
 
@@ -26,7 +26,6 @@ export function SettingsModelsSection({
   const [scopedQuery, setScopedQuery] = useState("");
 
   const models = runtime?.models ?? [];
-  const providers = runtime?.providers ?? [];
   const availableModels = models.filter((m) => m.available);
 
   const enabledPatterns = runtime?.settings.enabledModelPatterns ?? [];
@@ -62,65 +61,49 @@ export function SettingsModelsSection({
 
   return (
     <>
-      <SettingsCard
-        description="Choose the default model for new sessions in this workspace."
-        icon={<ModelIcon />}
-        title="Default model"
-      >
-        <div className="settings-stack">
-          <label className="settings-field">
-            <span>Enabled models</span>
-            <select
-              className="settings-select"
-              value={
-                defaultProvider && defaultModelId && defaultIsEnabled
-                  ? `${defaultProvider}:${defaultModelId}`
-                  : ""
+      <SettingsGroup>
+        <SettingsRow title="Default model" description="Choose the default model for new sessions.">
+          <select
+            className="settings-select"
+            value={
+              defaultProvider && defaultModelId && defaultIsEnabled
+                ? `${defaultProvider}:${defaultModelId}`
+                : ""
+            }
+            onChange={(event) => {
+              const [provider, ...modelParts] = event.target.value.split(":");
+              const modelId = modelParts.join(":");
+              if (provider && modelId) {
+                onSetDefaultModel(provider, modelId);
               }
-              onChange={(event) => {
-                const [provider, ...modelParts] = event.target.value.split(":");
-                const modelId = modelParts.join(":");
-                if (provider && modelId) {
-                  onSetDefaultModel(provider, modelId);
-                }
-              }}
-            >
-              <option value="">Choose a model</option>
-              {enabledAvailableModels.map((model) => (
-                <option key={`${model.providerId}:${model.modelId}`} value={`${model.providerId}:${model.modelId}`}>
-                  {model.providerName} · {model.label}
-                </option>
-              ))}
-            </select>
-          </label>
-        </div>
-      </SettingsCard>
+            }}
+          >
+            <option value="">Choose a model</option>
+            {enabledAvailableModels.map((model) => (
+              <option key={`${model.providerId}:${model.modelId}`} value={`${model.providerId}:${model.modelId}`}>
+                {model.providerName} · {model.label}
+              </option>
+            ))}
+          </select>
+        </SettingsRow>
+        <SettingsRow title="Reasoning" description="Set the workspace default reasoning level.">
+          <div className="settings-pill-row">
+            {THINKING_LEVELS.map((level) => (
+              <button
+                className={settingsPill(runtime?.settings.defaultThinkingLevel === level)}
+                key={level}
+                type="button"
+                onClick={() => onSetThinkingLevel(level)}
+              >
+                {labelForThinking(level)}
+              </button>
+            ))}
+          </div>
+        </SettingsRow>
+      </SettingsGroup>
 
-      <SettingsCard
-        description="Set the workspace default reasoning level."
-        icon={<ReasoningIcon />}
-        title="Reasoning"
-      >
-        <div className="settings-pill-row">
-          {THINKING_LEVELS.map((level) => (
-            <button
-              className={settingsPill(runtime?.settings.defaultThinkingLevel === level)}
-              key={level}
-              type="button"
-              onClick={() => onSetThinkingLevel(level)}
-            >
-              {labelForThinking(level)}
-            </button>
-          ))}
-        </div>
-      </SettingsCard>
-
-      <SettingsCard
-        description="Choose which models appear in pickers throughout the app."
-        icon={<SettingsIcon />}
-        title="Enabled models"
-      >
-        <div className="settings-stack">
+      <SettingsGroup title="Enabled models" description="Choose which models appear in pickers throughout the app.">
+        <div className="settings-row">
           <div className="settings-pill-row">
             {activeScopedPatterns.map((pattern) => (
               <span className={settingsPill(true)} key={pattern}>
@@ -128,59 +111,59 @@ export function SettingsModelsSection({
               </span>
             ))}
           </div>
-          {allImplicitlyEnabled ? (
+        </div>
+        {allImplicitlyEnabled ? (
+          <div className="settings-row">
             <span className="settings-hint">All models enabled by default.</span>
-          ) : null}
-          {!defaultIsEnabled && defaultProvider && defaultModelId ? (
+          </div>
+        ) : null}
+        {!defaultIsEnabled && defaultProvider && defaultModelId ? (
+          <div className="settings-row">
             <span className="settings-warning">
               Your default model ({defaultProvider}:{defaultModelId}) is not enabled. Choose a new default above.
             </span>
-          ) : null}
-          <details className="settings-disclosure">
-            <summary className="settings-disclosure__summary">
-              <span>Edit enabled models</span>
-              <span>{filteredScopedModels.length}</span>
-            </summary>
-            <div className="settings-disclosure__body">
-              <input
-                aria-label="Search enabled models"
-                className="settings-search"
-                placeholder="Search enabled models"
-                value={scopedQuery}
-                onChange={(event) => setScopedQuery(event.target.value)}
-              />
-              <div className="settings-list">
-                {filteredScopedModels.map((model) => {
-                  const pattern = `${model.providerId}/${model.modelId}`;
-                  const enabled = activeScopedSet.has(pattern);
-                  const isLast = enabled && activeScopedPatterns.length <= 1;
-                  return (
-                    <label className="settings-toggle settings-toggle--row" key={pattern}>
-                      <input
-                        checked={enabled}
-                        disabled={isLast}
-                        title={isLast ? "At least one model must be enabled" : undefined}
-                        type="checkbox"
-                        onChange={(event) => togglePattern(pattern, event.target.checked)}
-                      />
-                      <span>
-                        <strong>{model.providerName}</strong> · {model.label}
-                        <span className="settings-list__meta"> · {pattern}</span>
-                      </span>
-                    </label>
-                  );
-                })}
-              </div>
+          </div>
+        ) : null}
+        <details className="settings-disclosure">
+          <summary className="settings-disclosure__summary">
+            <span>Edit enabled models</span>
+            <span>{filteredScopedModels.length}</span>
+          </summary>
+          <div className="settings-disclosure__body">
+            <input
+              aria-label="Search enabled models"
+              className="settings-search"
+              placeholder="Search enabled models"
+              value={scopedQuery}
+              onChange={(event) => setScopedQuery(event.target.value)}
+            />
+            <div className="settings-list">
+              {filteredScopedModels.map((model) => {
+                const pattern = `${model.providerId}/${model.modelId}`;
+                const enabled = activeScopedSet.has(pattern);
+                const isLast = enabled && activeScopedPatterns.length <= 1;
+                return (
+                  <label className="settings-toggle settings-toggle--row" key={pattern}>
+                    <input
+                      checked={enabled}
+                      disabled={isLast}
+                      title={isLast ? "At least one model must be enabled" : undefined}
+                      type="checkbox"
+                      onChange={(event) => togglePattern(pattern, event.target.checked)}
+                    />
+                    <span>
+                      <strong>{model.providerName}</strong> · {model.label}
+                      <span className="settings-list__meta"> · {pattern}</span>
+                    </span>
+                  </label>
+                );
+              })}
             </div>
-          </details>
-        </div>
-      </SettingsCard>
+          </div>
+        </details>
+      </SettingsGroup>
 
-      <SettingsCard
-        description="Browse the full model catalog. Enable models above to use them."
-        icon={<ModelIcon />}
-        title="All models"
-      >
+      <SettingsGroup title="All models" description="Browse the full model catalog. Enable models above to use them.">
         <details className="settings-disclosure">
           <summary className="settings-disclosure__summary">
             <span>Browse full model inventory</span>
@@ -229,7 +212,7 @@ export function SettingsModelsSection({
             </div>
           </div>
         </details>
-      </SettingsCard>
+      </SettingsGroup>
     </>
   );
 }

--- a/apps/desktop/src/settings-notifications-section.tsx
+++ b/apps/desktop/src/settings-notifications-section.tsx
@@ -1,6 +1,5 @@
 import type { NotificationPreferences } from "./desktop-state";
-import { StatusIcon } from "./icons";
-import { SettingsCard } from "./settings-utils";
+import { SettingsGroup, SettingsRow } from "./settings-utils";
 
 interface SettingsNotificationsSectionProps {
   readonly notificationPreferences: NotificationPreferences;
@@ -12,37 +11,28 @@ export function SettingsNotificationsSection({
   onSetNotificationPreferences,
 }: SettingsNotificationsSectionProps) {
   return (
-    <SettingsCard
-      description="Control which background events trigger desktop notifications."
-      icon={<StatusIcon />}
-      title="Notifications"
-    >
-      <div className="settings-toggle-list">
-        <label className="settings-toggle">
-          <input
-            checked={notificationPreferences.backgroundCompletion}
-            type="checkbox"
-            onChange={(event) => onSetNotificationPreferences({ backgroundCompletion: event.target.checked })}
-          />
-          <span>Background completion</span>
-        </label>
-        <label className="settings-toggle">
-          <input
-            checked={notificationPreferences.backgroundFailure}
-            type="checkbox"
-            onChange={(event) => onSetNotificationPreferences({ backgroundFailure: event.target.checked })}
-          />
-          <span>Background failures</span>
-        </label>
-        <label className="settings-toggle">
-          <input
-            checked={notificationPreferences.attentionNeeded}
-            type="checkbox"
-            onChange={(event) => onSetNotificationPreferences({ attentionNeeded: event.target.checked })}
-          />
-          <span>Needs input or approval</span>
-        </label>
-      </div>
-    </SettingsCard>
+    <SettingsGroup title="Notifications">
+      <SettingsRow title="Background completion" description="Notify when a background session finishes.">
+        <input
+          checked={notificationPreferences.backgroundCompletion}
+          type="checkbox"
+          onChange={(event) => onSetNotificationPreferences({ backgroundCompletion: event.target.checked })}
+        />
+      </SettingsRow>
+      <SettingsRow title="Background failures" description="Notify when a background session fails.">
+        <input
+          checked={notificationPreferences.backgroundFailure}
+          type="checkbox"
+          onChange={(event) => onSetNotificationPreferences({ backgroundFailure: event.target.checked })}
+        />
+      </SettingsRow>
+      <SettingsRow title="Needs input or approval" description="Notify when input is needed to continue.">
+        <input
+          checked={notificationPreferences.attentionNeeded}
+          type="checkbox"
+          onChange={(event) => onSetNotificationPreferences({ attentionNeeded: event.target.checked })}
+        />
+      </SettingsRow>
+    </SettingsGroup>
   );
 }

--- a/apps/desktop/src/settings-providers-section.tsx
+++ b/apps/desktop/src/settings-providers-section.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import type { RuntimeSnapshot } from "@pi-gui/session-driver/runtime-types";
-import { SettingsIcon, StatusIcon } from "./icons";
-import { filterProviders, ProviderRow, SettingsCard } from "./settings-utils";
+import { filterProviders, ProviderRow, SettingsGroup } from "./settings-utils";
 
 interface SettingsProvidersSectionProps {
   readonly runtime?: RuntimeSnapshot;
@@ -19,49 +18,35 @@ export function SettingsProvidersSection({ runtime, onLoginProvider, onLogoutPro
 
   return (
     <>
-      <SettingsCard
-        description="Connected providers are used first for picking models and auth-aware slash commands."
-        icon={<StatusIcon />}
-        title="Connected"
-      >
-        <div className="settings-list">
-          {connectedProviders.length > 0 ? (
-            connectedProviders.map((provider) => (
-              <ProviderRow
-                key={provider.id}
-                provider={provider}
-                onLoginProvider={onLoginProvider}
-                onLogoutProvider={onLogoutProvider}
-              />
-            ))
-          ) : (
-            <div className="settings-card__empty">No providers connected yet.</div>
-          )}
-        </div>
-      </SettingsCard>
-
-      <SettingsCard
-        description="OAuth-capable providers can sign in directly from the desktop app."
-        icon={<StatusIcon />}
-        title="Sign in"
-      >
-        <div className="settings-list">
-          {oauthProviders.map((provider) => (
+      <SettingsGroup title="Connected" description="Connected providers are used first for picking models.">
+        {connectedProviders.length > 0 ? (
+          connectedProviders.map((provider) => (
             <ProviderRow
               key={provider.id}
               provider={provider}
               onLoginProvider={onLoginProvider}
               onLogoutProvider={onLogoutProvider}
             />
-          ))}
-        </div>
-      </SettingsCard>
+          ))
+        ) : (
+          <div className="settings-row">
+            <span className="settings-row__description">No providers connected yet.</span>
+          </div>
+        )}
+      </SettingsGroup>
 
-      <SettingsCard
-        description="The full provider inventory stays searchable here without dominating the default settings view."
-        icon={<SettingsIcon />}
-        title="All providers"
-      >
+      <SettingsGroup title="Sign in" description="OAuth-capable providers can sign in directly from the desktop app.">
+        {oauthProviders.map((provider) => (
+          <ProviderRow
+            key={provider.id}
+            provider={provider}
+            onLoginProvider={onLoginProvider}
+            onLogoutProvider={onLogoutProvider}
+          />
+        ))}
+      </SettingsGroup>
+
+      <SettingsGroup title="All providers" description="Browse the full provider inventory.">
         <details className="settings-disclosure">
           <summary className="settings-disclosure__summary">
             <span>Browse all providers</span>
@@ -87,7 +72,7 @@ export function SettingsProvidersSection({ runtime, onLoginProvider, onLogoutPro
             </div>
           </div>
         </details>
-      </SettingsCard>
+      </SettingsGroup>
     </>
   );
 }

--- a/apps/desktop/src/settings-utils.tsx
+++ b/apps/desktop/src/settings-utils.tsx
@@ -79,37 +79,54 @@ export function filterModels(
   );
 }
 
-export function SettingsCard({
+/* ── Layout components ────────────────────────────────── */
+
+export function SettingsGroup({
   title,
   description,
-  icon,
   children,
 }: {
-  readonly title: string;
-  readonly description: string;
-  readonly icon: ReactNode;
+  readonly title?: string;
+  readonly description?: string;
   readonly children: ReactNode;
 }) {
   return (
-    <section className="settings-card">
-      <div className="settings-card__header">
-        <span className="settings-card__icon">{icon}</span>
-        <div>
-          <h2>{title}</h2>
-          <p>{description}</p>
-        </div>
+    <div className="settings-section">
+      {title ? <h3 className="settings-section__title">{title}</h3> : null}
+      {description ? <p className="settings-section__description">{description}</p> : null}
+      <div className="settings-group">{children}</div>
+    </div>
+  );
+}
+
+export function SettingsRow({
+  title,
+  description,
+  children,
+}: {
+  readonly title: string;
+  readonly description?: string;
+  readonly children?: ReactNode;
+}) {
+  return (
+    <div className="settings-row">
+      <div className="settings-row__label">
+        <div className="settings-row__title">{title}</div>
+        {description ? <div className="settings-row__description">{description}</div> : null}
       </div>
-      {children}
-    </section>
+      {children ? <div className="settings-row__control">{children}</div> : null}
+    </div>
   );
 }
 
 export function SettingsInfoRow({ label, value }: { readonly label: string; readonly value: string }) {
   return (
-    <div className="settings-list__row">
-      <div className="settings-list__body">
-        <div className="settings-list__title">{label}</div>
-        <div className="settings-list__meta">{value}</div>
+    <div className="settings-row">
+      <div className="settings-row__label">
+        <div className="settings-row__title">{label}</div>
+      </div>
+      <div className="settings-row__control">
+        <span className="settings-row__value">{value}</span>
       </div>
     </div>
   );
@@ -125,21 +142,23 @@ export function ProviderRow({
   readonly onLogoutProvider: (providerId: string) => void;
 }) {
   return (
-    <div className="settings-list__row">
-      <div className="settings-list__body">
-        <div className="settings-list__title">{provider.name}</div>
-        <div className="settings-list__meta">
+    <div className="settings-row">
+      <div className="settings-row__label">
+        <div className="settings-row__title">{provider.name}</div>
+        <div className="settings-row__description">
           {provider.oauthSupported ? "OAuth" : provider.authType === "api_key" ? "API key" : "Built in"}
           {provider.hasAuth ? " · connected" : ""}
         </div>
       </div>
-      <button
-        className="button button--secondary"
-        type="button"
-        onClick={() => (provider.hasAuth ? onLogoutProvider(provider.id) : onLoginProvider(provider.id))}
-      >
-        {provider.hasAuth ? "Logout" : provider.oauthSupported ? "Login" : "Configure externally"}
-      </button>
+      <div className="settings-row__control">
+        <button
+          className="button button--secondary"
+          type="button"
+          onClick={() => (provider.hasAuth ? onLogoutProvider(provider.id) : onLoginProvider(provider.id))}
+        >
+          {provider.hasAuth ? "Logout" : provider.oauthSupported ? "Login" : "Configure externally"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/settings-view.tsx
+++ b/apps/desktop/src/settings-view.tsx
@@ -83,7 +83,6 @@ export function SettingsView({
           {section === "general" ? (
             <SettingsGeneralSection
               runtime={runtime}
-              workspace={workspace}
               onToggleSkillCommands={onToggleSkillCommands}
             />
           ) : null}

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -314,10 +314,7 @@ function WorkspaceGroupContent(
       <div className={`workspace-row ${workspaceActive ? "workspace-row--active" : ""}`}>
         <button
           className={`workspace-row__select ${dragHandleProps ? "workspace-row__select--draggable" : ""}`}
-          onClick={() => {
-            wsMenu.toggleWorkspaceCollapsed(rootWorkspace.id);
-            wsMenu.selectWorkspace(rootWorkspace.id);
-          }}
+          onClick={() => wsMenu.toggleWorkspaceCollapsed(rootWorkspace.id)}
           type="button"
           {...(dragHandleProps ? { ...dragHandleProps.attributes, ...dragHandleProps.listeners } : {})}
         >

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import {
-  closestCenter,
   DndContext,
   DragOverlay,
   PointerSensor,
   useSensor,
   useSensors,
+  type CollisionDetection,
   type DraggableAttributes,
   type DraggableSyntheticListeners,
   type DragEndEvent,
@@ -71,6 +71,25 @@ export function Sidebar(props: SidebarProps) {
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  // Collision detection based on workspace row headers only (~30px top of each group),
+  // not the full group height including all sessions.
+  const headerCollision: CollisionDetection = (args) => {
+    const pointerY = args.pointerCoordinates?.y;
+    if (pointerY == null) return [];
+
+    let closest: { id: string; distance: number } | null = null;
+    for (const container of args.droppableContainers) {
+      const rect = container.rect.current;
+      if (!rect) continue;
+      const headerCenter = rect.top + 15; // center of the ~30px workspace row header
+      const distance = Math.abs(pointerY - headerCenter);
+      if (!closest || distance < closest.distance) {
+        closest = { id: String(container.id), distance };
+      }
+    }
+    return closest ? [{ id: closest.id, data: { droppableContainer: args.droppableContainers.find((c) => String(c.id) === closest!.id)! } }] : [];
+  };
 
   const rootGroups = threadGroups.filter((g) => g.rootWorkspace.kind === "primary");
   const orphanGroups = threadGroups.filter((g) => g.rootWorkspace.kind !== "primary");
@@ -179,7 +198,7 @@ export function Sidebar(props: SidebarProps) {
             </button>
           </div>
         ) : (
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <DndContext sensors={sensors} collisionDetection={headerCollision} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
             <SortableContext items={rootGroupIds} strategy={verticalListSortingStrategy}>
               <div className="workspace-list" data-testid="workspace-list">
                 {rootGroups.map((group) => (

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -13,7 +13,7 @@ import {
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { AppView, SessionRecord, WorkspaceRecord, WorktreeRecord } from "./desktop-state";
-import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, GripIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
+import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
 import type { PiDesktopApi } from "./ipc";
 import { formatRelativeTime } from "./string-utils";
 import type { WorkspaceMenuState } from "./hooks/use-workspace-menu";
@@ -312,20 +312,11 @@ function WorkspaceGroupContent(
     <>
       <div className={`workspace-row ${workspaceActive ? "workspace-row--active" : ""}`}>
         <button
-          className="workspace-row__select"
+          className={`workspace-row__select ${dragHandleProps ? "workspace-row__select--draggable" : ""}`}
           onClick={() => wsMenu.selectWorkspace(rootWorkspace.id)}
           type="button"
+          {...(dragHandleProps ? { ...dragHandleProps.attributes, ...dragHandleProps.listeners } : {})}
         >
-          {dragHandleProps ? (
-            <span
-              className="workspace-row__drag-handle"
-              {...dragHandleProps.attributes}
-              {...dragHandleProps.listeners}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <GripIcon />
-            </span>
-          ) : null}
           <span className="workspace-row__icon" aria-hidden="true">
             <FolderIcon />
           </span>

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import {
+  closestCenter,
   DndContext,
   DragOverlay,
   PointerSensor,
@@ -178,7 +179,7 @@ export function Sidebar(props: SidebarProps) {
             </button>
           </div>
         ) : (
-          <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
             <SortableContext items={rootGroupIds} strategy={verticalListSortingStrategy}>
               <div className="workspace-list" data-testid="workspace-list">
                 {rootGroups.map((group) => (

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -5,10 +5,12 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
+  type DraggableAttributes,
+  type DraggableSyntheticListeners,
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
-import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { AppView, SessionRecord, WorkspaceRecord, WorktreeRecord } from "./desktop-state";
 import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, GripIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
@@ -85,11 +87,9 @@ export function Sidebar(props: SidebarProps) {
 
     const oldIndex = rootGroupIds.indexOf(String(active.id));
     const newIndex = rootGroupIds.indexOf(String(over.id));
-    if (oldIndex === -1 || newIndex === -1) return;
+    if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return;
 
-    const newOrder = [...rootGroupIds];
-    newOrder.splice(oldIndex, 1);
-    newOrder.splice(newIndex, 0, String(active.id));
+    const newOrder = arrayMove(rootGroupIds, oldIndex, newIndex);
     void updateSnapshot(api, setSnapshot, () => api.reorderWorkspaces(newOrder));
   }
 
@@ -184,7 +184,6 @@ export function Sidebar(props: SidebarProps) {
                     key={group.rootWorkspace.id}
                     group={group}
                     canDrag={canDrag}
-                    isDragging={activeId === group.rootWorkspace.id}
                     selectedWorkspace={selectedWorkspace}
                     selectedSession={selectedSession}
                     linkedWorktreeByWorkspaceId={linkedWorktreeByWorkspaceId}
@@ -200,7 +199,6 @@ export function Sidebar(props: SidebarProps) {
                     key={group.rootWorkspace.id}
                     group={group}
                     canDrag={false}
-                    isDragging={false}
                     selectedWorkspace={selectedWorkspace}
                     selectedSession={selectedSession}
                     linkedWorktreeByWorkspaceId={linkedWorktreeByWorkspaceId}
@@ -219,7 +217,6 @@ export function Sidebar(props: SidebarProps) {
                   <WorkspaceGroupContent
                     group={activeGroup}
                     canDrag={false}
-                    isDragging={false}
                     selectedWorkspace={selectedWorkspace}
                     selectedSession={selectedSession}
                     linkedWorktreeByWorkspaceId={linkedWorktreeByWorkspaceId}
@@ -244,7 +241,6 @@ export function Sidebar(props: SidebarProps) {
 interface WorkspaceGroupProps {
   readonly group: ThreadGroup;
   readonly canDrag: boolean;
-  readonly isDragging: boolean;
   readonly selectedWorkspace: WorkspaceRecord | undefined;
   readonly selectedSession: SessionRecord | undefined;
   readonly linkedWorktreeByWorkspaceId: Map<string, WorktreeRecord>;
@@ -277,7 +273,6 @@ function SortableWorkspaceGroup(props: WorkspaceGroupProps) {
     >
       <WorkspaceGroupContent
         {...props}
-        isDragging={isDragging}
         dragHandleProps={props.canDrag && !isRenaming ? { attributes, listeners } : undefined}
       />
     </section>
@@ -287,18 +282,12 @@ function SortableWorkspaceGroup(props: WorkspaceGroupProps) {
 /* ── Workspace group content (used both inline and in overlay) ──── */
 
 interface DragHandleProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly attributes: Record<string, any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly listeners: Record<string, any> | undefined;
+  readonly attributes: DraggableAttributes;
+  readonly listeners: DraggableSyntheticListeners;
 }
 
 function WorkspaceGroupContent(
-  props: WorkspaceGroupProps & {
-    readonly dragHandleProps?: DragHandleProps;
-    readonly style?: React.CSSProperties;
-    readonly ref?: React.Ref<HTMLElement>;
-  },
+  props: WorkspaceGroupProps & { readonly dragHandleProps?: DragHandleProps },
 ) {
   const {
     group: { rootWorkspace, threads, archivedThreads },

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -1,5 +1,17 @@
+import { useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { AppView, SessionRecord, WorkspaceRecord, WorktreeRecord } from "./desktop-state";
-import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
+import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, GripIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
 import type { PiDesktopApi } from "./ipc";
 import { formatRelativeTime } from "./string-utils";
 import type { WorkspaceMenuState } from "./hooks/use-workspace-menu";
@@ -53,6 +65,35 @@ export function Sidebar(props: SidebarProps) {
     onSelectSession,
     onUnarchiveSession,
   } = props;
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const rootGroups = threadGroups.filter((g) => g.rootWorkspace.kind === "primary");
+  const orphanGroups = threadGroups.filter((g) => g.rootWorkspace.kind !== "primary");
+  const rootGroupIds = rootGroups.map((g) => g.rootWorkspace.id);
+  const canDrag = rootGroups.length > 1;
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(String(event.active.id));
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    setActiveId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = rootGroupIds.indexOf(String(active.id));
+    const newIndex = rootGroupIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const newOrder = [...rootGroupIds];
+    newOrder.splice(oldIndex, 1);
+    newOrder.splice(newIndex, 0, String(active.id));
+    void updateSnapshot(api, setSnapshot, () => api.reorderWorkspaces(newOrder));
+  }
+
+  const activeGroup = activeId ? rootGroups.find((g) => g.rootWorkspace.id === activeId) : undefined;
 
   return (
     <aside className="sidebar">
@@ -135,203 +176,344 @@ export function Sidebar(props: SidebarProps) {
             </button>
           </div>
         ) : (
-          <div className="workspace-list" data-testid="workspace-list">
-            {threadGroups.map(({ rootWorkspace, threads, archivedThreads }) => {
-              const workspaceActive =
-                rootWorkspace.id === selectedWorkspace?.id ||
-                rootWorkspace.id === selectedWorkspace?.rootWorkspaceId;
-              const linkedWorktree = linkedWorktreeByWorkspaceId.get(rootWorkspace.id);
-              const archivedSectionOpen = wsMenu.expandedArchivedByWorkspace[rootWorkspace.id] ?? false;
-              return (
-                <section key={rootWorkspace.id} className="workspace-group">
-                  <div className={`workspace-row ${workspaceActive ? "workspace-row--active" : ""}`}>
-                    <button
-                      className="workspace-row__select"
-                      onClick={() => wsMenu.selectWorkspace(rootWorkspace.id)}
-                      type="button"
-                    >
-                      <span className="workspace-row__icon" aria-hidden="true">
-                        <FolderIcon />
-                      </span>
-                      <span className="workspace-row__name">{rootWorkspace.name}</span>
-                      <span className="workspace-row__time">{formatRelativeTime(rootWorkspace.lastOpenedAt)}</span>
-                    </button>
-                    <span
-                      className="workspace-row__menu-wrap"
-                      ref={wsMenu.workspaceMenuId === rootWorkspace.id ? wsMenu.workspaceMenuWrapRef : undefined}
-                    >
-                      <button
-                        aria-label={`Workspace actions for ${rootWorkspace.name}`}
-                        aria-haspopup="menu"
-                        className="icon-button workspace-row__menu-button"
-                        aria-expanded={wsMenu.workspaceMenuId === rootWorkspace.id}
-                        type="button"
-                        onClick={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          wsMenu.openWorkspaceMenu(rootWorkspace.id);
-                        }}
-                      >
-                        …
-                      </button>
-                      {wsMenu.workspaceMenuId === rootWorkspace.id ? (
-                        <div className="workspace-menu">
-                          <button
-                            className="workspace-menu__item"
-                            type="button"
-                            onClick={(event) =>
-                              wsMenu.runWorkspaceMenuAction(event, () => {
-                                void api.openWorkspaceInFinder(rootWorkspace.id);
-                              })
-                            }
-                          >
-                            Open in Finder
-                          </button>
-                          {linkedWorktree ? (
-                            <button
-                              className="workspace-menu__item workspace-menu__item--danger"
-                              type="button"
-                              onClick={(event) =>
-                                wsMenu.runWorkspaceMenuAction(event, () =>
-                                  wsMenu.removeWorktree(linkedWorktree.rootWorkspaceId || rootWorkspace.id, linkedWorktree),
-                                )
-                              }
-                            >
-                              Remove worktree
-                            </button>
-                          ) : (
-                            <button
-                              className="workspace-menu__item"
-                              type="button"
-                              onClick={(event) =>
-                                wsMenu.runWorkspaceMenuAction(event, () => wsMenu.createWorktree(rootWorkspace.id))
-                              }
-                            >
-                              Create permanent worktree
-                            </button>
-                          )}
-                          <button
-                            className="workspace-menu__item"
-                            type="button"
-                            onClick={(event) => wsMenu.runWorkspaceMenuAction(event, () => wsMenu.startRename(rootWorkspace))}
-                          >
-                            Edit name
-                          </button>
-                          <button
-                            className="workspace-menu__item workspace-menu__item--danger"
-                            type="button"
-                            onClick={(event) => wsMenu.runWorkspaceMenuAction(event, () => wsMenu.removeWorkspace(rootWorkspace))}
-                          >
-                            Remove
-                          </button>
-                        </div>
-                      ) : null}
-                    </span>
-                  </div>
-                  {wsMenu.workspaceRenameId === rootWorkspace.id ? (
-                    <form
-                      className="workspace-rename"
-                      ref={wsMenu.workspaceRenamePanelRef}
-                      onSubmit={(event) => {
-                        event.preventDefault();
-                        wsMenu.submitRename(rootWorkspace);
-                      }}
-                    >
-                      <input
-                        aria-label={`Rename ${rootWorkspace.name}`}
-                        className="workspace-rename__input"
-                        ref={wsMenu.workspaceRenameInputRef}
-                        value={wsMenu.workspaceRenameDraft}
-                        onChange={(event) => {
-                          wsMenu.setWorkspaceRenameDraft(event.target.value);
-                        }}
-                        onKeyDown={(event) => {
-                          if (event.key === "Escape") {
-                            event.preventDefault();
-                            wsMenu.cancelRename();
-                          }
-                        }}
-                      />
-                      <div className="workspace-rename__actions">
-                        <button className="workspace-rename__button" type="button" onClick={wsMenu.cancelRename}>
-                          Cancel
-                        </button>
-                        <button className="workspace-rename__button workspace-rename__button--primary" type="submit">
-                          Save
-                        </button>
-                      </div>
-                    </form>
-                  ) : null}
-                  <div className="session-list">
-                    {threads.map((thread) => {
-                      const active = thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
-                      return (
-                        <ThreadSessionRow
-                          key={`${thread.workspaceId}:${thread.session.id}`}
-                          active={active}
-                          thread={thread}
-                          onAction={() =>
-                            onArchiveSession(rootWorkspace.id, {
-                              workspaceId: thread.workspaceId,
-                              sessionId: thread.session.id,
-                            })
-                          }
-                          onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
-                        />
-                      );
-                    })}
-                  </div>
-                  {archivedThreads.length > 0 ? (
-                    <div className="archived-thread-group">
-                      <button
-                        aria-expanded={archivedSectionOpen}
-                        className="archived-thread-group__toggle"
-                        type="button"
-                        onClick={() => wsMenu.toggleArchived(rootWorkspace.id, !archivedSectionOpen)}
-                      >
-                        <span
-                          aria-hidden="true"
-                          className={`archived-thread-group__chevron ${archivedSectionOpen ? "archived-thread-group__chevron--open" : ""}`}
-                        >
-                          <ChevronDownIcon />
-                        </span>
-                        <span>Archived</span>
-                        <span className="archived-thread-group__count">{archivedThreads.length}</span>
-                      </button>
-                      {archivedSectionOpen ? (
-                        <div className="session-list session-list--archived">
-                          {archivedThreads.map((thread) => {
-                            const active =
-                              thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
-                            return (
-                              <ThreadSessionRow
-                                key={`${thread.workspaceId}:${thread.session.id}`}
-                                active={active}
-                                archived
-                                thread={thread}
-                                onAction={() =>
-                                  onUnarchiveSession({
-                                    workspaceId: thread.workspaceId,
-                                    sessionId: thread.session.id,
-                                  })
-                                }
-                                onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
-                              />
-                            );
-                          })}
-                        </div>
-                      ) : null}
-                    </div>
-                  ) : null}
-                </section>
-              );
-            })}
-          </div>
+          <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+            <SortableContext items={rootGroupIds} strategy={verticalListSortingStrategy}>
+              <div className="workspace-list" data-testid="workspace-list">
+                {rootGroups.map((group) => (
+                  <SortableWorkspaceGroup
+                    key={group.rootWorkspace.id}
+                    group={group}
+                    canDrag={canDrag}
+                    isDragging={activeId === group.rootWorkspace.id}
+                    selectedWorkspace={selectedWorkspace}
+                    selectedSession={selectedSession}
+                    linkedWorktreeByWorkspaceId={linkedWorktreeByWorkspaceId}
+                    wsMenu={wsMenu}
+                    api={api}
+                    onArchiveSession={onArchiveSession}
+                    onSelectSession={onSelectSession}
+                    onUnarchiveSession={onUnarchiveSession}
+                  />
+                ))}
+                {orphanGroups.map((group) => (
+                  <WorkspaceGroupContent
+                    key={group.rootWorkspace.id}
+                    group={group}
+                    canDrag={false}
+                    isDragging={false}
+                    selectedWorkspace={selectedWorkspace}
+                    selectedSession={selectedSession}
+                    linkedWorktreeByWorkspaceId={linkedWorktreeByWorkspaceId}
+                    wsMenu={wsMenu}
+                    api={api}
+                    onArchiveSession={onArchiveSession}
+                    onSelectSession={onSelectSession}
+                    onUnarchiveSession={onUnarchiveSession}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+            <DragOverlay>
+              {activeGroup ? (
+                <div className="workspace-group workspace-group--overlay">
+                  <WorkspaceGroupContent
+                    group={activeGroup}
+                    canDrag={false}
+                    isDragging={false}
+                    selectedWorkspace={selectedWorkspace}
+                    selectedSession={selectedSession}
+                    linkedWorktreeByWorkspaceId={linkedWorktreeByWorkspaceId}
+                    wsMenu={wsMenu}
+                    api={api}
+                    onArchiveSession={onArchiveSession}
+                    onSelectSession={onSelectSession}
+                    onUnarchiveSession={onUnarchiveSession}
+                  />
+                </div>
+              ) : null}
+            </DragOverlay>
+          </DndContext>
         )}
       </div>
     </aside>
   );
 }
+
+/* ── Sortable workspace group wrapper ──────────────────── */
+
+interface WorkspaceGroupProps {
+  readonly group: ThreadGroup;
+  readonly canDrag: boolean;
+  readonly isDragging: boolean;
+  readonly selectedWorkspace: WorkspaceRecord | undefined;
+  readonly selectedSession: SessionRecord | undefined;
+  readonly linkedWorktreeByWorkspaceId: Map<string, WorktreeRecord>;
+  readonly wsMenu: WorkspaceMenuState;
+  readonly api: PiDesktopApi;
+  readonly onArchiveSession: (rootWorkspaceId: string, target: { workspaceId: string; sessionId: string }) => void;
+  readonly onSelectSession: (target: { workspaceId: string; sessionId: string }) => void;
+  readonly onUnarchiveSession: (target: { workspaceId: string; sessionId: string }) => void;
+}
+
+function SortableWorkspaceGroup(props: WorkspaceGroupProps) {
+  const { group, wsMenu } = props;
+  const isRenaming = wsMenu.workspaceRenameId === group.rootWorkspace.id;
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: group.rootWorkspace.id,
+    disabled: isRenaming,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.3 : undefined,
+  };
+
+  return (
+    <section
+      ref={setNodeRef}
+      style={style}
+      className={`workspace-group ${isDragging ? "workspace-group--dragging" : ""}`}
+    >
+      <WorkspaceGroupContent
+        {...props}
+        isDragging={isDragging}
+        dragHandleProps={props.canDrag && !isRenaming ? { attributes, listeners } : undefined}
+      />
+    </section>
+  );
+}
+
+/* ── Workspace group content (used both inline and in overlay) ──── */
+
+interface DragHandleProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly attributes: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly listeners: Record<string, any> | undefined;
+}
+
+function WorkspaceGroupContent(
+  props: WorkspaceGroupProps & {
+    readonly dragHandleProps?: DragHandleProps;
+    readonly style?: React.CSSProperties;
+    readonly ref?: React.Ref<HTMLElement>;
+  },
+) {
+  const {
+    group: { rootWorkspace, threads, archivedThreads },
+    selectedWorkspace,
+    selectedSession,
+    linkedWorktreeByWorkspaceId,
+    wsMenu,
+    api,
+    onArchiveSession,
+    onSelectSession,
+    onUnarchiveSession,
+    dragHandleProps,
+  } = props;
+
+  const workspaceActive =
+    rootWorkspace.id === selectedWorkspace?.id ||
+    rootWorkspace.id === selectedWorkspace?.rootWorkspaceId;
+  const linkedWorktree = linkedWorktreeByWorkspaceId.get(rootWorkspace.id);
+  const archivedSectionOpen = wsMenu.expandedArchivedByWorkspace[rootWorkspace.id] ?? false;
+
+  return (
+    <>
+      <div className={`workspace-row ${workspaceActive ? "workspace-row--active" : ""}`}>
+        {dragHandleProps ? (
+          <span
+            className="workspace-row__drag-handle"
+            {...dragHandleProps.attributes}
+            {...dragHandleProps.listeners}
+          >
+            <GripIcon />
+          </span>
+        ) : null}
+        <button
+          className="workspace-row__select"
+          onClick={() => wsMenu.selectWorkspace(rootWorkspace.id)}
+          type="button"
+        >
+          <span className="workspace-row__icon" aria-hidden="true">
+            <FolderIcon />
+          </span>
+          <span className="workspace-row__name">{rootWorkspace.name}</span>
+          <span className="workspace-row__time">{formatRelativeTime(rootWorkspace.lastOpenedAt)}</span>
+        </button>
+        <span
+          className="workspace-row__menu-wrap"
+          ref={wsMenu.workspaceMenuId === rootWorkspace.id ? wsMenu.workspaceMenuWrapRef : undefined}
+        >
+          <button
+            aria-label={`Workspace actions for ${rootWorkspace.name}`}
+            aria-haspopup="menu"
+            className="icon-button workspace-row__menu-button"
+            aria-expanded={wsMenu.workspaceMenuId === rootWorkspace.id}
+            type="button"
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              wsMenu.openWorkspaceMenu(rootWorkspace.id);
+            }}
+          >
+            …
+          </button>
+          {wsMenu.workspaceMenuId === rootWorkspace.id ? (
+            <div className="workspace-menu">
+              <button
+                className="workspace-menu__item"
+                type="button"
+                onClick={(event) =>
+                  wsMenu.runWorkspaceMenuAction(event, () => {
+                    void api.openWorkspaceInFinder(rootWorkspace.id);
+                  })
+                }
+              >
+                Open in Finder
+              </button>
+              {linkedWorktree ? (
+                <button
+                  className="workspace-menu__item workspace-menu__item--danger"
+                  type="button"
+                  onClick={(event) =>
+                    wsMenu.runWorkspaceMenuAction(event, () =>
+                      wsMenu.removeWorktree(linkedWorktree.rootWorkspaceId || rootWorkspace.id, linkedWorktree),
+                    )
+                  }
+                >
+                  Remove worktree
+                </button>
+              ) : (
+                <button
+                  className="workspace-menu__item"
+                  type="button"
+                  onClick={(event) =>
+                    wsMenu.runWorkspaceMenuAction(event, () => wsMenu.createWorktree(rootWorkspace.id))
+                  }
+                >
+                  Create permanent worktree
+                </button>
+              )}
+              <button
+                className="workspace-menu__item"
+                type="button"
+                onClick={(event) => wsMenu.runWorkspaceMenuAction(event, () => wsMenu.startRename(rootWorkspace))}
+              >
+                Edit name
+              </button>
+              <button
+                className="workspace-menu__item workspace-menu__item--danger"
+                type="button"
+                onClick={(event) => wsMenu.runWorkspaceMenuAction(event, () => wsMenu.removeWorkspace(rootWorkspace))}
+              >
+                Remove
+              </button>
+            </div>
+          ) : null}
+        </span>
+      </div>
+      {wsMenu.workspaceRenameId === rootWorkspace.id ? (
+        <form
+          className="workspace-rename"
+          ref={wsMenu.workspaceRenamePanelRef}
+          onSubmit={(event) => {
+            event.preventDefault();
+            wsMenu.submitRename(rootWorkspace);
+          }}
+        >
+          <input
+            aria-label={`Rename ${rootWorkspace.name}`}
+            className="workspace-rename__input"
+            ref={wsMenu.workspaceRenameInputRef}
+            value={wsMenu.workspaceRenameDraft}
+            onChange={(event) => {
+              wsMenu.setWorkspaceRenameDraft(event.target.value);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                wsMenu.cancelRename();
+              }
+            }}
+          />
+          <div className="workspace-rename__actions">
+            <button className="workspace-rename__button" type="button" onClick={wsMenu.cancelRename}>
+              Cancel
+            </button>
+            <button className="workspace-rename__button workspace-rename__button--primary" type="submit">
+              Save
+            </button>
+          </div>
+        </form>
+      ) : null}
+      <div className="session-list">
+        {threads.map((thread) => {
+          const active = thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
+          return (
+            <ThreadSessionRow
+              key={`${thread.workspaceId}:${thread.session.id}`}
+              active={active}
+              thread={thread}
+              onAction={() =>
+                onArchiveSession(rootWorkspace.id, {
+                  workspaceId: thread.workspaceId,
+                  sessionId: thread.session.id,
+                })
+              }
+              onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
+            />
+          );
+        })}
+      </div>
+      {archivedThreads.length > 0 ? (
+        <div className="archived-thread-group">
+          <button
+            aria-expanded={archivedSectionOpen}
+            className="archived-thread-group__toggle"
+            type="button"
+            onClick={() => wsMenu.toggleArchived(rootWorkspace.id, !archivedSectionOpen)}
+          >
+            <span
+              aria-hidden="true"
+              className={`archived-thread-group__chevron ${archivedSectionOpen ? "archived-thread-group__chevron--open" : ""}`}
+            >
+              <ChevronDownIcon />
+            </span>
+            <span>Archived</span>
+            <span className="archived-thread-group__count">{archivedThreads.length}</span>
+          </button>
+          {archivedSectionOpen ? (
+            <div className="session-list session-list--archived">
+              {archivedThreads.map((thread) => {
+                const active =
+                  thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
+                return (
+                  <ThreadSessionRow
+                    key={`${thread.workspaceId}:${thread.session.id}`}
+                    active={active}
+                    archived
+                    thread={thread}
+                    onAction={() =>
+                      onUnarchiveSession({
+                        workspaceId: thread.workspaceId,
+                        sessionId: thread.session.id,
+                      })
+                    }
+                    onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
+                  />
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+/* ── Thread session row ────────────────────────────────── */
 
 function sessionIndicatorVariant(thread: ThreadListEntry): "running" | "unseen" | "none" {
   if (thread.session.status === "running") {

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -311,25 +311,25 @@ function WorkspaceGroupContent(
   return (
     <>
       <div className={`workspace-row ${workspaceActive ? "workspace-row--active" : ""}`}>
-        {dragHandleProps ? (
-          <span
-            className="workspace-row__drag-handle"
-            {...dragHandleProps.attributes}
-            {...dragHandleProps.listeners}
-          >
-            <GripIcon />
-          </span>
-        ) : null}
         <button
           className="workspace-row__select"
           onClick={() => wsMenu.selectWorkspace(rootWorkspace.id)}
           type="button"
         >
+          {dragHandleProps ? (
+            <span
+              className="workspace-row__drag-handle"
+              {...dragHandleProps.attributes}
+              {...dragHandleProps.listeners}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <GripIcon />
+            </span>
+          ) : null}
           <span className="workspace-row__icon" aria-hidden="true">
             <FolderIcon />
           </span>
           <span className="workspace-row__name">{rootWorkspace.name}</span>
-          <span className="workspace-row__time">{formatRelativeTime(rootWorkspace.lastOpenedAt)}</span>
         </button>
         <span
           className="workspace-row__menu-wrap"

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -90,7 +90,9 @@ export function Sidebar(props: SidebarProps) {
     if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return;
 
     const newOrder = arrayMove(rootGroupIds, oldIndex, newIndex);
-    void updateSnapshot(api, setSnapshot, () => api.reorderWorkspaces(newOrder));
+    // Optimistically update local state to avoid snap-back animation
+    setSnapshot((prev) => prev ? { ...prev, workspaceOrder: newOrder } : prev);
+    void api.reorderWorkspaces(newOrder);
   }
 
   const activeGroup = activeId ? rootGroups.find((g) => g.rootWorkspace.id === activeId) : undefined;

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -307,18 +307,23 @@ function WorkspaceGroupContent(
     rootWorkspace.id === selectedWorkspace?.rootWorkspaceId;
   const linkedWorktree = linkedWorktreeByWorkspaceId.get(rootWorkspace.id);
   const archivedSectionOpen = wsMenu.expandedArchivedByWorkspace[rootWorkspace.id] ?? false;
+  const isCollapsed = wsMenu.collapsedWorkspaces[rootWorkspace.id] ?? false;
 
   return (
     <>
       <div className={`workspace-row ${workspaceActive ? "workspace-row--active" : ""}`}>
         <button
           className={`workspace-row__select ${dragHandleProps ? "workspace-row__select--draggable" : ""}`}
-          onClick={() => wsMenu.selectWorkspace(rootWorkspace.id)}
+          onClick={() => {
+            wsMenu.toggleWorkspaceCollapsed(rootWorkspace.id);
+            wsMenu.selectWorkspace(rootWorkspace.id);
+          }}
           type="button"
           {...(dragHandleProps ? { ...dragHandleProps.attributes, ...dragHandleProps.listeners } : {})}
         >
-          <span className="workspace-row__icon" aria-hidden="true">
-            <FolderIcon />
+          <span className="workspace-row__icon" aria-hidden="true" data-collapsed={isCollapsed || undefined}>
+            <span className="workspace-row__icon-folder"><FolderIcon /></span>
+            <span className="workspace-row__icon-chevron"><ChevronDownIcon /></span>
           </span>
           <span className="workspace-row__name">{rootWorkspace.name}</span>
         </button>
@@ -428,66 +433,70 @@ function WorkspaceGroupContent(
           </div>
         </form>
       ) : null}
-      <div className="session-list">
-        {threads.map((thread) => {
-          const active = thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
-          return (
-            <ThreadSessionRow
-              key={`${thread.workspaceId}:${thread.session.id}`}
-              active={active}
-              thread={thread}
-              onAction={() =>
-                onArchiveSession(rootWorkspace.id, {
-                  workspaceId: thread.workspaceId,
-                  sessionId: thread.session.id,
-                })
-              }
-              onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
-            />
-          );
-        })}
-      </div>
-      {archivedThreads.length > 0 ? (
-        <div className="archived-thread-group">
-          <button
-            aria-expanded={archivedSectionOpen}
-            className="archived-thread-group__toggle"
-            type="button"
-            onClick={() => wsMenu.toggleArchived(rootWorkspace.id, !archivedSectionOpen)}
-          >
-            <span
-              aria-hidden="true"
-              className={`archived-thread-group__chevron ${archivedSectionOpen ? "archived-thread-group__chevron--open" : ""}`}
-            >
-              <ChevronDownIcon />
-            </span>
-            <span>Archived</span>
-            <span className="archived-thread-group__count">{archivedThreads.length}</span>
-          </button>
-          {archivedSectionOpen ? (
-            <div className="session-list session-list--archived">
-              {archivedThreads.map((thread) => {
-                const active =
-                  thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
-                return (
-                  <ThreadSessionRow
-                    key={`${thread.workspaceId}:${thread.session.id}`}
-                    active={active}
-                    archived
-                    thread={thread}
-                    onAction={() =>
-                      onUnarchiveSession({
-                        workspaceId: thread.workspaceId,
-                        sessionId: thread.session.id,
-                      })
-                    }
-                    onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
-                  />
-                );
-              })}
+      {!isCollapsed ? (
+        <>
+          <div className="session-list">
+            {threads.map((thread) => {
+              const active = thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
+              return (
+                <ThreadSessionRow
+                  key={`${thread.workspaceId}:${thread.session.id}`}
+                  active={active}
+                  thread={thread}
+                  onAction={() =>
+                    onArchiveSession(rootWorkspace.id, {
+                      workspaceId: thread.workspaceId,
+                      sessionId: thread.session.id,
+                    })
+                  }
+                  onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
+                />
+              );
+            })}
+          </div>
+          {archivedThreads.length > 0 ? (
+            <div className="archived-thread-group">
+              <button
+                aria-expanded={archivedSectionOpen}
+                className="archived-thread-group__toggle"
+                type="button"
+                onClick={() => wsMenu.toggleArchived(rootWorkspace.id, !archivedSectionOpen)}
+              >
+                <span
+                  aria-hidden="true"
+                  className={`archived-thread-group__chevron ${archivedSectionOpen ? "archived-thread-group__chevron--open" : ""}`}
+                >
+                  <ChevronDownIcon />
+                </span>
+                <span>Archived</span>
+                <span className="archived-thread-group__count">{archivedThreads.length}</span>
+              </button>
+              {archivedSectionOpen ? (
+                <div className="session-list session-list--archived">
+                  {archivedThreads.map((thread) => {
+                    const active =
+                      thread.workspaceId === selectedWorkspace?.id && thread.session.id === selectedSession?.id;
+                    return (
+                      <ThreadSessionRow
+                        key={`${thread.workspaceId}:${thread.session.id}`}
+                        active={active}
+                        archived
+                        thread={thread}
+                        onAction={() =>
+                          onUnarchiveSession({
+                            workspaceId: thread.workspaceId,
+                            sessionId: thread.session.id,
+                          })
+                        }
+                        onSelect={() => onSelectSession({ workspaceId: thread.workspaceId, sessionId: thread.session.id })}
+                      />
+                    );
+                  })}
+                </div>
+              ) : null}
             </div>
           ) : null}
-        </div>
+        </>
       ) : null}
     </>
   );

--- a/apps/desktop/src/string-utils.ts
+++ b/apps/desktop/src/string-utils.ts
@@ -24,5 +24,10 @@ export function formatRelativeTime(value: string): string {
   if (diffHours < 24) return `${diffHours}h`;
   const diffDays = Math.floor(diffHours / 24);
   if (diffDays < 7) return `${diffDays}d`;
-  return new Date(timestamp).toLocaleDateString();
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffDays < 30) return `${diffWeeks}w`;
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}mo`;
+  const diffYears = Math.floor(diffDays / 365);
+  return `${diffYears}y`;
 }

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -1401,6 +1401,11 @@
   padding-top: 12px;
 }
 
+.settings-group > .settings-disclosure {
+  border-top: none;
+  padding: 14px 18px;
+}
+
 .settings-disclosure__summary {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -1462,7 +1462,78 @@
 
 .settings-grid {
   display: grid;
-  gap: 16px;
+  gap: 24px;
+}
+
+.settings-section {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-section__title {
+  font-size: 16px;
+  font-weight: 600;
+  color: inherit;
+}
+
+.settings-section__description {
+  font-size: 13px;
+  color: var(--muted-soft);
+}
+
+.settings-group {
+  border: 1px solid #dfe4ee;
+  border-radius: 18px;
+  background: #fff;
+}
+
+.settings-group > :first-child {
+  border-radius: 18px 18px 0 0;
+}
+
+.settings-group > :last-child {
+  border-radius: 0 0 18px 18px;
+}
+
+.settings-group > :only-child {
+  border-radius: 18px;
+}
+
+.settings-group > * + * {
+  border-top: 1px solid #edf0f6;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 14px 18px;
+}
+
+.settings-row__label {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-row__title {
+  font-size: 14px;
+  font-weight: 590;
+}
+
+.settings-row__description {
+  font-size: 13px;
+  color: var(--muted-soft);
+  line-height: 1.4;
+}
+
+.settings-row__control {
+  flex-shrink: 0;
+}
+
+.settings-row__value {
+  font-size: 13px;
+  color: var(--muted-soft);
 }
 
 .settings-stack {
@@ -1519,13 +1590,13 @@
   font-size: 13px;
 }
 
-.settings-card__hint {
+.settings-hint {
   color: var(--muted-soft);
   font-size: 13px;
   font-style: italic;
 }
 
-.settings-card__warning {
+.settings-warning {
   color: var(--warning, #d97706);
   font-size: 13px;
 }
@@ -2221,6 +2292,15 @@ mark.thread-find-active {
 }
 
 :root.dark .settings-disclosure {
+  border-top-color: var(--line);
+}
+
+:root.dark .settings-group {
+  border-color: var(--line);
+  background: var(--surface);
+}
+
+:root.dark .settings-group > * + * {
   border-top-color: var(--line);
 }
 

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -1524,6 +1524,24 @@
   font-size: 13px;
 }
 
+.settings-card__hint {
+  color: var(--muted-soft);
+  font-size: 13px;
+  font-style: italic;
+}
+
+.settings-card__warning {
+  color: var(--warning, #d97706);
+  font-size: 13px;
+}
+
+.settings-toggle--inline {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  cursor: pointer;
+}
+
 .settings-field {
   display: grid;
   gap: 6px;

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -1536,60 +1536,6 @@
   color: var(--muted-soft);
 }
 
-.settings-stack {
-  display: grid;
-  gap: 12px;
-}
-
-.settings-card {
-  padding: 16px 18px;
-  border-radius: 18px;
-  border: 1px solid #dfe4ee;
-  background: #fff;
-  display: grid;
-  gap: 12px;
-}
-
-.settings-card__header {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.settings-card__icon {
-  width: 28px;
-  height: 28px;
-  display: grid;
-  place-items: center;
-  color: var(--muted-soft);
-  border-radius: 10px;
-  background: #f5f7fb;
-}
-
-.settings-card__icon svg {
-  width: 18px;
-  height: 18px;
-}
-
-.settings-card h2 {
-  margin: 0;
-  color: var(--text-strong);
-  font-size: 17px;
-  font-weight: 620;
-}
-
-.settings-card p {
-  margin: 0;
-  color: var(--muted-strong);
-  font-size: 14px;
-  line-height: 1.55;
-}
-
-.settings-card__empty {
-  color: var(--muted-soft);
-  font-size: 13px;
-}
-
 .settings-hint {
   color: var(--muted-soft);
   font-size: 13px;
@@ -2243,15 +2189,6 @@ mark.thread-find-active {
 :root.dark .surface-toolbar__field select {
   border-color: var(--line);
   background: var(--surface);
-}
-
-:root.dark .settings-card {
-  border-color: var(--line);
-  background: var(--surface);
-}
-
-:root.dark .settings-card__icon {
-  background: var(--surface-muted);
 }
 
 :root.dark .settings-list__row {

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -1394,6 +1394,13 @@
   height: 14px;
 }
 
+.new-thread__meta .model-selector__dropdown {
+  bottom: auto;
+  top: 100%;
+  margin-bottom: 0;
+  margin-top: 4px;
+}
+
 .settings-disclosure {
   border-top: 1px solid #edf0f6;
   padding-top: 12px;

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -868,11 +868,6 @@
   font-weight: 500;
 }
 
-.model-selector__item--unavailable {
-  opacity: 0.4;
-  cursor: default;
-}
-
 .model-selector__item-label {
   flex: 1;
 }

--- a/apps/desktop/src/styles/sidebar.css
+++ b/apps/desktop/src/styles/sidebar.css
@@ -178,33 +178,11 @@
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
-.workspace-row__drag-handle {
-  position: absolute;
-  left: -2px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 18px;
-  height: 18px;
-  display: grid;
-  place-items: center;
-  color: var(--muted-soft);
+.workspace-row__select--draggable {
   cursor: grab;
-  touch-action: none;
-  opacity: 0;
-  transition: opacity 0.15s;
-  z-index: 1;
 }
 
-.workspace-row__drag-handle svg {
-  width: 14px;
-  height: 14px;
-}
-
-.workspace-row:hover .workspace-row__drag-handle {
-  opacity: 1;
-}
-
-.workspace-row__drag-handle:active {
+.workspace-row__select--draggable:active {
   cursor: grabbing;
 }
 

--- a/apps/desktop/src/styles/sidebar.css
+++ b/apps/desktop/src/styles/sidebar.css
@@ -206,10 +206,13 @@
   width: 100%;
   display: grid;
   align-items: center;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 10px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  min-width: 0;
+  padding-left: 23px;
   text-align: left;
   color: inherit;
+  position: relative;
 }
 
 .worktree-row__select {
@@ -235,6 +238,11 @@
   display: grid;
   place-items: center;
   color: var(--muted-icon);
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 
 .workspace-row__icon svg {
@@ -530,6 +538,7 @@
   align-items: center;
   justify-content: flex-end;
   width: 100%;
+  padding-right: 5px;
 }
 
 .session-row__workspace-icon {

--- a/apps/desktop/src/styles/sidebar.css
+++ b/apps/desktop/src/styles/sidebar.css
@@ -538,7 +538,6 @@
   align-items: center;
   justify-content: flex-end;
   width: 100%;
-  padding-right: 5px;
 }
 
 .session-row__workspace-icon {
@@ -571,11 +570,22 @@
   color: var(--muted-strong);
 }
 
-.session-row__action {
+.session-row .session-row__action {
+  width: auto;
+  height: auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 6px;
+  padding-right: 0;
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
   transform: scale(0.92);
+}
+
+.session-row .session-row__action svg {
+  width: 16px;
+  height: 16px;
 }
 
 .session-row:hover .session-row__time,

--- a/apps/desktop/src/styles/sidebar.css
+++ b/apps/desktop/src/styles/sidebar.css
@@ -178,6 +178,44 @@
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
+.workspace-row:has(.workspace-row__drag-handle) {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.workspace-row__drag-handle {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  color: var(--muted-soft);
+  cursor: grab;
+  touch-action: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.workspace-row__drag-handle svg {
+  width: 14px;
+  height: 14px;
+}
+
+.workspace-row:hover .workspace-row__drag-handle {
+  opacity: 1;
+}
+
+.workspace-row__drag-handle:active {
+  cursor: grabbing;
+}
+
+.workspace-group--dragging {
+  opacity: 0.3;
+}
+
+.workspace-group--overlay {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .worktree-row {
   padding: 2px 4px 1px;
   border-radius: 9px;

--- a/apps/desktop/src/styles/sidebar.css
+++ b/apps/desktop/src/styles/sidebar.css
@@ -178,11 +178,11 @@
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
-.workspace-row:has(.workspace-row__drag-handle) {
-  grid-template-columns: auto minmax(0, 1fr) auto;
-}
-
 .workspace-row__drag-handle {
+  position: absolute;
+  left: -2px;
+  top: 50%;
+  transform: translateY(-50%);
   width: 18px;
   height: 18px;
   display: grid;
@@ -192,6 +192,7 @@
   touch-action: none;
   opacity: 0;
   transition: opacity 0.15s;
+  z-index: 1;
 }
 
 .workspace-row__drag-handle svg {
@@ -224,10 +225,11 @@
 }
 
 .workspace-row__select {
+  position: relative;
   width: 100%;
   display: grid;
   align-items: center;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 10px;
   text-align: left;
   color: inherit;

--- a/apps/desktop/src/styles/sidebar.css
+++ b/apps/desktop/src/styles/sidebar.css
@@ -203,11 +203,10 @@
 }
 
 .workspace-row__select {
-  position: relative;
   width: 100%;
   display: grid;
   align-items: center;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 10px;
   text-align: left;
   color: inherit;

--- a/apps/desktop/src/styles/sidebar.css
+++ b/apps/desktop/src/styles/sidebar.css
@@ -242,6 +242,35 @@
   height: 18px;
 }
 
+/* Expanded: always show chevron, hide folder */
+.workspace-row__icon-chevron {
+  display: grid;
+  place-items: center;
+}
+
+.workspace-row__icon-folder {
+  display: none;
+}
+
+/* Collapsed: show folder, hide chevron */
+.workspace-row__icon[data-collapsed] .workspace-row__icon-folder {
+  display: grid;
+  place-items: center;
+}
+
+.workspace-row__icon[data-collapsed] .workspace-row__icon-chevron {
+  display: none;
+}
+
+/* Collapsed + hover on workspace row: swap folder → chevron */
+.workspace-row:hover .workspace-row__icon[data-collapsed] .workspace-row__icon-chevron {
+  display: grid;
+}
+
+.workspace-row:hover .workspace-row__icon[data-collapsed] .workspace-row__icon-folder {
+  display: none;
+}
+
 .workspace-row__name,
 .session-row__title {
   min-width: 0;

--- a/apps/desktop/src/thread-groups.ts
+++ b/apps/desktop/src/thread-groups.ts
@@ -26,8 +26,19 @@ export function buildThreadGroups(state: DesktopAppState): readonly ThreadGroup[
     (workspace) => workspace.kind === "worktree" && !workspacesById.has(workspace.rootWorkspaceId ?? ""),
   );
 
+  const order = state.workspaceOrder;
+  const sortedRoots = [...rootWorkspaces].sort((a, b) => {
+    const ai = order.indexOf(a.id);
+    const bi = order.indexOf(b.id);
+    // Workspaces not in the order list come first (newly added)
+    if (ai === -1 && bi === -1) return 0;
+    if (ai === -1) return -1;
+    if (bi === -1) return 1;
+    return ai - bi;
+  });
+
   return [
-    ...rootWorkspaces.map((workspace) => buildRootGroup(state, workspacesById, workspace)),
+    ...sortedRoots.map((workspace) => buildRootGroup(state, workspacesById, workspace)),
     ...orphanWorktrees.map(buildOrphanGroup),
   ];
 }

--- a/apps/desktop/tests/helpers/electron-app.ts
+++ b/apps/desktop/tests/helpers/electron-app.ts
@@ -244,7 +244,7 @@ export async function startThreadFromSurface(
 ): Promise<void> {
   const {
     environment = "local",
-    prompt = "",
+    prompt = "Start thread",
     workspaceName,
   } = options;
 

--- a/apps/desktop/tests/live/extensions.spec.ts
+++ b/apps/desktop/tests/live/extensions.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
+  createSessionViaIpc,
+  getDesktopState,
   launchDesktop,
   makeUserDataDir,
   makeWorkspace,
@@ -33,6 +35,43 @@ export default function demoExtension(pi) {
 }
 `;
 
+const customFallbackExtensionSource = String.raw`
+export default function customFallbackExtension(pi) {
+  pi.registerCommand("read-mode-test", {
+    description: "Terminal-only read mode",
+    handler: async (_args, ctx) => {
+      const result = await ctx.ui.custom((_tui, _theme, _kb, done) => ({
+        render: () => ["read-mode"],
+        handleInput: () => done({ text: "should-not-send" }),
+      }));
+      if (result?.text) {
+        pi.sendUserMessage(result.text);
+        return;
+      }
+      ctx.ui.notify("Read mode ignored", "info");
+    },
+  });
+}
+`;
+
+const newSessionExtensionSource = String.raw`
+export default function newSessionExtension(pi) {
+  pi.registerCommand("spawn-child", {
+    description: "Create a child session with a draft",
+    handler: async (_args, ctx) => {
+      const parentSession = ctx.sessionManager.getSessionFile();
+      const result = await ctx.newSession(parentSession ? { parentSession } : undefined);
+      if (result.cancelled) {
+        ctx.ui.notify("Child session cancelled", "info");
+        return;
+      }
+      ctx.ui.setEditorText("Child draft");
+      ctx.ui.notify("Child session ready", "info");
+    },
+  });
+}
+`;
+
 async function expandDock(window: Page) {
   const toggle = window.getByTestId("extension-dock-toggle");
   await toggle.click();
@@ -52,7 +91,7 @@ test("manages extensions and prefers runtime commands over colliding host action
 
   try {
     const window = await harness.firstWindow();
-    await startThreadFromSurface(window);
+    await startThreadFromSurface(window, { prompt: "Inspect extension surface" });
 
     await expect(window.locator(".topbar__session")).toHaveText("Extension Surface");
     await expect(window.getByTestId("extension-dock")).toBeVisible();
@@ -78,13 +117,10 @@ test("manages extensions and prefers runtime commands over colliding host action
     await window.getByRole("button", { name: "Disable", exact: true }).click();
     await expect(window.locator(".skill-detail__status")).toHaveText("Disabled");
     await window.getByRole("button", { name: "Back to app", exact: true }).click();
-    await expect(window.locator(".topbar__session")).toHaveText("New thread");
+    await expect(window.locator(".topbar__session")).toHaveText("Inspect extension surface");
     await expect(window.getByTestId("extension-dock")).toHaveCount(0);
     const composer = window.getByTestId("composer");
-    await composer.fill("/settings");
-    const disabledSlashMenu = window.getByTestId("slash-menu");
-    await expect(disabledSlashMenu).toContainText("Host Actions");
-    await disabledSlashMenu.getByRole("button", { name: /settings/i }).click();
+    await window.getByRole("button", { name: "Settings", exact: true }).click();
     await expect(window.getByTestId("settings-surface")).toBeVisible();
     await window.getByRole("button", { name: "Back to app", exact: true }).click();
 
@@ -97,7 +133,7 @@ test("manages extensions and prefers runtime commands over colliding host action
     await expect(window.getByTestId("extension-dock-summary")).toHaveText("Demo ready");
     await expect(window.getByTestId("extension-dock-body")).toHaveCount(0);
 
-    await composer.fill("/settings");
+    await composer.fill("/se");
     const slashMenu = window.getByTestId("slash-menu");
     await expect(slashMenu).toContainText("Runtime Commands");
     await expect(slashMenu).toContainText("Host Actions");
@@ -111,6 +147,71 @@ test("manages extensions and prefers runtime commands over colliding host action
     await composer.press("Enter");
     await expect(composer).toHaveValue("Prefilled from extension");
     await expect(window.locator(".timeline")).toContainText("Composer prefilled");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("degrades terminal-only custom extension ui without sending stray messages", async () => {
+  test.setTimeout(60_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await makeWorkspace("extensions-custom-fallback-workspace");
+  await writeProjectExtension(workspacePath, "custom-fallback-extension.ts", customFallbackExtensionSource);
+
+  const harness = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+
+  try {
+    const window = await harness.firstWindow();
+    await createSessionViaIpc(window, workspacePath, "Custom fallback session");
+
+    const composer = window.getByTestId("composer");
+    await composer.fill("/read-mode-test ");
+    await composer.press("Enter");
+
+    await expect(window.getByTestId("extension-dialog")).toHaveCount(0);
+    await expect(window.locator(".timeline")).toContainText("Read mode ignored");
+    await expect(window.locator(".timeline")).not.toContainText("should-not-send");
+    await expect(composer).toHaveValue("");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("keeps a single subscription path when an extension creates a child session and prefills the draft", async () => {
+  test.setTimeout(60_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await makeWorkspace("extensions-new-session-workspace");
+  await writeProjectExtension(workspacePath, "new-session-extension.ts", newSessionExtensionSource);
+
+  const harness = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+
+  try {
+    const window = await harness.firstWindow();
+    await createSessionViaIpc(window, workspacePath, "Parent session");
+
+    const beforeState = await getDesktopState(window);
+    const beforeSelectedSessionId = beforeState.selectedSessionId;
+    const resumedCountBefore = await window.getByText("Resumed session", { exact: true }).count();
+
+    const composer = window.getByTestId("composer");
+    await composer.fill("/spawn-child ");
+    await composer.press("Enter");
+
+    await expect
+      .poll(async () => {
+        const nextState = await getDesktopState(window);
+        return nextState.selectedSessionId;
+      })
+      .not.toBe(beforeSelectedSessionId);
+    await expect(composer).toHaveValue("Child draft");
+    await expect(window.locator(".timeline")).toContainText("Child session ready");
+    await expect(window.getByText("Resumed session", { exact: true })).toHaveCount(resumedCountBefore);
   } finally {
     await harness.close();
   }

--- a/packages/pi-sdk-driver/src/session-supervisor.ts
+++ b/packages/pi-sdk-driver/src/session-supervisor.ts
@@ -769,7 +769,10 @@ export class SessionSupervisor {
           title,
         });
       },
-      custom: async () => undefined as never,
+      // pi-gui does not render arbitrary TUI custom components. Returning null
+      // lets extensions that handle cancellation degrade cleanly instead of
+      // continuing with an undefined result.
+      custom: async () => null as never,
       pasteToEditor: (text) => {
         this.emitHostUiRequest(record, {
           kind: "editorText",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@mariozechner/pi-ai@0.60.0':
-    hash: 52727a90544b4c3be3bceb540763dfb4599adef2bc3d83182eb819e340692def
-    path: patches/@mariozechner__pi-ai@0.60.0.patch
+  '@mariozechner/pi-ai@0.62.0':
+    hash: 64da4c8158b86cb5fe41f55bcc7a0cd79f1d2baa0fdd6be657b22cc7a941f087
+    path: patches/@mariozechner__pi-ai@0.62.0.patch
 
 importers:
 
@@ -44,6 +44,15 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
     devDependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@types/node':
         specifier: ^22.13.0
         version: 22.19.15
@@ -106,8 +115,8 @@ importers:
   packages/pi-sdk-driver:
     dependencies:
       '@mariozechner/pi-coding-agent':
-        specifier: ^0.60.0
-        version: 0.60.0(ws@8.19.0)(zod@4.3.6)
+        specifier: ^0.62.0
+        version: 0.62.0(ws@8.19.0)(zod@4.3.6)
       '@pi-gui/catalogs':
         specifier: workspace:*
         version: link:../catalogs
@@ -374,6 +383,28 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electron/get@2.0.3':
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
@@ -1102,22 +1133,22 @@ packages:
     resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
     hasBin: true
 
-  '@mariozechner/pi-agent-core@0.60.0':
-    resolution: {integrity: sha512-1zQcfFp8r0iwZCxCBQ9/ccFJoagns68cndLPTJJXl1ZqkYirzSld1zBOPxLAgeAKWIz3OX8dB2WQwTJFhmEojQ==}
+  '@mariozechner/pi-agent-core@0.62.0':
+    resolution: {integrity: sha512-SBjqgDrgKOaC+IGzFGB3jXQErv9H1QMYnWFvUg6ra6dG0ZgWFBUZb6unidngWLsmaxSDWes6KeKiVFMsr2VSEQ==}
     engines: {node: '>=20.0.0'}
 
-  '@mariozechner/pi-ai@0.60.0':
-    resolution: {integrity: sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A==}
+  '@mariozechner/pi-ai@0.62.0':
+    resolution: {integrity: sha512-mJgryZ5RgBQG++tiETMtCQQJoH2MAhKetCfqI98NMvGydu7L9x2qC2JekQlRaAgIlTgv4MRH1UXHMEs4UweE/Q==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
-  '@mariozechner/pi-coding-agent@0.60.0':
-    resolution: {integrity: sha512-IOv7cTU4nbznFNUE5ofi13k2dmSG39coBoGWIBQTVw3iVyl0HxuHbg0NiTx3ktrPIDNtkii+y7tWXzWqwoo4lw==}
+  '@mariozechner/pi-coding-agent@0.62.0':
+    resolution: {integrity: sha512-f1NnExqsHuA6w8UVlBtPsvTBhdkMc0h1JD9SzGCdWTLou5GHJr2JIP6DlwV9IKWAnM+sAelaoFez+14wLP2zOQ==}
     engines: {node: '>=20.6.0'}
     hasBin: true
 
-  '@mariozechner/pi-tui@0.60.0':
-    resolution: {integrity: sha512-ZAK5gxYhGmfJqMjfWcRBjB8glITltDbTrYJXvcDtfengbKTZN0p39p5uO5pvUB8/PiAWKTRS06yaNMhf/LG26g==}
+  '@mariozechner/pi-tui@0.62.0':
+    resolution: {integrity: sha512-/At11PPe8l319MnUoK4wN5L/uVCU6bDdiIUzH8Ez0stOkjSF6isRXScZ+RMM+6iCKsD4muBTX8Cmcif+3/UWHA==}
     engines: {node: '>=20.0.0'}
 
   '@mediabunny/aac-encoder@1.39.2':
@@ -4299,6 +4330,31 @@ snapshots:
 
   '@borewit/text-codec@0.2.2': {}
 
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
   '@electron/get@2.0.3':
     dependencies:
       debug: 4.4.3
@@ -4757,9 +4813,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.60.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.62.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.60.0(patch_hash=52727a90544b4c3be3bceb540763dfb4599adef2bc3d83182eb819e340692def)(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.62.0(patch_hash=64da4c8158b86cb5fe41f55bcc7a0cd79f1d2baa0fdd6be657b22cc7a941f087)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -4769,7 +4825,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.60.0(patch_hash=52727a90544b4c3be3bceb540763dfb4599adef2bc3d83182eb819e340692def)(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.62.0(patch_hash=64da4c8158b86cb5fe41f55bcc7a0cd79f1d2baa0fdd6be657b22cc7a941f087)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1013.0
@@ -4793,12 +4849,12 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.60.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.62.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.60.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.60.0(patch_hash=52727a90544b4c3be3bceb540763dfb4599adef2bc3d83182eb819e340692def)(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.60.0
+      '@mariozechner/pi-agent-core': 0.62.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.62.0(patch_hash=64da4c8158b86cb5fe41f55bcc7a0cd79f1d2baa0fdd6be657b22cc7a941f087)(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.62.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cli-highlight: 2.1.11
@@ -4825,7 +4881,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-tui@0.60.0':
+  '@mariozechner/pi-tui@0.62.0':
     dependencies:
       '@types/mime-types': 2.1.4
       chalk: 5.6.2


### PR DESCRIPTION
## Summary
- Add interactive model and reasoning level selection to the new thread page
- Unify model selection: pickers only show enabled+available models, guard stale defaults
- Restyle all settings tabs to match Codex's horizontal row layout (label left, control right)
- Add drag-and-drop workspace reordering in sidebar
- Add collapse/expand toggle for sidebar workspaces
- Use relative dates in sidebar session list

## Test plan
- [ ] New thread page: model/thinking dropdowns appear, selection persists into session
- [ ] Settings → Models: default dropdown shows only enabled models, reasoning pills work
- [ ] Settings → Enabled models: checkboxes work, last model can't be unchecked
- [ ] All 5 settings tabs: horizontal row layout, dark mode works
- [ ] Sidebar: drag workspaces to reorder, collapse/expand workspaces
- [ ] Composer: model selector still works with filtered models