### PR TITLE
fix: wrap long lines in message bubbles

### DIFF
--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -1038,6 +1038,9 @@
   display: grid;
   gap: 9px;
   line-height: 1.65;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .message__content > :first-child {
@@ -1046,6 +1049,12 @@
 
 .message__content > :last-child {
   margin-bottom: 0;
+}
+
+.message__content p {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .message__content p,
@@ -1084,10 +1093,13 @@
 .message__content pre {
   padding: 12px 14px;
   border-radius: 10px;
-  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
   background: #f2f4f8;
   color: #25304a;
   border: 1px solid #dfe3eb;
+  max-width: 100%;
 }
 
 .message__content pre code {


### PR DESCRIPTION
## Problem

Long lines in assistant messages (long URLs, wide tables, unbreakable strings) overflow past the message bubble's right edge and get clipped by the viewport. Code blocks also scroll horizontally instead of wrapping.

## Root cause

Three CSS rules in `apps/desktop/src/styles/main.css` are missing text-wrapping rules:

1. **`.message__content`** is a `display: grid` container. Grid items don't shrink below their content's intrinsic size by default — `min-width: 0` is required to let them fit the bubble width. Also no `overflow-wrap` / `word-break` to handle unbreakable strings.

2. **`.message__content p`** (and other text elements) have no `white-space: pre-wrap`, so pre-formatted text and lines from copy-paste refuse to wrap.

3. **`.message__content pre`** uses `overflow: auto`, which causes a horizontal scrollbar for any code line wider than the bubble, instead of wrapping.

## Changes

- Add `min-width: 0`, `overflow-wrap: anywhere`, `word-break: break-word` to `.message__content`
- Add a dedicated `.message__content p` rule with `white-space: pre-wrap`, `overflow-wrap: anywhere`, `word-break: break-word`
- Replace `overflow: auto` on `.message__content pre` with `white-space: pre-wrap`, `word-break: break-word`, `overflow-wrap: anywhere`, and `max-width: 100%`

## Verification

Built a patched asar locally, tested the resulting bundle in the running app — long lines now wrap inside the bubble, code blocks wrap instead of scrolling horizontally, and the existing aesthetic is preserved.