### PR TITLE
Approve native build dependencies for dev setup

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,9 @@ packages:
 
 onlyBuiltDependencies:
   - electron
+  - electron-winstaller
+  - esbuild
+  - koffi
+  - node-pty
+  - protobufjs
+  - sharp


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Approve workspace native/tooling build scripts required by local development setup.
- Allows `node-pty` to build during `pnpm install`, which unblocks the desktop integrated terminal dependency on Linux.

### Validation
- `corepack enable && pnpm install`
- `node -e "const pty=require('node-pty'); console.log(typeof pty.spawn)"`
- `pnpm typecheck`
- `pnpm --filter @pi-gui/desktop build`
- `pnpm --filter @pi-gui/desktop run test:e2e:runner -- apps/desktop/tests/core/integrated-terminal.spec.ts apps/desktop/tests/core/provider-settings.spec.ts` launched Electron and passed 4/6 focused specs; two pre-existing product assertions still fail.

### Walkthrough
<a href="https://cursor.com/agents/bc-5effa4ca-b85a-473e-bd21-1dc0c894862e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_running_surfaces.mp4"><img src="https://cursor.com/artifacts/c/art-9b427798-36c0-4d82-bec0-ca411f84e591" alt="dev_environment_running_surfaces.mp4" /></a>

Screenshots:
- ![Electron desktop dev app](https://cursor.com/artifacts/c/art-3bb1656e-5b31-42a2-93fc-244285d29f1c)
- ![Website dev home](https://cursor.com/artifacts/c/art-147cd149-f742-4bf4-aa62-126f0b0e8a93)
- ![Remotion preview](https://cursor.com/artifacts/c/art-4b7aa95c-e63e-47de-a53a-1dc01495846c)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5effa4ca-b85a-473e-bd21-1dc0c894862e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5effa4ca-b85a-473e-bd21-1dc0c894862e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

