### PR TITLE
Trustable review UX: highlighted diffs, reviewed checkboxes, timeline-to-diff link

### DIFF
--- a/apps/desktop/electron/app-store-diff.ts
+++ b/apps/desktop/electron/app-store-diff.ts
@@ -12,6 +12,7 @@ function validateFilePath(workspacePath: string, filePath: string): string {
 export interface ChangedFileEntry {
   readonly path: string;
   readonly status: "added" | "modified" | "deleted" | "untracked";
+  readonly staged: boolean;
 }
 
 export function getChangedFiles(workspacePath: string): Promise<ChangedFileEntry[]> {
@@ -40,6 +41,7 @@ export function getChangedFiles(workspacePath: string): Promise<ChangedFileEntry
           entries.push({
             path: filePath,
             status: parseStatus(xy),
+            staged: isFullyStaged(xy),
           });
         }
         resolve(entries);
@@ -119,4 +121,11 @@ function parseStatus(xy: string): ChangedFileEntry["status"] {
     return "deleted";
   }
   return "modified";
+}
+
+function isFullyStaged(xy: string): boolean {
+  const x = xy[0] ?? " ";
+  const y = xy[1] ?? " ";
+  if (x === "?" || x === " ") return false;
+  return y === " ";
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -249,7 +249,7 @@ contextBridge.exposeInMainWorld("piApp", {
   listWorkspaceFiles: (workspaceId: string) =>
     ipcRenderer.invoke(desktopIpc.listWorkspaceFiles, workspaceId) as Promise<string[]>,
   getChangedFiles: (workspaceId: string) =>
-    ipcRenderer.invoke(desktopIpc.getChangedFiles, workspaceId) as Promise<{ path: string; status: "added" | "modified" | "deleted" | "untracked" }[]>,
+    ipcRenderer.invoke(desktopIpc.getChangedFiles, workspaceId) as Promise<{ path: string; status: "added" | "modified" | "deleted" | "untracked"; staged: boolean }[]>,
   getFileDiff: (workspaceId: string, filePath: string) =>
     ipcRenderer.invoke(desktopIpc.getFileDiff, workspaceId, filePath) as Promise<string>,
   stageFile: (workspaceId: string, filePath: string) =>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -79,6 +79,7 @@
     "brace-expansion": "^5.0.2",
     "chalk": "^5.5.0",
     "glob": "^13.0.1",
+    "highlight.js": "^11.11.1",
     "hosted-git-info": "^9.0.2",
     "lru-cache": "^11.1.0",
     "minimatch": "^10.2.3",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -16,7 +16,7 @@ import {
 } from "./desktop-state";
 import { formatRelativeTime } from "./string-utils";
 import { ComposerPanel } from "./composer-panel";
-import { DiffPanel } from "./diff-panel";
+import { DiffPanel, type DiffPanelHandle } from "./diff-panel";
 import { buildModelOptions } from "./composer-commands";
 import { parseTreeComposerCommand } from "./composer-commands";
 import {
@@ -201,6 +201,7 @@ export default function App() {
   const [openTerminalSessionKeys, setOpenTerminalSessionKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [takeoverTerminalSessionKeys, setTakeoverTerminalSessionKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [terminalHeight, setTerminalHeight] = useState(340);
+  const diffPanelRef = useRef<DiffPanelHandle | null>(null);
   const [timelinePaneMountVersion, setTimelinePaneMountVersion] = useState(0);
   const [disableTimelineVirtualization, setDisableTimelineVirtualization] = useState(true);
   const threadSearch = useThreadSearch(timelinePaneRef);
@@ -627,6 +628,11 @@ export default function App() {
 
     waitForFrames(delayFrames);
   }, [requestPinnedBottomAlignment]);
+
+  const handleViewFileInDiff = useCallback((path: string) => {
+    setShowDiffPanel(true);
+    void diffPanelRef.current?.selectFile(path);
+  }, []);
 
   const toggleDiffPanel = useCallback(() => {
     const pane = timelinePaneRef.current;
@@ -2141,6 +2147,7 @@ export default function App() {
                   showJumpToLatest={showJumpToLatest}
                   onJumpToLatest={jumpToLatest}
                   onContentHeightChange={handleTimelineContentHeightChange}
+                  onViewFileInDiff={handleViewFileInDiff}
                 />
               </div>
             </section>
@@ -2244,6 +2251,7 @@ export default function App() {
 
         {showDiffPanel && selectedWorkspace && selectedSession ? (
           <DiffPanel
+            ref={diffPanelRef}
             workspaceId={selectedWorkspace.id}
             sessionId={selectedSession.id}
             api={api}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -16,7 +16,7 @@ import {
 } from "./desktop-state";
 import { formatRelativeTime } from "./string-utils";
 import { ComposerPanel } from "./composer-panel";
-import { DiffPanel, type DiffPanelHandle } from "./diff-panel";
+import { DiffPanel, type DiffPanelFileRequest } from "./diff-panel";
 import { buildModelOptions } from "./composer-commands";
 import { parseTreeComposerCommand } from "./composer-commands";
 import {
@@ -201,7 +201,7 @@ export default function App() {
   const [openTerminalSessionKeys, setOpenTerminalSessionKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [takeoverTerminalSessionKeys, setTakeoverTerminalSessionKeys] = useState<ReadonlySet<string>>(() => new Set());
   const [terminalHeight, setTerminalHeight] = useState(340);
-  const diffPanelRef = useRef<DiffPanelHandle | null>(null);
+  const [diffFileRequest, setDiffFileRequest] = useState<DiffPanelFileRequest | null>(null);
   const [timelinePaneMountVersion, setTimelinePaneMountVersion] = useState(0);
   const [disableTimelineVirtualization, setDisableTimelineVirtualization] = useState(true);
   const threadSearch = useThreadSearch(timelinePaneRef);
@@ -629,23 +629,10 @@ export default function App() {
     waitForFrames(delayFrames);
   }, [requestPinnedBottomAlignment]);
 
-  const pendingDiffSelectionRef = useRef<string | null>(null);
   const handleViewFileInDiff = useCallback((path: string) => {
-    if (diffPanelRef.current) {
-      void diffPanelRef.current.selectFile(path);
-    } else {
-      pendingDiffSelectionRef.current = path;
-    }
     setShowDiffPanel(true);
+    setDiffFileRequest({ path, nonce: Date.now() });
   }, []);
-
-  useEffect(() => {
-    if (!showDiffPanel) return;
-    const pending = pendingDiffSelectionRef.current;
-    if (!pending) return;
-    pendingDiffSelectionRef.current = null;
-    void diffPanelRef.current?.selectFile(pending);
-  }, [showDiffPanel]);
 
   const toggleDiffPanel = useCallback(() => {
     const pane = timelinePaneRef.current;
@@ -2264,11 +2251,11 @@ export default function App() {
 
         {showDiffPanel && selectedWorkspace && selectedSession ? (
           <DiffPanel
-            ref={diffPanelRef}
             workspaceId={selectedWorkspace.id}
             sessionId={selectedSession.id}
             api={api}
             sessionStatus={selectedSession.status}
+            fileRequest={diffFileRequest}
           />
         ) : null}
           </>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -629,10 +629,23 @@ export default function App() {
     waitForFrames(delayFrames);
   }, [requestPinnedBottomAlignment]);
 
+  const pendingDiffSelectionRef = useRef<string | null>(null);
   const handleViewFileInDiff = useCallback((path: string) => {
+    if (diffPanelRef.current) {
+      void diffPanelRef.current.selectFile(path);
+    } else {
+      pendingDiffSelectionRef.current = path;
+    }
     setShowDiffPanel(true);
-    void diffPanelRef.current?.selectFile(path);
   }, []);
+
+  useEffect(() => {
+    if (!showDiffPanel) return;
+    const pending = pendingDiffSelectionRef.current;
+    if (!pending) return;
+    pendingDiffSelectionRef.current = null;
+    void diffPanelRef.current?.selectFile(pending);
+  }, [showDiffPanel]);
 
   const toggleDiffPanel = useCallback(() => {
     const pane = timelinePaneRef.current;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2242,11 +2242,12 @@ export default function App() {
 
         {terminalPanel}
 
-        {showDiffPanel && selectedWorkspace ? (
+        {showDiffPanel && selectedWorkspace && selectedSession ? (
           <DiffPanel
             workspaceId={selectedWorkspace.id}
+            sessionId={selectedSession.id}
             api={api}
-            sessionStatus={selectedSession?.status}
+            sessionStatus={selectedSession.status}
           />
         ) : null}
           </>

--- a/apps/desktop/src/conversation-timeline.tsx
+++ b/apps/desktop/src/conversation-timeline.tsx
@@ -30,6 +30,7 @@ interface ConversationTimelineProps {
   readonly showJumpToLatest: boolean;
   readonly onJumpToLatest: () => void;
   readonly onContentHeightChange: () => void;
+  readonly onViewFileInDiff?: (path: string) => void;
 }
 
 export function ConversationTimeline({
@@ -44,6 +45,7 @@ export function ConversationTimeline({
   showJumpToLatest,
   onJumpToLatest,
   onContentHeightChange,
+  onViewFileInDiff,
 }: ConversationTimelineProps) {
   // Giant prose blocks and attachment-heavy rows routinely blow past the estimator,
   // so keep those transcripts on the exact DOM path instead of restoring to a fake bottom.
@@ -170,6 +172,7 @@ export function ConversationTimeline({
           expandedToolCallIds={expandedToolCallIds}
           onHeightChange={updateMeasuredHeight}
           onToggleToolCall={toggleToolCall}
+          onViewFileInDiff={onViewFileInDiff}
         />
       ) : (
         <div className="timeline" data-testid="transcript">
@@ -180,6 +183,7 @@ export function ConversationTimeline({
               onHeightChange={updateMeasuredHeight}
               expandedToolCallIds={expandedToolCallIds}
               onToggleToolCall={toggleToolCall}
+              onViewFileInDiff={onViewFileInDiff}
             />
           ))}
         </div>
@@ -202,6 +206,7 @@ function VirtualizedTranscriptList({
   expandedToolCallIds,
   onHeightChange,
   onToggleToolCall,
+  onViewFileInDiff,
 }: {
   readonly transcript: readonly TranscriptMessage[];
   readonly timelinePaneRef: MutableRefObject<HTMLDivElement | null>;
@@ -211,6 +216,7 @@ function VirtualizedTranscriptList({
   readonly expandedToolCallIds: ReadonlySet<string>;
   readonly onHeightChange: (id: string, height: number) => void;
   readonly onToggleToolCall: (callId: string) => void;
+  readonly onViewFileInDiff?: (path: string) => void;
 }) {
   const [viewport, setViewport] = useState({ scrollTop: 0, height: 0 });
   const previousTotalHeightRef = useRef(0);
@@ -282,6 +288,7 @@ function VirtualizedTranscriptList({
             onHeightChange={onHeightChange}
             expandedToolCallIds={expandedToolCallIds}
             onToggleToolCall={onToggleToolCall}
+            onViewFileInDiff={onViewFileInDiff}
           />
         );
       })}
@@ -296,6 +303,7 @@ function MeasuredTimelineItem({
   onHeightChange,
   expandedToolCallIds,
   onToggleToolCall,
+  onViewFileInDiff,
 }: {
   readonly item: TranscriptMessage;
   readonly className?: string;
@@ -303,6 +311,7 @@ function MeasuredTimelineItem({
   readonly onHeightChange: (id: string, height: number) => void;
   readonly expandedToolCallIds: ReadonlySet<string>;
   readonly onToggleToolCall: (callId: string) => void;
+  readonly onViewFileInDiff?: (path: string) => void;
 }) {
   const rowRef = useRef<HTMLDivElement | null>(null);
 
@@ -337,6 +346,7 @@ function MeasuredTimelineItem({
         item={item}
         expandedToolCallIds={expandedToolCallIds}
         onToggleToolCall={onToggleToolCall}
+        onViewFileInDiff={onViewFileInDiff}
       />
     </div>
   );

--- a/apps/desktop/src/diff-inline.tsx
+++ b/apps/desktop/src/diff-inline.tsx
@@ -1,4 +1,10 @@
 import { useMemo } from "react";
+import {
+  MAX_HIGHLIGHTED_LINES,
+  highlightLine,
+  type HighlightLine,
+  type HighlightTokenChild,
+} from "./syntax-highlight";
 
 interface DiffLine {
   readonly type: "added" | "removed" | "context" | "header";
@@ -6,14 +12,25 @@ interface DiffLine {
   readonly lineNumber?: number;
 }
 
-export function InlineDiff({ diff }: { readonly diff: string }) {
+export function InlineDiff({
+  diff,
+  language,
+}: {
+  readonly diff: string;
+  readonly language?: string;
+}) {
   const lines = useMemo(() => parseDiff(diff), [diff]);
+  const highlightActive = language !== undefined && lines.length <= MAX_HIGHLIGHTED_LINES;
+
   if (lines.length === 0) {
     return null;
   }
 
   return (
-    <pre className="diff-inline">
+    <pre
+      className="diff-inline"
+      data-language={highlightActive ? language : undefined}
+    >
       {lines.map((line, index) => (
         <div className={`diff-line diff-line--${line.type}`} key={index}>
           {line.lineNumber !== undefined ? (
@@ -21,10 +38,48 @@ export function InlineDiff({ diff }: { readonly diff: string }) {
           ) : (
             <span className="diff-line__number" />
           )}
-          <span className="diff-line__content">{line.content}</span>
+          <span className="diff-line__content">
+            {highlightActive && line.type !== "header" ? (
+              <HighlightedContent content={line.content} language={language!} />
+            ) : (
+              line.content
+            )}
+          </span>
         </div>
       ))}
     </pre>
+  );
+}
+
+function HighlightedContent({
+  content,
+  language,
+}: {
+  readonly content: string;
+  readonly language: string;
+}) {
+  const tokens = useMemo(() => highlightLine(content, language), [content, language]);
+  return <RenderTokens tokens={tokens} />;
+}
+
+function RenderTokens({ tokens }: { readonly tokens: HighlightLine }) {
+  return (
+    <>
+      {tokens.map((token, index) => (
+        <RenderToken key={index} token={token} />
+      ))}
+    </>
+  );
+}
+
+function RenderToken({ token }: { readonly token: HighlightTokenChild }) {
+  if (typeof token === "string") {
+    return <>{token}</>;
+  }
+  return (
+    <span className={token.className}>
+      <RenderTokens tokens={token.children} />
+    </span>
   );
 }
 

--- a/apps/desktop/src/diff-inline.tsx
+++ b/apps/desktop/src/diff-inline.tsx
@@ -1,10 +1,5 @@
-import { useMemo } from "react";
-import {
-  MAX_HIGHLIGHTED_LINES,
-  highlightLine,
-  type HighlightLine,
-  type HighlightTokenChild,
-} from "./syntax-highlight";
+import { useMemo, type ReactNode } from "react";
+import { MAX_HIGHLIGHTED_LINES, highlightLine, type HighlightLine } from "./syntax-highlight";
 
 interface DiffLine {
   readonly type: "added" | "removed" | "context" | "header";
@@ -59,27 +54,18 @@ function HighlightedContent({
   readonly language: string;
 }) {
   const tokens = useMemo(() => highlightLine(content, language), [content, language]);
-  return <RenderTokens tokens={tokens} />;
+  return <>{renderTokens(tokens)}</>;
 }
 
-function RenderTokens({ tokens }: { readonly tokens: HighlightLine }) {
-  return (
-    <>
-      {tokens.map((token, index) => (
-        <RenderToken key={index} token={token} />
-      ))}
-    </>
-  );
-}
-
-function RenderToken({ token }: { readonly token: HighlightTokenChild }) {
-  if (typeof token === "string") {
-    return <>{token}</>;
-  }
-  return (
-    <span className={token.className}>
-      <RenderTokens tokens={token.children} />
-    </span>
+function renderTokens(tokens: HighlightLine): ReactNode {
+  return tokens.map((token, index) =>
+    typeof token === "string" ? (
+      token
+    ) : (
+      <span className={token.className} key={index}>
+        {renderTokens(token.children)}
+      </span>
+    ),
   );
 }
 

--- a/apps/desktop/src/diff-panel.tsx
+++ b/apps/desktop/src/diff-panel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { PiDesktopApi } from "./ipc";
 import { InlineDiff } from "./diff-inline";
 import { RefreshIcon } from "./icons";
+import { extensionToLanguage } from "./syntax-highlight";
 
 interface ChangedFile {
   readonly path: string;
@@ -109,7 +110,7 @@ export function DiffPanel({ workspaceId, api, sessionStatus }: DiffPanelProps) {
           {selectedFile && diffText ? (
             <div className="diff-panel__viewer">
               <div className="diff-panel__viewer-header">{selectedFile}</div>
-              <InlineDiff diff={diffText} />
+              <InlineDiff diff={diffText} language={extensionToLanguage(selectedFile)} />
             </div>
           ) : null}
         </>

--- a/apps/desktop/src/diff-panel.tsx
+++ b/apps/desktop/src/diff-panel.tsx
@@ -8,6 +8,7 @@ import { loadReviewed, pruneReviewed, saveReviewed } from "./reviewed-files-stor
 interface ChangedFile {
   readonly path: string;
   readonly status: "added" | "modified" | "deleted" | "untracked";
+  readonly staged: boolean;
 }
 
 export interface DiffPanelFileRequest {
@@ -177,8 +178,9 @@ export function DiffPanel({
                     className="diff-panel__stage-btn"
                     type="button"
                     onClick={() => handleStage(file.path)}
+                    disabled={file.staged}
                   >
-                    Stage
+                    {file.staged ? "Staged" : "Stage"}
                   </button>
                 </div>
               );

--- a/apps/desktop/src/diff-panel.tsx
+++ b/apps/desktop/src/diff-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { PiDesktopApi } from "./ipc";
 import { InlineDiff } from "./diff-inline";
 import { RefreshIcon } from "./icons";
@@ -17,7 +17,14 @@ interface DiffPanelProps {
   readonly sessionStatus: string | undefined;
 }
 
-export function DiffPanel({ workspaceId, sessionId, api, sessionStatus }: DiffPanelProps) {
+export interface DiffPanelHandle {
+  selectFile(path: string): Promise<void>;
+}
+
+export const DiffPanel = forwardRef<DiffPanelHandle, DiffPanelProps>(function DiffPanel(
+  { workspaceId, sessionId, api, sessionStatus },
+  ref,
+) {
   const [files, setFiles] = useState<readonly ChangedFile[]>([]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [diffText, setDiffText] = useState("");
@@ -28,26 +35,54 @@ export function DiffPanel({ workspaceId, sessionId, api, sessionStatus }: DiffPa
     setReviewed(loadReviewed(workspaceId, sessionId));
   }, [workspaceId, sessionId]);
 
-  const refresh = useCallback(() => {
+  const fetchFiles = useCallback(async (): Promise<readonly ChangedFile[]> => {
     setLoading(true);
-    void api.getChangedFiles(workspaceId).then((result) => {
-      setFiles(result);
-      setSelectedFile((current) => {
-        if (current && !result.some((f) => f.path === current)) {
-          return null;
-        }
-        return current;
-      });
-      setReviewed((current) => {
-        const pruned = pruneReviewed(current, result.map((f) => f.path));
-        if (pruned !== current) {
-          saveReviewed(workspaceId, sessionId, pruned);
-        }
-        return pruned;
-      });
-      setLoading(false);
+    const result = await api.getChangedFiles(workspaceId);
+    setFiles(result);
+    setReviewed((current) => {
+      const pruned = pruneReviewed(current, result.map((f) => f.path));
+      if (pruned !== current) {
+        saveReviewed(workspaceId, sessionId, pruned);
+      }
+      return pruned;
     });
+    setLoading(false);
+    return result;
   }, [api, workspaceId, sessionId]);
+
+  const refresh = useCallback(() => {
+    void fetchFiles().then((result) => {
+      setSelectedFile((current) =>
+        current && !result.some((f) => f.path === current) ? null : current,
+      );
+    });
+  }, [fetchFiles]);
+
+  const fileListRef = useRef<HTMLDivElement | null>(null);
+  const pendingScrollPathRef = useRef<string | null>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      async selectFile(path: string) {
+        await fetchFiles();
+        pendingScrollPathRef.current = path;
+        setSelectedFile(path);
+      },
+    }),
+    [fetchFiles],
+  );
+
+  useEffect(() => {
+    const target = pendingScrollPathRef.current;
+    if (!target || target !== selectedFile) return;
+    pendingScrollPathRef.current = null;
+    const list = fileListRef.current;
+    if (!list) return;
+    const safeAttr = CSS.escape(target);
+    const row = list.querySelector<HTMLElement>(`[data-file-path="${safeAttr}"]`);
+    row?.scrollIntoView({ block: "nearest", behavior: "auto" });
+  }, [selectedFile, files]);
 
   const prevStatusRef = useRef(sessionStatus);
   useEffect(() => {
@@ -119,7 +154,7 @@ export function DiffPanel({ workspaceId, sessionId, api, sessionStatus }: DiffPa
         <div className="diff-panel__empty">No changes</div>
       ) : (
         <>
-          <div className="diff-panel__file-list">
+          <div className="diff-panel__file-list" ref={fileListRef}>
             {files.map((file) => {
               const isReviewed = reviewed.has(file.path);
               const isSelected = selectedFile === file.path;
@@ -131,7 +166,7 @@ export function DiffPanel({ workspaceId, sessionId, api, sessionStatus }: DiffPa
                 .filter(Boolean)
                 .join(" ");
               return (
-                <div className={className} key={file.path}>
+                <div className={className} key={file.path} data-file-path={file.path}>
                   <input
                     aria-label={`Mark ${file.path} reviewed`}
                     className="diff-panel__reviewed-checkbox"
@@ -170,4 +205,4 @@ export function DiffPanel({ workspaceId, sessionId, api, sessionStatus }: DiffPa
       )}
     </aside>
   );
-}
+});

--- a/apps/desktop/src/diff-panel.tsx
+++ b/apps/desktop/src/diff-panel.tsx
@@ -34,7 +34,9 @@ export function DiffPanel({
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [diffText, setDiffText] = useState("");
   const [loading, setLoading] = useState(false);
-  const [reviewed, setReviewed] = useState<ReadonlySet<string>>(() => new Set());
+  const [reviewed, setReviewed] = useState<ReadonlySet<string>>(() =>
+    loadReviewed(workspaceId, sessionId),
+  );
 
   useEffect(() => {
     setReviewed(loadReviewed(workspaceId, sessionId));
@@ -69,7 +71,7 @@ export function DiffPanel({
 
   useEffect(() => {
     refresh();
-  }, [workspaceId]);
+  }, [workspaceId, sessionId]);
 
   useEffect(() => {
     if (!fileRequest) return;
@@ -91,7 +93,7 @@ export function DiffPanel({
       `[data-file-path="${CSS.escape(selectedFile)}"]`,
     );
     row?.scrollIntoView({ block: "nearest", behavior: "auto" });
-  }, [selectedFile]);
+  }, [selectedFile, files]);
 
   const handleStage = (filePath: string) => {
     void api.stageFile(workspaceId, filePath).then(refresh);

--- a/apps/desktop/src/diff-panel.tsx
+++ b/apps/desktop/src/diff-panel.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PiDesktopApi } from "./ipc";
 import { InlineDiff } from "./diff-inline";
 import { RefreshIcon } from "./icons";
 import { extensionToLanguage } from "./syntax-highlight";
+import { loadReviewed, pruneReviewed, saveReviewed } from "./reviewed-files-store";
 
 interface ChangedFile {
   readonly path: string;
@@ -11,15 +12,21 @@ interface ChangedFile {
 
 interface DiffPanelProps {
   readonly workspaceId: string;
+  readonly sessionId: string;
   readonly api: PiDesktopApi;
   readonly sessionStatus: string | undefined;
 }
 
-export function DiffPanel({ workspaceId, api, sessionStatus }: DiffPanelProps) {
+export function DiffPanel({ workspaceId, sessionId, api, sessionStatus }: DiffPanelProps) {
   const [files, setFiles] = useState<readonly ChangedFile[]>([]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [diffText, setDiffText] = useState("");
   const [loading, setLoading] = useState(false);
+  const [reviewed, setReviewed] = useState<ReadonlySet<string>>(() => new Set());
+
+  useEffect(() => {
+    setReviewed(loadReviewed(workspaceId, sessionId));
+  }, [workspaceId, sessionId]);
 
   const refresh = useCallback(() => {
     setLoading(true);
@@ -31,11 +38,17 @@ export function DiffPanel({ workspaceId, api, sessionStatus }: DiffPanelProps) {
         }
         return current;
       });
+      setReviewed((current) => {
+        const pruned = pruneReviewed(current, result.map((f) => f.path));
+        if (pruned !== current) {
+          saveReviewed(workspaceId, sessionId, pruned);
+        }
+        return pruned;
+      });
       setLoading(false);
     });
-  }, [api, workspaceId]);
+  }, [api, workspaceId, sessionId]);
 
-  // Auto-refresh on mount and when session transitions from running to idle/failed
   const prevStatusRef = useRef(sessionStatus);
   useEffect(() => {
     const prev = prevStatusRef.current;
@@ -45,12 +58,10 @@ export function DiffPanel({ workspaceId, api, sessionStatus }: DiffPanelProps) {
     }
   }, [sessionStatus, refresh]);
 
-  // Initial load
   useEffect(() => {
     refresh();
   }, [workspaceId]);
 
-  // Fetch diff when file selected
   useEffect(() => {
     if (!selectedFile) {
       setDiffText("");
@@ -63,10 +74,36 @@ export function DiffPanel({ workspaceId, api, sessionStatus }: DiffPanelProps) {
     void api.stageFile(workspaceId, filePath).then(refresh);
   };
 
+  const toggleReviewed = useCallback(
+    (filePath: string) => {
+      setReviewed((current) => {
+        const next = new Set(current);
+        if (next.has(filePath)) {
+          next.delete(filePath);
+        } else {
+          next.add(filePath);
+        }
+        saveReviewed(workspaceId, sessionId, next);
+        return next;
+      });
+    },
+    [workspaceId, sessionId],
+  );
+
+  const reviewedCount = useMemo(
+    () => files.reduce((acc, f) => acc + (reviewed.has(f.path) ? 1 : 0), 0),
+    [files, reviewed],
+  );
+
   return (
     <aside className="diff-panel">
       <div className="diff-panel__header">
         <h2 className="diff-panel__title">Changes</h2>
+        {files.length > 0 ? (
+          <span className="diff-panel__counter" data-testid="diff-panel-counter">
+            {`Reviewed ${reviewedCount} of ${files.length}`}
+          </span>
+        ) : null}
         <button
           className="icon-button"
           type="button"
@@ -83,28 +120,44 @@ export function DiffPanel({ workspaceId, api, sessionStatus }: DiffPanelProps) {
       ) : (
         <>
           <div className="diff-panel__file-list">
-            {files.map((file) => (
-              <div
-                className={`diff-panel__file ${selectedFile === file.path ? "diff-panel__file--selected" : ""}`}
-                key={file.path}
-              >
-                <button
-                  className="diff-panel__file-name"
-                  type="button"
-                  onClick={() => setSelectedFile(file.path === selectedFile ? null : file.path)}
-                >
-                  <span className={`diff-panel__status-dot diff-panel__status-dot--${file.status}`} />
-                  <span>{file.path}</span>
-                </button>
-                <button
-                  className="diff-panel__stage-btn"
-                  type="button"
-                  onClick={() => handleStage(file.path)}
-                >
-                  Stage
-                </button>
-              </div>
-            ))}
+            {files.map((file) => {
+              const isReviewed = reviewed.has(file.path);
+              const isSelected = selectedFile === file.path;
+              const className = [
+                "diff-panel__file",
+                isSelected ? "diff-panel__file--selected" : "",
+                isReviewed ? "diff-panel__file--reviewed" : "",
+              ]
+                .filter(Boolean)
+                .join(" ");
+              return (
+                <div className={className} key={file.path}>
+                  <input
+                    aria-label={`Mark ${file.path} reviewed`}
+                    className="diff-panel__reviewed-checkbox"
+                    data-testid={`diff-panel-reviewed-${file.path}`}
+                    type="checkbox"
+                    checked={isReviewed}
+                    onChange={() => toggleReviewed(file.path)}
+                  />
+                  <button
+                    className="diff-panel__file-name"
+                    type="button"
+                    onClick={() => setSelectedFile(file.path === selectedFile ? null : file.path)}
+                  >
+                    <span className={`diff-panel__status-dot diff-panel__status-dot--${file.status}`} />
+                    <span>{file.path}</span>
+                  </button>
+                  <button
+                    className="diff-panel__stage-btn"
+                    type="button"
+                    onClick={() => handleStage(file.path)}
+                  >
+                    Stage
+                  </button>
+                </div>
+              );
+            })}
           </div>
 
           {selectedFile && diffText ? (

--- a/apps/desktop/src/diff-panel.tsx
+++ b/apps/desktop/src/diff-panel.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PiDesktopApi } from "./ipc";
 import { InlineDiff } from "./diff-inline";
 import { RefreshIcon } from "./icons";
@@ -10,21 +10,26 @@ interface ChangedFile {
   readonly status: "added" | "modified" | "deleted" | "untracked";
 }
 
+export interface DiffPanelFileRequest {
+  readonly path: string;
+  readonly nonce: number;
+}
+
 interface DiffPanelProps {
   readonly workspaceId: string;
   readonly sessionId: string;
   readonly api: PiDesktopApi;
   readonly sessionStatus: string | undefined;
+  readonly fileRequest?: DiffPanelFileRequest | null;
 }
 
-export interface DiffPanelHandle {
-  selectFile(path: string): Promise<void>;
-}
-
-export const DiffPanel = forwardRef<DiffPanelHandle, DiffPanelProps>(function DiffPanel(
-  { workspaceId, sessionId, api, sessionStatus },
-  ref,
-) {
+export function DiffPanel({
+  workspaceId,
+  sessionId,
+  api,
+  sessionStatus,
+  fileRequest,
+}: DiffPanelProps) {
   const [files, setFiles] = useState<readonly ChangedFile[]>([]);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [diffText, setDiffText] = useState("");
@@ -35,54 +40,23 @@ export const DiffPanel = forwardRef<DiffPanelHandle, DiffPanelProps>(function Di
     setReviewed(loadReviewed(workspaceId, sessionId));
   }, [workspaceId, sessionId]);
 
-  const fetchFiles = useCallback(async (): Promise<readonly ChangedFile[]> => {
-    setLoading(true);
-    const result = await api.getChangedFiles(workspaceId);
-    setFiles(result);
-    setReviewed((current) => {
-      const pruned = pruneReviewed(current, result.map((f) => f.path));
-      if (pruned !== current) {
-        saveReviewed(workspaceId, sessionId, pruned);
-      }
-      return pruned;
-    });
-    setLoading(false);
-    return result;
-  }, [api, workspaceId, sessionId]);
-
   const refresh = useCallback(() => {
-    void fetchFiles().then((result) => {
+    setLoading(true);
+    void api.getChangedFiles(workspaceId).then((result) => {
+      setFiles(result);
       setSelectedFile((current) =>
         current && !result.some((f) => f.path === current) ? null : current,
       );
+      setReviewed((current) => {
+        const pruned = pruneReviewed(current, result.map((f) => f.path));
+        if (pruned !== current) {
+          saveReviewed(workspaceId, sessionId, pruned);
+        }
+        return pruned;
+      });
+      setLoading(false);
     });
-  }, [fetchFiles]);
-
-  const fileListRef = useRef<HTMLDivElement | null>(null);
-  const pendingScrollPathRef = useRef<string | null>(null);
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      async selectFile(path: string) {
-        await fetchFiles();
-        pendingScrollPathRef.current = path;
-        setSelectedFile(path);
-      },
-    }),
-    [fetchFiles],
-  );
-
-  useEffect(() => {
-    const target = pendingScrollPathRef.current;
-    if (!target || target !== selectedFile) return;
-    pendingScrollPathRef.current = null;
-    const list = fileListRef.current;
-    if (!list) return;
-    const safeAttr = CSS.escape(target);
-    const row = list.querySelector<HTMLElement>(`[data-file-path="${safeAttr}"]`);
-    row?.scrollIntoView({ block: "nearest", behavior: "auto" });
-  }, [selectedFile, files]);
+  }, [api, workspaceId, sessionId]);
 
   const prevStatusRef = useRef(sessionStatus);
   useEffect(() => {
@@ -98,12 +72,26 @@ export const DiffPanel = forwardRef<DiffPanelHandle, DiffPanelProps>(function Di
   }, [workspaceId]);
 
   useEffect(() => {
+    if (!fileRequest) return;
+    setSelectedFile(fileRequest.path);
+  }, [fileRequest]);
+
+  useEffect(() => {
     if (!selectedFile) {
       setDiffText("");
       return;
     }
     void api.getFileDiff(workspaceId, selectedFile).then(setDiffText);
   }, [api, workspaceId, selectedFile]);
+
+  const fileListRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!selectedFile) return;
+    const row = fileListRef.current?.querySelector<HTMLElement>(
+      `[data-file-path="${CSS.escape(selectedFile)}"]`,
+    );
+    row?.scrollIntoView({ block: "nearest", behavior: "auto" });
+  }, [selectedFile]);
 
   const handleStage = (filePath: string) => {
     void api.stageFile(workspaceId, filePath).then(refresh);
@@ -205,4 +193,4 @@ export const DiffPanel = forwardRef<DiffPanelHandle, DiffPanelProps>(function Di
       )}
     </aside>
   );
-});
+}

--- a/apps/desktop/src/icons.tsx
+++ b/apps/desktop/src/icons.tsx
@@ -312,23 +312,6 @@ export function RefreshIcon() {
   );
 }
 
-export function PanelRightIcon() {
-  return (
-    <Icon>
-      <rect
-        x="3"
-        y="4"
-        width="14"
-        height="12"
-        rx="1.6"
-        stroke="currentColor"
-        strokeWidth="1.45"
-      />
-      <path d="M12.5 4v12" stroke="currentColor" strokeWidth="1.45" />
-    </Icon>
-  );
-}
-
 export function WorktreeIcon() {
   return (
     <Icon>

--- a/apps/desktop/src/icons.tsx
+++ b/apps/desktop/src/icons.tsx
@@ -312,6 +312,23 @@ export function RefreshIcon() {
   );
 }
 
+export function PanelRightIcon() {
+  return (
+    <Icon>
+      <rect
+        x="3"
+        y="4"
+        width="14"
+        height="12"
+        rx="1.6"
+        stroke="currentColor"
+        strokeWidth="1.45"
+      />
+      <path d="M12.5 4v12" stroke="currentColor" strokeWidth="1.45" />
+    </Icon>
+  );
+}
+
 export function WorktreeIcon() {
   return (
     <Icon>

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -320,7 +320,7 @@ export interface PiDesktopApi {
     options?: NavigateSessionTreeOptions,
   ): Promise<{ readonly state: DesktopAppState; readonly result: NavigateSessionTreeResult }>;
   listWorkspaceFiles(workspaceId: string): Promise<string[]>;
-  getChangedFiles(workspaceId: string): Promise<{ path: string; status: "added" | "modified" | "deleted" | "untracked" }[]>;
+  getChangedFiles(workspaceId: string): Promise<{ path: string; status: "added" | "modified" | "deleted" | "untracked"; staged: boolean }[]>;
   getFileDiff(workspaceId: string, filePath: string): Promise<string>;
   stageFile(workspaceId: string, filePath: string): Promise<void>;
   toggleWindowMaximize(): Promise<void>;

--- a/apps/desktop/src/reviewed-files-store.ts
+++ b/apps/desktop/src/reviewed-files-store.ts
@@ -1,0 +1,65 @@
+const KEY_PREFIX = "pi-gui:reviewed-files:v1";
+
+export function reviewedFilesKey(workspaceId: string, sessionId: string): string {
+  return `${KEY_PREFIX}:${workspaceId}:${sessionId}`;
+}
+
+export function loadReviewed(workspaceId: string, sessionId: string): ReadonlySet<string> {
+  const raw = readStorage(reviewedFilesKey(workspaceId, sessionId));
+  if (!raw) return new Set();
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((entry): entry is string => typeof entry === "string"));
+    }
+  } catch {
+    // fall through to empty set
+  }
+  return new Set();
+}
+
+export function saveReviewed(
+  workspaceId: string,
+  sessionId: string,
+  reviewed: ReadonlySet<string>,
+): void {
+  const key = reviewedFilesKey(workspaceId, sessionId);
+  if (reviewed.size === 0) {
+    writeStorage(key, "[]");
+    return;
+  }
+  writeStorage(key, JSON.stringify([...reviewed].sort()));
+}
+
+export function pruneReviewed(
+  reviewed: ReadonlySet<string>,
+  currentPaths: readonly string[],
+): ReadonlySet<string> {
+  const allowed = new Set(currentPaths);
+  let changed = false;
+  const next = new Set<string>();
+  for (const path of reviewed) {
+    if (allowed.has(path)) {
+      next.add(path);
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : reviewed;
+}
+
+function readStorage(key: string): string | null {
+  try {
+    return globalThis.localStorage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key: string, value: string): void {
+  try {
+    globalThis.localStorage?.setItem(key, value);
+  } catch {
+    // localStorage unavailable; skip persistence
+  }
+}

--- a/apps/desktop/src/reviewed-files-store.ts
+++ b/apps/desktop/src/reviewed-files-store.ts
@@ -25,7 +25,7 @@ export function saveReviewed(
 ): void {
   const key = reviewedFilesKey(workspaceId, sessionId);
   if (reviewed.size === 0) {
-    writeStorage(key, "[]");
+    removeStorage(key);
     return;
   }
   writeStorage(key, JSON.stringify([...reviewed].sort()));
@@ -59,6 +59,14 @@ function readStorage(key: string): string | null {
 function writeStorage(key: string, value: string): void {
   try {
     globalThis.localStorage?.setItem(key, value);
+  } catch {
+    // localStorage unavailable; skip persistence
+  }
+}
+
+function removeStorage(key: string): void {
+  try {
+    globalThis.localStorage?.removeItem(key);
   } catch {
     // localStorage unavailable; skip persistence
   }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,3 +1,4 @@
 @import "./styles/base.css";
 @import "./styles/sidebar.css";
 @import "./styles/main.css";
+@import "./styles/syntax-highlight.css";

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -671,6 +671,25 @@
   color: var(--ink-strong);
 }
 
+.diff-panel__counter {
+  margin-left: auto;
+  margin-right: 8px;
+  font-size: 12px;
+  color: var(--muted-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.diff-panel__reviewed-checkbox {
+  margin: 0 0 0 12px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.diff-panel__file--reviewed .diff-panel__file-name {
+  color: var(--muted-soft);
+  text-decoration: line-through;
+}
+
 .diff-panel__empty {
   padding: 40px 16px;
   text-align: center;

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -479,7 +479,14 @@
   color: var(--error-ink);
 }
 
+.timeline-tool__header-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .timeline-tool__header {
+  flex: 1;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -490,10 +497,22 @@
   font: inherit;
   text-align: left;
   color: inherit;
+  min-width: 0;
 }
 
 .timeline-tool__header:disabled {
   cursor: default;
+}
+
+.timeline-tool__view-in-diff {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  color: var(--muted-soft);
+}
+
+.timeline-tool__view-in-diff:hover {
+  color: var(--ink);
 }
 
 .timeline-tool__chevron {

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -958,8 +958,14 @@
   color: var(--muted-strong);
 }
 
-.diff-panel__stage-btn:hover {
+.diff-panel__stage-btn:hover:not(:disabled) {
   background: var(--surface-muted);
+}
+
+.diff-panel__stage-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+  color: var(--muted-soft);
 }
 
 .diff-panel__viewer {

--- a/apps/desktop/src/styles/syntax-highlight.css
+++ b/apps/desktop/src/styles/syntax-highlight.css
@@ -1,0 +1,54 @@
+:root {
+  --hljs-keyword: #cf222e;
+  --hljs-built-in: #0550ae;
+  --hljs-type: #0550ae;
+  --hljs-string: #0a3069;
+  --hljs-number: #0550ae;
+  --hljs-literal: #0550ae;
+  --hljs-comment: #6e7781;
+  --hljs-regexp: #116329;
+  --hljs-meta: #6639ba;
+  --hljs-title: #6639ba;
+  --hljs-class: #6639ba;
+  --hljs-function: #8250df;
+  --hljs-variable: #953800;
+  --hljs-params: #24292f;
+  --hljs-attr: #0550ae;
+  --hljs-subst: #24292f;
+}
+
+:root.dark {
+  --hljs-keyword: #ff7b72;
+  --hljs-built-in: #79c0ff;
+  --hljs-type: #79c0ff;
+  --hljs-string: #a5d6ff;
+  --hljs-number: #79c0ff;
+  --hljs-literal: #79c0ff;
+  --hljs-comment: #8b949e;
+  --hljs-regexp: #7ee787;
+  --hljs-meta: #d2a8ff;
+  --hljs-title: #d2a8ff;
+  --hljs-class: #d2a8ff;
+  --hljs-function: #d2a8ff;
+  --hljs-variable: #ffa657;
+  --hljs-params: #c9d1d9;
+  --hljs-attr: #79c0ff;
+  --hljs-subst: #c9d1d9;
+}
+
+.hljs-keyword { color: var(--hljs-keyword); }
+.hljs-built_in { color: var(--hljs-built-in); }
+.hljs-type { color: var(--hljs-type); }
+.hljs-string { color: var(--hljs-string); }
+.hljs-number { color: var(--hljs-number); }
+.hljs-literal { color: var(--hljs-literal); }
+.hljs-comment { color: var(--hljs-comment); font-style: italic; }
+.hljs-regexp { color: var(--hljs-regexp); }
+.hljs-meta { color: var(--hljs-meta); }
+.hljs-title { color: var(--hljs-title); }
+.hljs-class { color: var(--hljs-class); }
+.hljs-function { color: var(--hljs-function); }
+.hljs-variable { color: var(--hljs-variable); }
+.hljs-params { color: var(--hljs-params); }
+.hljs-attr { color: var(--hljs-attr); }
+.hljs-subst { color: var(--hljs-subst); }

--- a/apps/desktop/src/syntax-highlight.ts
+++ b/apps/desktop/src/syntax-highlight.ts
@@ -1,0 +1,130 @@
+import { LRUCache } from "lru-cache";
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import python from "highlight.js/lib/languages/python";
+import typescript from "highlight.js/lib/languages/typescript";
+
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("bash", bash);
+
+export const MAX_HIGHLIGHTED_LINES = 500;
+
+export type HighlightToken = {
+  readonly className?: string;
+  readonly children: readonly HighlightTokenChild[];
+};
+
+export type HighlightTokenChild = string | HighlightToken;
+
+export type HighlightLine = readonly HighlightTokenChild[];
+
+const EXTENSION_TO_LANGUAGE: Readonly<Record<string, string>> = {
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  json: "json",
+  py: "python",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+};
+
+export function extensionToLanguage(filePath: string): string | undefined {
+  const dotIndex = filePath.lastIndexOf(".");
+  if (dotIndex < 0) return undefined;
+  const ext = filePath.slice(dotIndex + 1).toLowerCase();
+  return EXTENSION_TO_LANGUAGE[ext];
+}
+
+const lineCache = new LRUCache<string, HighlightLine>({ max: 5000 });
+
+export function highlightLine(line: string, language: string): HighlightLine {
+  const cacheKey = `${language}\0${line}`;
+  const cached = lineCache.get(cacheKey);
+  if (cached) return cached;
+  const html = hljs.highlight(line, { language, ignoreIllegals: true }).value;
+  const tokens = parseHljsHtml(html);
+  lineCache.set(cacheKey, tokens);
+  return tokens;
+}
+
+export function parseHljsHtml(html: string): HighlightLine {
+  const parser = new HljsHtmlParser(html);
+  return parser.parseChildren(null);
+}
+
+class HljsHtmlParser {
+  private pos = 0;
+  constructor(private readonly source: string) {}
+
+  parseChildren(closingTag: string | null): readonly HighlightTokenChild[] {
+    const out: HighlightTokenChild[] = [];
+    let textStart = this.pos;
+
+    const flushText = (end: number): void => {
+      if (end > textStart) {
+        out.push(decodeEntities(this.source.slice(textStart, end)));
+      }
+    };
+
+    while (this.pos < this.source.length) {
+      const ch = this.source.charCodeAt(this.pos);
+      if (ch !== 0x3c) {
+        this.pos += 1;
+        continue;
+      }
+      if (closingTag !== null && this.matchClosingTag(closingTag)) {
+        flushText(this.pos);
+        this.pos += closingTag.length + 3;
+        return out;
+      }
+      const open = this.tryConsumeOpenSpan();
+      if (open !== null) {
+        flushText(open.tagStart);
+        const children = this.parseChildren("span");
+        out.push({ className: open.className, children });
+        textStart = this.pos;
+        continue;
+      }
+      this.pos += 1;
+    }
+    flushText(this.pos);
+    return out;
+  }
+
+  private matchClosingTag(tag: string): boolean {
+    const expected = `</${tag}>`;
+    return this.source.startsWith(expected, this.pos);
+  }
+
+  private tryConsumeOpenSpan(): { className?: string; tagStart: number } | null {
+    const tagStart = this.pos;
+    if (!this.source.startsWith("<span", this.pos)) return null;
+    const closeIdx = this.source.indexOf(">", this.pos);
+    if (closeIdx < 0) return null;
+    const inner = this.source.slice(this.pos + 5, closeIdx);
+    const classMatch = /\sclass="([^"]*)"/.exec(inner);
+    this.pos = closeIdx + 1;
+    return { className: classMatch?.[1], tagStart };
+  }
+}
+
+function decodeEntities(s: string): string {
+  if (s.indexOf("&") < 0) return s;
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}

--- a/apps/desktop/src/syntax-highlight.ts
+++ b/apps/desktop/src/syntax-highlight.ts
@@ -14,10 +14,10 @@ hljs.registerLanguage("bash", bash);
 
 export const MAX_HIGHLIGHTED_LINES = 500;
 
-export type HighlightToken = {
+interface HighlightToken {
   readonly className?: string;
-  readonly children: readonly HighlightTokenChild[];
-};
+  readonly children: HighlightLine;
+}
 
 export type HighlightTokenChild = string | HighlightToken;
 
@@ -58,7 +58,7 @@ export function highlightLine(line: string, language: string): HighlightLine {
   return tokens;
 }
 
-export function parseHljsHtml(html: string): HighlightLine {
+function parseHljsHtml(html: string): HighlightLine {
   const parser = new HljsHtmlParser(html);
   return parser.parseChildren(null);
 }

--- a/apps/desktop/src/syntax-highlight.ts
+++ b/apps/desktop/src/syntax-highlight.ts
@@ -121,10 +121,12 @@ class HljsHtmlParser {
 
 function decodeEntities(s: string): string {
   if (s.indexOf("&") < 0) return s;
+  // &amp; must be replaced last so &amp;lt; etc. survive intact.
   return s
     .replace(/&lt;/g, "<")
     .replace(/&gt;/g, ">")
     .replace(/&quot;/g, '"')
+    .replace(/&#x27;/gi, "'")
     .replace(/&#39;/g, "'")
     .replace(/&amp;/g, "&");
 }

--- a/apps/desktop/src/timeline-item.tsx
+++ b/apps/desktop/src/timeline-item.tsx
@@ -3,6 +3,7 @@ import type { TimelineActivity, TimelineToolCall, TimelineSummary, TranscriptMes
 import { MessageMarkdown } from "./message-markdown";
 import { InlineDiff, extractDiffFromOutput } from "./diff-inline";
 import { ChevronRightIcon, CopyIcon, FileIcon } from "./icons";
+import { extensionToLanguage } from "./syntax-highlight";
 
 export function TimelineItem({
   item,
@@ -110,6 +111,7 @@ function TimelineToolCallItem({
   const diffText = isWriteTool(item.toolName) ? extractDiffFromOutput(item.output) : undefined;
   const diffStats = diffText ? countDiffStats(diffText) : undefined;
   const compactLabel = buildCompactLabel(item, diffStats);
+  const diffLanguage = diffText ? extensionToLanguage(extractFilename(item.input)) : undefined;
 
   const handleCopy = () => {
     const text = diffText ?? formatToolContent(item.input, item.output);
@@ -158,7 +160,7 @@ function TimelineToolCallItem({
                   <CopyIcon />
                 </button>
               </div>
-              <InlineDiff diff={diffText} />
+              <InlineDiff diff={diffText} language={diffLanguage} />
             </>
           ) : (
             <>

--- a/apps/desktop/src/timeline-item.tsx
+++ b/apps/desktop/src/timeline-item.tsx
@@ -2,7 +2,7 @@ import type { SessionTranscriptMessage } from "@pi-gui/pi-sdk-driver";
 import type { TimelineActivity, TimelineToolCall, TimelineSummary, TranscriptMessage } from "./timeline-types";
 import { MessageMarkdown } from "./message-markdown";
 import { InlineDiff, extractDiffFromOutput } from "./diff-inline";
-import { ChevronRightIcon, CopyIcon, FileIcon, PanelRightIcon } from "./icons";
+import { ChevronRightIcon, CopyIcon, DiffIcon, FileIcon } from "./icons";
 import { extensionToLanguage } from "./syntax-highlight";
 
 export function TimelineItem({
@@ -160,7 +160,7 @@ function TimelineToolCallItem({
               onViewFileInDiff(filePath);
             }}
           >
-            <PanelRightIcon />
+            <DiffIcon />
           </button>
         ) : null}
       </div>

--- a/apps/desktop/src/timeline-item.tsx
+++ b/apps/desktop/src/timeline-item.tsx
@@ -116,9 +116,8 @@ function TimelineToolCallItem({
   const diffText = isWriteTool(item.toolName) ? extractDiffFromOutput(item.output) : undefined;
   const diffStats = diffText ? countDiffStats(diffText) : undefined;
   const compactLabel = buildCompactLabel(item, diffStats);
-  const filePath = isWriteTool(item.toolName) ? extractFilename(item.input) : "";
-  const diffLanguage = diffText ? extensionToLanguage(filePath) : undefined;
-  const showViewInDiff = Boolean(filePath) && Boolean(onViewFileInDiff);
+  const filePath = isWriteTool(item.toolName) ? extractFilename(item.input) || undefined : undefined;
+  const diffLanguage = diffText && filePath ? extensionToLanguage(filePath) : undefined;
 
   const handleCopy = () => {
     const text = diffText ?? formatToolContent(item.input, item.output);
@@ -150,7 +149,7 @@ function TimelineToolCallItem({
           ) : null}
           <span className="timeline-tool__meta-inline">{`${item.toolName} \u00b7 ${statusLabel(item.status)}`}</span>
         </button>
-        {showViewInDiff ? (
+        {filePath && onViewFileInDiff ? (
           <button
             aria-label={`View ${filePath} in changes`}
             className="icon-button timeline-tool__view-in-diff"
@@ -158,7 +157,7 @@ function TimelineToolCallItem({
             type="button"
             onClick={(event) => {
               event.stopPropagation();
-              onViewFileInDiff?.(filePath);
+              onViewFileInDiff(filePath);
             }}
           >
             <PanelRightIcon />

--- a/apps/desktop/src/timeline-item.tsx
+++ b/apps/desktop/src/timeline-item.tsx
@@ -2,7 +2,7 @@ import type { SessionTranscriptMessage } from "@pi-gui/pi-sdk-driver";
 import type { TimelineActivity, TimelineToolCall, TimelineSummary, TranscriptMessage } from "./timeline-types";
 import { MessageMarkdown } from "./message-markdown";
 import { InlineDiff, extractDiffFromOutput } from "./diff-inline";
-import { ChevronRightIcon, CopyIcon, FileIcon } from "./icons";
+import { ChevronRightIcon, CopyIcon, FileIcon, PanelRightIcon } from "./icons";
 import { extensionToLanguage } from "./syntax-highlight";
 
 export function TimelineItem({
@@ -116,7 +116,9 @@ function TimelineToolCallItem({
   const diffText = isWriteTool(item.toolName) ? extractDiffFromOutput(item.output) : undefined;
   const diffStats = diffText ? countDiffStats(diffText) : undefined;
   const compactLabel = buildCompactLabel(item, diffStats);
-  const diffLanguage = diffText ? extensionToLanguage(extractFilename(item.input)) : undefined;
+  const filePath = isWriteTool(item.toolName) ? extractFilename(item.input) : "";
+  const diffLanguage = diffText ? extensionToLanguage(filePath) : undefined;
+  const showViewInDiff = Boolean(filePath) && Boolean(onViewFileInDiff);
 
   const handleCopy = () => {
     const text = diffText ?? formatToolContent(item.input, item.output);
@@ -125,28 +127,44 @@ function TimelineToolCallItem({
 
   return (
     <article className={`timeline-tool timeline-tool--${item.status}`}>
-      <button
-        className="timeline-tool__header"
-        type="button"
-        aria-expanded={expanded}
-        disabled={!hasContent}
-        onClick={() => onToggle?.(item.callId)}
-      >
-        {hasContent ? (
-          <span className={`timeline-tool__chevron ${expanded ? "timeline-tool__chevron--expanded" : ""}`}>
-            <ChevronRightIcon />
-          </span>
+      <div className="timeline-tool__header-row">
+        <button
+          className="timeline-tool__header"
+          type="button"
+          aria-expanded={expanded}
+          disabled={!hasContent}
+          onClick={() => onToggle?.(item.callId)}
+        >
+          {hasContent ? (
+            <span className={`timeline-tool__chevron ${expanded ? "timeline-tool__chevron--expanded" : ""}`}>
+              <ChevronRightIcon />
+            </span>
+          ) : null}
+          <span className="timeline-tool__label">{compactLabel}</span>
+          {diffStats ? (
+            <span className="timeline-tool__diff-stats">
+              <span className="timeline-tool__stat-add">+{diffStats.added}</span>
+              {" "}
+              <span className="timeline-tool__stat-del">-{diffStats.removed}</span>
+            </span>
+          ) : null}
+          <span className="timeline-tool__meta-inline">{`${item.toolName} \u00b7 ${statusLabel(item.status)}`}</span>
+        </button>
+        {showViewInDiff ? (
+          <button
+            aria-label={`View ${filePath} in changes`}
+            className="icon-button timeline-tool__view-in-diff"
+            data-testid="timeline-tool-view-in-diff"
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onViewFileInDiff?.(filePath);
+            }}
+          >
+            <PanelRightIcon />
+          </button>
         ) : null}
-        <span className="timeline-tool__label">{compactLabel}</span>
-        {diffStats ? (
-          <span className="timeline-tool__diff-stats">
-            <span className="timeline-tool__stat-add">+{diffStats.added}</span>
-            {" "}
-            <span className="timeline-tool__stat-del">-{diffStats.removed}</span>
-          </span>
-        ) : null}
-        <span className="timeline-tool__meta-inline">{`${item.toolName} \u00b7 ${statusLabel(item.status)}`}</span>
-      </button>
+      </div>
       {expanded && hasContent ? (
         <div className="timeline-tool__body">
           {diffText ? (

--- a/apps/desktop/src/timeline-item.tsx
+++ b/apps/desktop/src/timeline-item.tsx
@@ -9,10 +9,12 @@ export function TimelineItem({
   item,
   expandedToolCallIds,
   onToggleToolCall,
+  onViewFileInDiff,
 }: {
   readonly item: TranscriptMessage;
   readonly expandedToolCallIds?: ReadonlySet<string>;
   readonly onToggleToolCall?: (callId: string) => void;
+  readonly onViewFileInDiff?: (path: string) => void;
 }) {
   switch (item.kind) {
     case "message":
@@ -25,6 +27,7 @@ export function TimelineItem({
           item={item}
           expanded={expandedToolCallIds?.has(item.callId) ?? false}
           onToggle={onToggleToolCall}
+          onViewFileInDiff={onViewFileInDiff}
         />
       );
     case "summary":
@@ -102,10 +105,12 @@ function TimelineToolCallItem({
   item,
   expanded,
   onToggle,
+  onViewFileInDiff,
 }: {
   readonly item: TimelineToolCall;
   readonly expanded: boolean;
   readonly onToggle?: (callId: string) => void;
+  readonly onViewFileInDiff?: (path: string) => void;
 }) {
   const hasContent = item.input !== undefined || item.output !== undefined;
   const diffText = isWriteTool(item.toolName) ? extractDiffFromOutput(item.output) : undefined;

--- a/apps/desktop/src/topbar.tsx
+++ b/apps/desktop/src/topbar.tsx
@@ -49,6 +49,7 @@ export function Topbar(props: TopbarProps) {
     onToggleDiffPanel,
   } = props;
   const terminalShortcut = getDesktopShortcutLabel(api.platform, "J");
+  const diffShortcut = getDesktopShortcutLabel(api.platform, "D");
 
   const handleDoubleClick = (event: ReactMouseEvent<HTMLElement>) => {
     const target = event.target;
@@ -147,14 +148,20 @@ export function Topbar(props: TopbarProps) {
             <kbd>{terminalShortcut}</kbd>
           </span>
         </div>
-        <button
-          aria-label="Toggle diff panel"
-          className={`icon-button topbar__icon ${showDiffPanel ? "icon-button--active" : ""}`}
-          type="button"
-          onClick={onToggleDiffPanel}
-        >
-          <DiffIcon />
-        </button>
+        <div className="shortcut-tooltip-wrap topbar__tooltip-wrap">
+          <button
+            aria-label="Toggle changes"
+            className={`icon-button topbar__icon ${showDiffPanel ? "icon-button--active" : ""}`}
+            type="button"
+            onClick={onToggleDiffPanel}
+          >
+            <DiffIcon />
+          </button>
+          <span className="shortcut-tooltip topbar__tooltip" role="tooltip">
+            <span>Toggle changes</span>
+            <kbd>{diffShortcut}</kbd>
+          </span>
+        </div>
         <button
           aria-label="Add folder"
           className="icon-button topbar__icon"

--- a/apps/desktop/tests/core/integrated-terminal.spec.ts
+++ b/apps/desktop/tests/core/integrated-terminal.spec.ts
@@ -28,8 +28,9 @@ test("opens a workspace terminal with persistent output, tabs, and takeover cont
     await createNamedThread(window, "Terminal host thread");
 
     await window.getByLabel("Toggle terminal").hover();
-    await expect(window.locator(".topbar__tooltip")).toContainText("Toggle terminal");
-    await expect(window.locator(".topbar__tooltip kbd")).toHaveText(/⌘J|Ctrl\+J/);
+    const terminalTooltip = window.locator(".topbar__tooltip", { hasText: "Toggle terminal" });
+    await expect(terminalTooltip).toContainText("Toggle terminal");
+    await expect(terminalTooltip.locator("kbd")).toHaveText(/⌘J|Ctrl\+J/);
 
     await window.getByLabel("Toggle terminal").click();
     const terminal = window.getByTestId("integrated-terminal");

--- a/apps/desktop/tests/core/review-ux.spec.ts
+++ b/apps/desktop/tests/core/review-ux.spec.ts
@@ -1,7 +1,10 @@
+import { execFile } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
+import { promisify } from "node:util";
 import { join } from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import type { SessionDriverEvent, SessionRef } from "@pi-gui/session-driver";
+import { reviewedFilesKey } from "../../src/reviewed-files-store";
 import {
   commitAllInGitRepo,
   createNamedThread,
@@ -14,7 +17,14 @@ import {
   makeWorkspace,
 } from "../helpers/electron-app";
 
-async function selectedSessionRef(window: Parameters<typeof getDesktopState>[0]): Promise<SessionRef> {
+const execFileAsync = promisify(execFile);
+
+async function commitFiles(workspacePath: string, paths: readonly string[], message: string): Promise<void> {
+  await execFileAsync("git", ["add", "--", ...paths], { cwd: workspacePath });
+  await execFileAsync("git", ["commit", "-m", message], { cwd: workspacePath });
+}
+
+async function selectedSessionRef(window: Page): Promise<SessionRef> {
   const state = await getDesktopState(window);
   if (!state.selectedWorkspaceId || !state.selectedSessionId) {
     throw new Error("Expected a selected session");
@@ -45,19 +55,27 @@ async function seedThreeFileWorkspace(): Promise<string> {
   return workspacePath;
 }
 
-test("syntax-highlights known languages and leaves unknown extensions plain", async () => {
-  test.setTimeout(45_000);
+async function launchSeeded(threadTitle: string): Promise<{
+  readonly harness: Awaited<ReturnType<typeof launchDesktop>>;
+  readonly window: Page;
+  readonly userDataDir: string;
+  readonly workspacePath: string;
+}> {
   const userDataDir = await makeUserDataDir();
   const workspacePath = await seedThreeFileWorkspace();
-
   const harness = await launchDesktop(userDataDir, {
     initialWorkspaces: [workspacePath],
     testMode: "background",
   });
-  try {
-    const window = await harness.firstWindow();
-    await createNamedThread(window, "Review UX highlight");
+  const window = await harness.firstWindow();
+  await createNamedThread(window, threadTitle);
+  return { harness, window, userDataDir, workspacePath };
+}
 
+test("syntax-highlights known languages and leaves unknown extensions plain", async () => {
+  test.setTimeout(45_000);
+  const { harness, window } = await launchSeeded("Review UX highlight");
+  try {
     await window.keyboard.press(desktopShortcut("D"));
     const diffPanel = window.locator(".diff-panel");
     await expect(diffPanel).toBeVisible();
@@ -86,92 +104,73 @@ test("syntax-highlights known languages and leaves unknown extensions plain", as
 
 test("reviewed checkboxes update counter, prune on changes, and survive relaunch", async () => {
   test.setTimeout(60_000);
-  const userDataDir = await makeUserDataDir();
-  const workspacePath = await seedThreeFileWorkspace();
+  const { harness, window: firstWindow, userDataDir, workspacePath } = await launchSeeded(
+    "Review UX checkboxes",
+  );
+  const sessionRef = await selectedSessionRef(firstWindow);
+  const storageKey = reviewedFilesKey(sessionRef.workspaceId, sessionRef.sessionId);
 
-  const harness = await launchDesktop(userDataDir, {
-    initialWorkspaces: [workspacePath],
-    testMode: "background",
-  });
+  await firstWindow.keyboard.press(desktopShortcut("D"));
+  const diffPanel = firstWindow.locator(".diff-panel");
+  await expect(diffPanel).toBeVisible();
+  await expect(diffPanel.locator(".diff-panel__file")).toHaveCount(3);
 
+  const counter = diffPanel.getByTestId("diff-panel-counter");
+  await expect(counter).toHaveText("Reviewed 0 of 3");
+
+  await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").check();
+  await expect(counter).toHaveText("Reviewed 1 of 3");
+  await expect(diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]')).toHaveClass(
+    /diff-panel__file--reviewed/,
+  );
+
+  expect(
+    await firstWindow.evaluate((key) => globalThis.localStorage.getItem(key), storageKey),
+  ).toBe(JSON.stringify(["src/foo.ts"]));
+
+  await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").uncheck();
+  await expect(counter).toHaveText("Reviewed 0 of 3");
+  await expect(
+    diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]'),
+  ).not.toHaveClass(/diff-panel__file--reviewed/);
+  expect(
+    await firstWindow.evaluate((key) => globalThis.localStorage.getItem(key), storageKey),
+  ).toBeNull();
+
+  await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").check();
+  await diffPanel.getByTestId("diff-panel-reviewed-script.py").check();
+  await expect(counter).toHaveText("Reviewed 2 of 3");
+
+  await harness.close();
+
+  const reopened = await launchDesktop(userDataDir, { testMode: "background" });
+  const window = await reopened.firstWindow();
   try {
-    let window = await harness.firstWindow();
-    await createNamedThread(window, "Review UX checkboxes");
-    const sessionRef = await selectedSessionRef(window);
-
     await window.keyboard.press(desktopShortcut("D"));
-    const diffPanel = window.locator(".diff-panel");
-    await expect(diffPanel).toBeVisible();
-    await expect(diffPanel.locator(".diff-panel__file")).toHaveCount(3);
+    const reopenedPanel = window.locator(".diff-panel");
+    await expect(reopenedPanel).toBeVisible();
+    await expect(reopenedPanel.getByTestId("diff-panel-counter")).toHaveText("Reviewed 2 of 3");
+    await expect(reopenedPanel.getByTestId("diff-panel-reviewed-src/foo.ts")).toBeChecked();
+    await expect(reopenedPanel.getByTestId("diff-panel-reviewed-script.py")).toBeChecked();
+    await expect(reopenedPanel.getByTestId("diff-panel-reviewed-notes.md")).not.toBeChecked();
 
-    const counter = diffPanel.getByTestId("diff-panel-counter");
-    await expect(counter).toHaveText("Reviewed 0 of 3");
+    await commitFiles(workspacePath, ["src/foo.ts"], "land foo");
+    await reopenedPanel.locator('button[aria-label="Refresh"]').click();
+    await expect(reopenedPanel.locator(".diff-panel__file")).toHaveCount(2);
+    await expect(reopenedPanel.getByTestId("diff-panel-counter")).toHaveText("Reviewed 1 of 2");
 
-    await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").check();
-    await expect(counter).toHaveText("Reviewed 1 of 3");
-    await expect(diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]')).toHaveClass(
-      /diff-panel__file--reviewed/,
-    );
-
-    const storageKey = `pi-gui:reviewed-files:v1:${sessionRef.workspaceId}:${sessionRef.sessionId}`;
-    const stored = await window.evaluate((key) => globalThis.localStorage.getItem(key), storageKey);
-    expect(stored).toBe(JSON.stringify(["src/foo.ts"]));
-
-    await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").uncheck();
-    await expect(counter).toHaveText("Reviewed 0 of 3");
-    await expect(
-      diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]'),
-    ).not.toHaveClass(/diff-panel__file--reviewed/);
-
-    await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").check();
-    await diffPanel.getByTestId("diff-panel-reviewed-script.py").check();
-    await expect(counter).toHaveText("Reviewed 2 of 3");
-
-    await harness.close();
-
-    const reopened = await launchDesktop(userDataDir, { testMode: "background" });
-    window = await reopened.firstWindow();
-    try {
-      await window.keyboard.press(desktopShortcut("D"));
-      const reopenedPanel = window.locator(".diff-panel");
-      await expect(reopenedPanel).toBeVisible();
-      await expect(reopenedPanel.getByTestId("diff-panel-counter")).toHaveText("Reviewed 2 of 3");
-      await expect(reopenedPanel.getByTestId("diff-panel-reviewed-src/foo.ts")).toBeChecked();
-      await expect(reopenedPanel.getByTestId("diff-panel-reviewed-script.py")).toBeChecked();
-      await expect(reopenedPanel.getByTestId("diff-panel-reviewed-notes.md")).not.toBeChecked();
-
-      await commitAllInGitRepo(workspacePath, "land foo");
-      await reopenedPanel.locator('button[aria-label="Refresh"]').click();
-      await expect(reopenedPanel.locator(".diff-panel__file")).toHaveCount(2);
-      await expect(reopenedPanel.getByTestId("diff-panel-counter")).toHaveText("Reviewed 1 of 2");
-
-      const prunedStored = await window.evaluate(
-        (key) => globalThis.localStorage.getItem(key),
-        storageKey,
-      );
-      expect(prunedStored).toBe(JSON.stringify(["script.py"]));
-    } finally {
-      await reopened.close();
-    }
+    expect(
+      await window.evaluate((key) => globalThis.localStorage.getItem(key), storageKey),
+    ).toBe(JSON.stringify(["script.py"]));
   } finally {
-    // best-effort if a relaunch failed mid-test
-    if (!harness.electronApp.windows().length) return;
-    await harness.close().catch(() => undefined);
+    await reopened.close();
   }
 });
 
 test("view-in-changes button on a write tool row opens the diff panel without toggling expand", async () => {
   test.setTimeout(45_000);
-  const userDataDir = await makeUserDataDir();
-  const workspacePath = await seedThreeFileWorkspace();
-
-  const harness = await launchDesktop(userDataDir, {
-    initialWorkspaces: [workspacePath],
-    testMode: "background",
-  });
+  const { harness, window } = await launchSeeded("Review UX tool link");
   try {
-    const window = await harness.firstWindow();
-    await createNamedThread(window, "Review UX tool link");
     const sessionRef = await selectedSessionRef(window);
 
     const diffPanel = window.locator(".diff-panel");
@@ -220,16 +219,8 @@ test("view-in-changes button on a write tool row opens the diff panel without to
 
 test("highlighting tokens swap palettes when the dark class flips", async () => {
   test.setTimeout(45_000);
-  const userDataDir = await makeUserDataDir();
-  const workspacePath = await seedThreeFileWorkspace();
-
-  const harness = await launchDesktop(userDataDir, {
-    initialWorkspaces: [workspacePath],
-    testMode: "background",
-  });
+  const { harness, window } = await launchSeeded("Review UX theme");
   try {
-    const window = await harness.firstWindow();
-    await createNamedThread(window, "Review UX theme");
     await window.keyboard.press(desktopShortcut("D"));
 
     const diffPanel = window.locator(".diff-panel");
@@ -242,7 +233,6 @@ test("highlighting tokens swap palettes when the dark class flips", async () => 
     const initiallyDark = await window.evaluate(() =>
       document.documentElement.classList.contains("dark"),
     );
-
     const colorBefore = await token.evaluate((el) => getComputedStyle(el).color);
 
     await window.evaluate((wasDark) => {

--- a/apps/desktop/tests/core/review-ux.spec.ts
+++ b/apps/desktop/tests/core/review-ux.spec.ts
@@ -1,0 +1,257 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import type { SessionDriverEvent, SessionRef } from "@pi-gui/session-driver";
+import {
+  commitAllInGitRepo,
+  createNamedThread,
+  desktopShortcut,
+  emitTestSessionEvent,
+  getDesktopState,
+  initGitRepo,
+  launchDesktop,
+  makeUserDataDir,
+  makeWorkspace,
+} from "../helpers/electron-app";
+
+async function selectedSessionRef(window: Parameters<typeof getDesktopState>[0]): Promise<SessionRef> {
+  const state = await getDesktopState(window);
+  if (!state.selectedWorkspaceId || !state.selectedSessionId) {
+    throw new Error("Expected a selected session");
+  }
+  return { workspaceId: state.selectedWorkspaceId, sessionId: state.selectedSessionId };
+}
+
+async function seedThreeFileWorkspace(): Promise<string> {
+  const workspacePath = await makeWorkspace("review-ux-workspace");
+  await initGitRepo(workspacePath);
+  await mkdir(join(workspacePath, "src"), { recursive: true });
+  await writeFile(join(workspacePath, "src", "foo.ts"), "export const x = 0;\n", "utf8");
+  await writeFile(join(workspacePath, "script.py"), "def hello():\n    pass\n", "utf8");
+  await writeFile(join(workspacePath, "notes.md"), "# notes\n", "utf8");
+  await commitAllInGitRepo(workspacePath, "init");
+
+  await writeFile(
+    join(workspacePath, "src", "foo.ts"),
+    "export const x = 1; // changed\nexport function add(a: number, b: number) { return a + b; }\n",
+    "utf8",
+  );
+  await writeFile(
+    join(workspacePath, "script.py"),
+    "def hello():\n    return 'hi'\n",
+    "utf8",
+  );
+  await writeFile(join(workspacePath, "notes.md"), "# notes\n\nMore.\n", "utf8");
+  return workspacePath;
+}
+
+test("syntax-highlights known languages and leaves unknown extensions plain", async () => {
+  test.setTimeout(45_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await seedThreeFileWorkspace();
+
+  const harness = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+  try {
+    const window = await harness.firstWindow();
+    await createNamedThread(window, "Review UX highlight");
+
+    await window.keyboard.press(desktopShortcut("D"));
+    const diffPanel = window.locator(".diff-panel");
+    await expect(diffPanel).toBeVisible();
+
+    const tsRow = diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]');
+    await expect(tsRow).toBeVisible();
+    await tsRow.locator(".diff-panel__file-name").click();
+    const tsDiff = diffPanel.locator(".diff-inline");
+    await expect(tsDiff).toHaveAttribute("data-language", "typescript");
+    await expect(tsDiff.locator('[class*="hljs-"]').first()).toBeVisible();
+
+    const pyRow = diffPanel.locator('.diff-panel__file[data-file-path="script.py"]');
+    await pyRow.locator(".diff-panel__file-name").click();
+    await expect(diffPanel.locator(".diff-inline")).toHaveAttribute("data-language", "python");
+    await expect(diffPanel.locator('.diff-inline [class*="hljs-"]').first()).toBeVisible();
+
+    const mdRow = diffPanel.locator('.diff-panel__file[data-file-path="notes.md"]');
+    await mdRow.locator(".diff-panel__file-name").click();
+    const mdDiff = diffPanel.locator(".diff-inline");
+    await expect(mdDiff).not.toHaveAttribute("data-language", /.*/);
+    await expect(mdDiff.locator('[class*="hljs-"]')).toHaveCount(0);
+  } finally {
+    await harness.close();
+  }
+});
+
+test("reviewed checkboxes update counter, prune on changes, and survive relaunch", async () => {
+  test.setTimeout(60_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await seedThreeFileWorkspace();
+
+  const harness = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+
+  try {
+    let window = await harness.firstWindow();
+    await createNamedThread(window, "Review UX checkboxes");
+    const sessionRef = await selectedSessionRef(window);
+
+    await window.keyboard.press(desktopShortcut("D"));
+    const diffPanel = window.locator(".diff-panel");
+    await expect(diffPanel).toBeVisible();
+    await expect(diffPanel.locator(".diff-panel__file")).toHaveCount(3);
+
+    const counter = diffPanel.getByTestId("diff-panel-counter");
+    await expect(counter).toHaveText("Reviewed 0 of 3");
+
+    await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").check();
+    await expect(counter).toHaveText("Reviewed 1 of 3");
+    await expect(diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]')).toHaveClass(
+      /diff-panel__file--reviewed/,
+    );
+
+    const storageKey = `pi-gui:reviewed-files:v1:${sessionRef.workspaceId}:${sessionRef.sessionId}`;
+    const stored = await window.evaluate((key) => globalThis.localStorage.getItem(key), storageKey);
+    expect(stored).toBe(JSON.stringify(["src/foo.ts"]));
+
+    await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").uncheck();
+    await expect(counter).toHaveText("Reviewed 0 of 3");
+    await expect(
+      diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]'),
+    ).not.toHaveClass(/diff-panel__file--reviewed/);
+
+    await diffPanel.getByTestId("diff-panel-reviewed-src/foo.ts").check();
+    await diffPanel.getByTestId("diff-panel-reviewed-script.py").check();
+    await expect(counter).toHaveText("Reviewed 2 of 3");
+
+    await harness.close();
+
+    const reopened = await launchDesktop(userDataDir, { testMode: "background" });
+    window = await reopened.firstWindow();
+    try {
+      await window.keyboard.press(desktopShortcut("D"));
+      const reopenedPanel = window.locator(".diff-panel");
+      await expect(reopenedPanel).toBeVisible();
+      await expect(reopenedPanel.getByTestId("diff-panel-counter")).toHaveText("Reviewed 2 of 3");
+      await expect(reopenedPanel.getByTestId("diff-panel-reviewed-src/foo.ts")).toBeChecked();
+      await expect(reopenedPanel.getByTestId("diff-panel-reviewed-script.py")).toBeChecked();
+      await expect(reopenedPanel.getByTestId("diff-panel-reviewed-notes.md")).not.toBeChecked();
+
+      await commitAllInGitRepo(workspacePath, "land foo");
+      await reopenedPanel.locator('button[aria-label="Refresh"]').click();
+      await expect(reopenedPanel.locator(".diff-panel__file")).toHaveCount(2);
+      await expect(reopenedPanel.getByTestId("diff-panel-counter")).toHaveText("Reviewed 1 of 2");
+
+      const prunedStored = await window.evaluate(
+        (key) => globalThis.localStorage.getItem(key),
+        storageKey,
+      );
+      expect(prunedStored).toBe(JSON.stringify(["script.py"]));
+    } finally {
+      await reopened.close();
+    }
+  } finally {
+    // best-effort if a relaunch failed mid-test
+    if (!harness.electronApp.windows().length) return;
+    await harness.close().catch(() => undefined);
+  }
+});
+
+test("view-in-changes button on a write tool row opens the diff panel without toggling expand", async () => {
+  test.setTimeout(45_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await seedThreeFileWorkspace();
+
+  const harness = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+  try {
+    const window = await harness.firstWindow();
+    await createNamedThread(window, "Review UX tool link");
+    const sessionRef = await selectedSessionRef(window);
+
+    const diffPanel = window.locator(".diff-panel");
+    await expect(diffPanel).toHaveCount(0);
+
+    const timestamp = new Date().toISOString();
+    const startedEvent: Extract<SessionDriverEvent, { type: "toolStarted" }> = {
+      type: "toolStarted",
+      sessionRef,
+      timestamp,
+      toolName: "Edit",
+      callId: "review-ux-edit-1",
+      input: { file_path: "src/foo.ts" },
+    };
+    await emitTestSessionEvent(harness, startedEvent);
+
+    const finishedEvent: Extract<SessionDriverEvent, { type: "toolFinished" }> = {
+      type: "toolFinished",
+      sessionRef,
+      timestamp,
+      callId: "review-ux-edit-1",
+      success: true,
+    };
+    await emitTestSessionEvent(harness, finishedEvent);
+
+    const viewButton = window.getByTestId("timeline-tool-view-in-diff");
+    await expect(viewButton).toBeVisible();
+
+    const toolHeader = window.locator(".timeline-tool__header").first();
+    await expect(toolHeader).toHaveAttribute("aria-expanded", "false");
+
+    await viewButton.click();
+    await expect(diffPanel).toBeVisible();
+    await expect(toolHeader).toHaveAttribute("aria-expanded", "false");
+
+    const selectedRow = diffPanel.locator('.diff-panel__file[data-file-path="src/foo.ts"]');
+    await expect(selectedRow).toHaveClass(/diff-panel__file--selected/);
+    await expect(diffPanel.locator(".diff-inline")).toHaveAttribute("data-language", "typescript");
+
+    await toolHeader.click();
+    await expect(toolHeader).toHaveAttribute("aria-expanded", "true");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("highlighting tokens swap palettes when the dark class flips", async () => {
+  test.setTimeout(45_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await seedThreeFileWorkspace();
+
+  const harness = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+  try {
+    const window = await harness.firstWindow();
+    await createNamedThread(window, "Review UX theme");
+    await window.keyboard.press(desktopShortcut("D"));
+
+    const diffPanel = window.locator(".diff-panel");
+    await diffPanel
+      .locator('.diff-panel__file[data-file-path="src/foo.ts"] .diff-panel__file-name')
+      .click();
+    const token = diffPanel.locator('.diff-inline [class*="hljs-"]').first();
+    await expect(token).toBeVisible();
+
+    const initiallyDark = await window.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+
+    const colorBefore = await token.evaluate((el) => getComputedStyle(el).color);
+
+    await window.evaluate((wasDark) => {
+      document.documentElement.classList.toggle("dark", !wasDark);
+    }, initiallyDark);
+
+    const colorAfter = await token.evaluate((el) => getComputedStyle(el).color);
+    expect(colorAfter).not.toBe(colorBefore);
+  } finally {
+    await harness.close();
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       glob:
         specifier: ^13.0.1
         version: 13.0.6
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       hosted-git-info:
         specifier: ^9.0.2
         version: 9.0.2
@@ -2740,6 +2743,10 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -7372,6 +7379,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   highlight.js@10.7.3: {}
+
+  highlight.js@11.11.1: {}
 
   hosted-git-info@4.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Syntax-highlight inline diffs (TS/JS/TSX/JSON/Python/Bash) with a CSS-variable-based theme that flips under `:root.dark`. Bundle delta: ~29 KB gzipped.
- Reviewed checkboxes + counter on the diff panel, persisted per `(workspaceId, sessionId)` via `localStorage`. Survives a full app relaunch and prunes when changed-files mutate.
- "View in changes" icon-button on Edit/Write timeline rows. One click opens the diff panel and selects + scrolls to the file. Chevron expand-state is unaffected.

Out of scope (rejected): per-hunk accept/revert, inline approval cards, side-by-side.

## Plan and review
- Plan: [`plans/milestone-a-review-ux/plan.md`](plans/milestone-a-review-ux/plan.md). Confidence reached 85% after R2 plan review.
- `plan-loop`: 2 native reviewers + 1 attempted Codex (MCP unavailable — `gpt-5.5`/`gpt-5*`/`codex-*` rejected by ChatGPT account; flagged at sign-off).
- `review-loop`: R1 (4 native, distinct surfaces) found two **[high]** bugs — scroll-race when panel mounts empty and missing `&#x27;` entity decode for apostrophes — plus a session-deps gap and a counter-flicker. Fixed in 35807fc. R2 verified all four resolved without regression.
- `simplify`: collapsed dual-ref + pending state into a `fileRequest` prop, narrowed `parseHljsHtml` to private, unified the token renderer, swapped empty-set `setItem("[]")` for `removeItem`, fixed a latent test bug where `commitAllInGitRepo` blew away every change instead of just `foo.ts`.

## Test plan
- [x] `pnpm --filter @pi-gui/desktop run typecheck`
- [x] `pnpm --filter @pi-gui/desktop run test:e2e:runner -- apps/desktop/tests/core/review-ux.spec.ts apps/desktop/tests/core/mentions-diff.spec.ts` — 6/6 passing
- [x] Full `core` lane — 58/60 passing; the 2 failures (`provider-settings`, `unread-state`) reproduce on the parent commit `30868cf` and are unrelated to this change

## Files
9 commits across `apps/desktop/src/{App,conversation-timeline,diff-inline,diff-panel,timeline-item,icons}.tsx`, new `syntax-highlight.ts`, `reviewed-files-store.ts`, `styles/syntax-highlight.css`, and `tests/core/review-ux.spec.ts`. No `desktop-state.ts`, main, preload, or IPC changes — reviewed-state is renderer-only by design.