### PR TITLE
Add Packages view for browsing installed pi packages

### DIFF
--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -19,6 +19,8 @@ const packagePaths = [
 ];
 
 const isBun = process.versions.bun || process.env.npm_config_user_agent?.includes("bun");
+const isWin = process.platform === "win32";
+const pnpmCmd = isWin ? "pnpm.cmd" : "pnpm";
 
 async function run(cmd, args, cwd) {
   await new Promise((resolve, reject) => {
@@ -26,6 +28,7 @@ async function run(cmd, args, cwd) {
       cwd,
       stdio: "inherit",
       env: process.env,
+      shell: isWin,
     });
 
     child.once("error", reject);
@@ -45,6 +48,7 @@ function start(cmd, args, cwd) {
     cwd,
     stdio: "inherit",
     env: process.env,
+    shell: isWin,
   });
 }
 
@@ -55,7 +59,7 @@ async function main() {
     }
   } else {
     await run(
-      "pnpm",
+      pnpmCmd,
       ["--dir", repoRoot, "--filter", packageFilters[0], "--filter", packageFilters[1], "--filter", packageFilters[2], "run", "build"],
       desktopDir,
     );
@@ -70,7 +74,7 @@ async function main() {
       ]
     : [
         start(
-          "pnpm",
+          pnpmCmd,
           [
             "--dir",
             repoRoot,
@@ -87,7 +91,7 @@ async function main() {
           ],
           desktopDir,
         ),
-        start("pnpm", ["exec", "electron-vite", "dev", "--watch", ...extraArgs], desktopDir),
+        start(pnpmCmd, ["exec", "electron-vite", "dev", "--watch", ...extraArgs], desktopDir),
       ];
 
   let exiting = false;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -33,6 +33,7 @@ import {
 import { deriveModelOnboardingState } from "./model-onboarding";
 import { SkillsView } from "./skills-view";
 import { ExtensionsView } from "./extensions-view";
+import { PackagesView } from "./packages-view";
 import { SettingsView, type SettingsSection } from "./settings-view";
 import { SecondarySurface } from "./secondary-surface";
 import { NewThreadView } from "./new-thread-view";
@@ -171,6 +172,7 @@ export default function App() {
   const [settingsWorkspaceId, setSettingsWorkspaceId] = useState("");
   const [skillsWorkspaceId, setSkillsWorkspaceId] = useState("");
   const [extensionsWorkspaceId, setExtensionsWorkspaceId] = useState("");
+  const [packagesWorkspaceId, setPackagesWorkspaceId] = useState("");
   const [pendingNewThreadWorkspaceId, setPendingNewThreadWorkspaceId] = useState("");
   const [newThreadRootWorkspaceId, setNewThreadRootWorkspaceId] = useState("");
   const [newThreadEnvironment, setNewThreadEnvironment] = useState<NewThreadEnvironment>("local");
@@ -368,6 +370,10 @@ export default function App() {
   const extensionsCommandCompatibility = extensionsWorkspace
     ? snapshot?.extensionCommandCompatibilityByWorkspace[extensionsWorkspace.id] ?? []
     : [];
+  const packagesWorkspace = packagesWorkspaceId
+    ? rootWorkspaceOptions.find((workspace) => workspace.id === packagesWorkspaceId)
+    : undefined;
+  const packagesRuntime = packagesWorkspace ? snapshot?.runtimeByWorkspace[packagesWorkspace.id] : undefined;
   const newThreadWorkspace =
     rootWorkspaceOptions.find((entry) => entry.id === newThreadRootWorkspaceId) ?? rootWorkspaceOptions[0];
   const newThreadRuntime = snapshot ? getEffectiveModelRuntime(snapshot, newThreadWorkspace) : undefined;
@@ -1106,6 +1112,7 @@ export default function App() {
       setSettingsWorkspaceId("");
       setSkillsWorkspaceId("");
       setExtensionsWorkspaceId("");
+      setPackagesWorkspaceId("");
       setPendingNewThreadWorkspaceId("");
       setNewThreadRootWorkspaceId("");
       setNewThreadEnvironment("local");
@@ -1119,6 +1126,9 @@ export default function App() {
       rootWorkspaceOptions.some((workspace) => workspace.id === current) ? current : (current || rootWorkspaceOptions[0]?.id || ""),
     );
     setExtensionsWorkspaceId((current) =>
+      rootWorkspaceOptions.some((workspace) => workspace.id === current) ? current : (current || rootWorkspaceOptions[0]?.id || ""),
+    );
+    setPackagesWorkspaceId((current) =>
       rootWorkspaceOptions.some((workspace) => workspace.id === current) ? current : (current || rootWorkspaceOptions[0]?.id || ""),
     );
     setNewThreadRootWorkspaceId((current) =>
@@ -1650,6 +1660,17 @@ export default function App() {
       setExtensionsWorkspaceId(nextWorkspaceId);
     }
     setActiveView("extensions");
+  };
+
+  const openPackages = (workspaceId?: string) => {
+    const nextWorkspaceId =
+      workspaceId && rootWorkspaceOptions.some((workspace) => workspace.id === workspaceId)
+        ? workspaceId
+        : packagesWorkspace?.id || rootWorkspaceOptions[0]?.id || "";
+    if (nextWorkspaceId) {
+      setPackagesWorkspaceId(nextWorkspaceId);
+    }
+    setActiveView("packages");
   };
 
   const openNewThreadSurface = (workspaceId?: string) => {
@@ -2459,6 +2480,38 @@ export default function App() {
     );
   }
 
+  if (snapshot.activeView === "packages") {
+    return (
+      <SecondarySurface onBack={() => setActiveView("threads")} testId="packages-surface" title="Packages">
+        <div className="surface-toolbar">
+          <label className="surface-toolbar__field">
+            <span>Workspace</span>
+            <select
+              value={packagesWorkspace?.id ?? ""}
+              onChange={(event) => setPackagesWorkspaceId(event.target.value)}
+            >
+              {rootWorkspaceOptions.map((workspace) => (
+                <option key={workspace.id} value={workspace.id}>
+                  {workspace.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <PackagesView
+          workspace={packagesWorkspace}
+          runtime={packagesRuntime}
+          onRefresh={() => {
+            if (!packagesWorkspace) {
+              return;
+            }
+            void updateSnapshot(api, setSnapshot, () => api.refreshRuntime(packagesWorkspace.id));
+          }}
+        />
+      </SecondarySurface>
+    );
+  }
+
   const shellClassName = `shell${snapshot.sidebarCollapsed ? " shell--sidebar-collapsed" : ""}`;
 
   return (
@@ -2487,6 +2540,7 @@ export default function App() {
           onSetActiveView={setActiveView}
           onOpenSkills={openSkills}
           onOpenExtensions={openExtensions}
+          onOpenPackages={openPackages}
           onOpenSettings={openSettings}
           onArchiveSession={handleArchiveSession}
           onSelectSession={handleSelectSession}

--- a/apps/desktop/src/desktop-state.ts
+++ b/apps/desktop/src/desktop-state.ts
@@ -4,7 +4,7 @@ export type SessionStatus = "idle" | "running" | "failed";
 export type { SessionRole, TimelineToolCall, TranscriptMessage } from "./timeline-types";
 import type { TranscriptMessage } from "./timeline-types";
 
-export type AppView = "threads" | "new-thread" | "skills" | "extensions" | "settings";
+export type AppView = "threads" | "new-thread" | "skills" | "extensions" | "packages" | "settings";
 export type WorkspaceKind = "primary" | "worktree";
 export type WorktreeStatus = "ready" | "missing" | "error";
 export type NewThreadEnvironment = "local" | "worktree";
@@ -283,6 +283,22 @@ export interface RemoveWorktreeInput {
   readonly worktreeId: string;
 }
 
+export type PackageKind = "npm" | "git" | "local";
+export type PackageScope = "user" | "project";
+
+export interface PackageRecord {
+  readonly source: string;
+  readonly kind: PackageKind;
+  readonly displayName: string;
+  readonly description?: string;
+  readonly scope: PackageScope;
+  readonly enabled: boolean;
+  readonly extensionCount: number;
+  readonly skillCount: number;
+  readonly promptCount: number;
+  readonly themeCount: number;
+}
+
 export interface DesktopAppState {
   readonly workspaces: readonly WorkspaceRecord[];
   readonly worktreesByWorkspace: Readonly<Record<string, readonly WorktreeRecord[]>>;
@@ -296,6 +312,7 @@ export interface DesktopAppState {
   readonly queuedComposerMessages: readonly QueuedComposerMessage[];
   readonly editingQueuedMessageId?: string;
   readonly runtimeByWorkspace: Readonly<Record<string, RuntimeSnapshot>>;
+  readonly packagesByWorkspace: Readonly<Record<string, readonly PackageRecord[]>>;
   readonly sessionCommandsBySession: Readonly<Record<string, readonly RuntimeCommandRecord[]>>;
   readonly sessionExtensionUiBySession: Readonly<Record<string, SessionExtensionUiStateRecord>>;
   readonly extensionCommandCompatibilityByWorkspace: Readonly<Record<string, readonly ExtensionCommandCompatibilityRecord[]>>;
@@ -339,6 +356,7 @@ export function createEmptyDesktopAppState(): DesktopAppState {
     composerAttachments: [],
     queuedComposerMessages: [],
     runtimeByWorkspace: {},
+    packagesByWorkspace: {},
     sessionCommandsBySession: {},
     sessionExtensionUiBySession: {},
     extensionCommandCompatibilityByWorkspace: {},

--- a/apps/desktop/src/icons.tsx
+++ b/apps/desktop/src/icons.tsx
@@ -381,3 +381,16 @@ export function DiffIcon() {
     </Icon>
   );
 }
+
+export function PackageIcon() {
+  return (
+    <Icon>
+      <path
+        d="M5.2 3.8h9.6a1.4 1.4 0 0 1 1.4 1.4v9.6a1.4 1.4 0 0 1-1.4 1.4H5.2a1.4 1.4 0 0 1-1.4-1.4V5.2a1.4 1.4 0 0 1 1.4-1.4Z"
+        stroke="currentColor"
+        strokeWidth="1.35"
+      />
+      <path d="M4.8 8h10.4M10 3.8v12.4" stroke="currentColor" strokeWidth="1.35" />
+    </Icon>
+  );
+}

--- a/apps/desktop/src/packages-view.tsx
+++ b/apps/desktop/src/packages-view.tsx
@@ -1,0 +1,307 @@
+import { useMemo, useState } from "react";
+import type { RuntimePackageRecord } from "@pi-gui/session-driver/runtime-types";
+import type { RuntimeSnapshot } from "@pi-gui/session-driver/runtime-types";
+import type { WorkspaceRecord } from "./desktop-state";
+import { RefreshIcon } from "./icons";
+
+type SortKey = "name" | "kind" | "scope" | "extensions" | "skills";
+
+interface PackagesViewProps {
+  readonly workspace?: WorkspaceRecord;
+  readonly runtime?: RuntimeSnapshot;
+  readonly onRefresh: () => void;
+}
+
+export function PackagesView({
+  workspace,
+  runtime,
+  onRefresh,
+}: PackagesViewProps) {
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("name");
+  const [selectedPackageSource, setSelectedPackageSource] = useState<string | undefined>();
+
+  const packages = runtime?.packages ?? [];
+
+  const filteredPackages = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    let results = normalized
+      ? packages.filter((pkg) =>
+          [pkg.displayName, pkg.source, pkg.kind, pkg.scope, pkg.description]
+            .some((value) => value?.toLowerCase().includes(normalized)),
+        )
+      : [...packages];
+
+    results.sort((left, right) => {
+      switch (sortKey) {
+        case "name":
+          return left.displayName.localeCompare(right.displayName);
+        case "kind":
+          return left.kind.localeCompare(right.kind) || left.displayName.localeCompare(right.displayName);
+        case "scope":
+          return left.scope.localeCompare(right.scope) || left.displayName.localeCompare(right.displayName);
+        case "extensions":
+          return (
+            right.extensionCount - left.extensionCount ||
+            left.displayName.localeCompare(right.displayName)
+          );
+        case "skills":
+          return (
+            right.skillCount - left.skillCount ||
+            left.displayName.localeCompare(right.displayName)
+          );
+        default:
+          return 0;
+      }
+    });
+
+    return results;
+  }, [packages, query, sortKey]);
+
+  const selectedPackage =
+    filteredPackages.find((pkg) => pkg.source === selectedPackageSource) ?? filteredPackages[0];
+
+  if (!workspace) {
+    return (
+      <section className="canvas canvas--empty">
+        <div className="empty-panel">
+          <div className="session-header__eyebrow">Packages</div>
+          <h1>Select a workspace</h1>
+          <p>Packages are loaded from user and project settings. Select a workspace to browse them.</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="canvas">
+      <div className="conversation skills-view">
+        <header className="view-header">
+          <div>
+            <div className="chat-header__eyebrow">Packages</div>
+            <h1 className="view-header__title">Packages</h1>
+            <p className="view-header__body">
+              Installed pi packages that contribute extensions, skills, prompt templates, and themes.
+            </p>
+          </div>
+          <div className="view-header__actions">
+            <button className="button button--secondary" type="button" onClick={onRefresh}>
+              <RefreshIcon />
+              <span>Refresh</span>
+            </button>
+          </div>
+        </header>
+
+        <div className="skills-toolbar">
+          <input
+            aria-label="Search packages"
+            className="skills-search"
+            placeholder="Search packages by name, source, or kind"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+            }}
+          />
+          <SortSelector sortKey={sortKey} onSortChange={setSortKey} />
+        </div>
+
+        <div className="skills-layout">
+          <div className="skills-grid" data-testid="packages-list">
+            {filteredPackages.length === 0 ? (
+              <PackagesEmptyState message="No installed packages found. Install packages with pi install from npm or git." />
+            ) : (
+              filteredPackages.map((pkg) => (
+                <button
+                  className={`skill-card ${selectedPackage?.source === pkg.source ? "skill-card--active" : ""}`}
+                  key={pkg.source}
+                  type="button"
+                  onClick={() => {
+                    setSelectedPackageSource(pkg.source);
+                  }}
+                >
+                  <span className="skill-card__title-row">
+                    <span className="skill-card__title">{pkg.displayName}</span>
+                    <span className="skill-card__badge skill-card__badge--enabled">
+                      Installed
+                    </span>
+                  </span>
+                  <span className="skill-card__description">{pkg.source}</span>
+                  <span className="skill-card__meta">
+                    <span>{pkg.kind}</span>
+                    <span>{pkg.scope}</span>
+                    <PackageCountLabel pkg={pkg} />
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+
+          <div className="skill-detail">
+            {selectedPackage ? (
+              <>
+                <div className="skill-detail__header">
+                  <div>
+                    <h2>{selectedPackage.displayName}</h2>
+                    <div className="skill-detail__slash">{selectedPackage.source}</div>
+                  </div>
+                </div>
+                <div className="skill-detail__meta-list">
+                  <PackageDetailItem label="Kind" value={kindLabel(selectedPackage.kind)} />
+                  <PackageDetailItem label="Scope" value={scopeLabel(selectedPackage.scope)} />
+                  <PackageDetailItem label="Source" value={selectedPackage.source} mono />
+                </div>
+                <div className="skill-detail__meta-list">
+                  <PackageDetailItem
+                    label="Resources contributed"
+                    value={contributedSummary(selectedPackage)}
+                  />
+                </div>
+                {selectedPackage.extensionCount > 0 ? (
+                  <div className="skill-detail__meta-list">
+                    <div>
+                      <div className="skill-detail__meta-label">Extensions</div>
+                      <div className="skill-detail__description">
+                        {selectedPackage.extensionCount} extension{selectedPackage.extensionCount !== 1 ? "s" : ""}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                {selectedPackage.skillCount > 0 ? (
+                  <div className="skill-detail__meta-list">
+                    <div>
+                      <div className="skill-detail__meta-label">Skills</div>
+                      <div className="skill-detail__description">
+                        {selectedPackage.skillCount} skill{selectedPackage.skillCount !== 1 ? "s" : ""}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                {selectedPackage.promptCount > 0 ? (
+                  <div className="skill-detail__meta-list">
+                    <div>
+                      <div className="skill-detail__meta-label">Prompt templates</div>
+                      <div className="skill-detail__description">
+                        {selectedPackage.promptCount} template{selectedPackage.promptCount !== 1 ? "s" : ""}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                {selectedPackage.themeCount > 0 ? (
+                  <div className="skill-detail__meta-list">
+                    <div>
+                      <div className="skill-detail__meta-label">Themes</div>
+                      <div className="skill-detail__description">
+                        {selectedPackage.themeCount} theme{selectedPackage.themeCount !== 1 ? "s" : ""}
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+                <div className="skill-detail__actions">
+                  <button className="button button--secondary" type="button" disabled>
+                    Manage in terminal
+                  </button>
+                </div>
+              </>
+            ) : (
+              <PackagesEmptyState message="Select a package to view details about its installed resources." />
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PackageCountLabel({ pkg }: { readonly pkg: RuntimePackageRecord }) {
+  const parts: string[] = [];
+  if (pkg.extensionCount > 0) parts.push(`${pkg.extensionCount} ext`);
+  if (pkg.skillCount > 0) parts.push(`${pkg.skillCount} skill`);
+  if (parts.length === 0) parts.push("No resources");
+  return <span>{parts.join(", ")}</span>;
+}
+
+function contributedSummary(pkg: RuntimePackageRecord): string {
+  const parts: string[] = [];
+  if (pkg.extensionCount > 0) parts.push(`${pkg.extensionCount} extension${pkg.extensionCount !== 1 ? "s" : ""}`);
+  if (pkg.skillCount > 0) parts.push(`${pkg.skillCount} skill${pkg.skillCount !== 1 ? "s" : ""}`);
+  if (pkg.promptCount > 0) parts.push(`${pkg.promptCount} prompt template${pkg.promptCount !== 1 ? "s" : ""}`);
+  if (pkg.themeCount > 0) parts.push(`${pkg.themeCount} theme${pkg.themeCount !== 1 ? "s" : ""}`);
+  return parts.length > 0 ? parts.join(", ") : "No resources contributed";
+}
+
+function kindLabel(kind: RuntimePackageRecord["kind"]): string {
+  switch (kind) {
+    case "npm":
+      return "npm";
+    case "git":
+      return "Git";
+    case "local":
+      return "Local";
+  }
+}
+
+function scopeLabel(scope: RuntimePackageRecord["scope"]): string {
+  return scope === "user" ? "User (global)" : "Project (local)";
+}
+
+function PackageDetailItem({
+  label,
+  value,
+  mono,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly mono?: boolean;
+}) {
+  return (
+    <div>
+      <div className="skill-detail__meta-label">{label}</div>
+      <div className={mono ? "skill-detail__path" : "skill-detail__description"}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SortSelector({
+  sortKey,
+  onSortChange,
+}: {
+  readonly sortKey: SortKey;
+  readonly onSortChange: (key: SortKey) => void;
+}) {
+  const options: { key: SortKey; label: string }[] = [
+    { key: "name", label: "Name" },
+    { key: "kind", label: "Kind" },
+    { key: "scope", label: "Scope" },
+    { key: "extensions", label: "Extensions" },
+    { key: "skills", label: "Skills" },
+  ];
+
+  return (
+    <div className="package-sort">
+      <span className="package-sort__label">Sort:</span>
+      <div className="package-sort__pills">
+        {options.map((option) => (
+          <button
+            key={option.key}
+            className={`package-sort__pill ${sortKey === option.key ? "package-sort__pill--active" : ""}`}
+            type="button"
+            onClick={() => onSortChange(option.key)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PackagesEmptyState({ message }: { readonly message: string }) {
+  return (
+    <div className="empty-state">
+      <h2>No packages found</h2>
+      <p>{message}</p>
+    </div>
+  );
+}

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -14,7 +14,7 @@ import {
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { AppView, SessionRecord, WorkspaceRecord, WorktreeRecord } from "./desktop-state";
-import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, PinIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
+import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, PackageIcon, PinIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
 import type { PiDesktopApi } from "./ipc";
 import { formatRelativeTime } from "./string-utils";
 import type { WorkspaceMenuState } from "./hooks/use-workspace-menu";
@@ -42,6 +42,7 @@ interface SidebarProps {
   readonly onSetActiveView: (view: AppView) => void;
   readonly onOpenSkills: (workspaceId?: string) => void;
   readonly onOpenExtensions: (workspaceId?: string) => void;
+  readonly onOpenPackages: (workspaceId?: string) => void;
   readonly onOpenSettings: (workspaceId?: string) => void;
   readonly onArchiveSession: (target: { workspaceId: string; sessionId: string }) => void;
   readonly onSelectSession: (target: { workspaceId: string; sessionId: string }) => void;
@@ -66,6 +67,7 @@ export function Sidebar(props: SidebarProps) {
     onSetActiveView,
     onOpenSkills,
     onOpenExtensions,
+    onOpenPackages,
     onOpenSettings,
     onArchiveSession,
     onSelectSession,
@@ -200,6 +202,14 @@ export function Sidebar(props: SidebarProps) {
           >
             <ExtensionIcon />
             <span>Extensions</span>
+          </button>
+          <button
+            className="sidebar__nav-item"
+            type="button"
+            onClick={() => onOpenPackages(selectedWorkspace?.rootWorkspaceId ?? selectedWorkspace?.id)}
+          >
+            <PackageIcon />
+            <span>Packages</span>
           </button>
           <button
             className="sidebar__nav-item"

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -2895,11 +2895,55 @@
 }
 
 .skills-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
   margin-bottom: 16px;
 }
 
 .skills-search {
   width: min(360px, 100%);
+}
+
+.package-sort {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.package-sort__label {
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.package-sort__pills {
+  display: flex;
+  gap: 4px;
+}
+
+.package-sort__pill {
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 12px;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.package-sort__pill:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.package-sort__pill--active {
+  background: var(--accent-bg);
+  color: var(--accent-text);
+  border-color: var(--accent-bg);
 }
 
 .skills-layout {


### PR DESCRIPTION
## Summary

Adds a Packages surface accessible from the sidebar to browse and inspect installed pi packages. Displays package kind (npm/git/local), scope (user/project), contributed resource counts (extensions, skills, prompt templates, themes), and includes search/filter by name/source/kind and sort-by-column.

Also fixes Windows compatibility in dev.mjs (pnpm.cmd, shell mode).

## Changes

- apps/desktop/src/packages-view.tsx — New component: full package browser with search, sort pills, detail panel, and empty states
- apps/desktop/src/desktop-state.ts — Added PackageRecord type, packagesByWorkspace state, packages to AppView union
- apps/desktop/src/App.tsx — Added Packages view routing, workspace selector toolbar, openPackages handler, and refresh support
- apps/desktop/src/sidebar.tsx — Added Packages nav item with PackageIcon
- apps/desktop/src/icons.tsx — Added PackageIcon component
- apps/desktop/src/styles/main.css — Added package-sort pill CSS styles
- apps/desktop/scripts/dev.mjs — Windows compat: pnpm.cmd, shell mode

## Test plan

- Verify Packages nav item appears in sidebar
- Verify selecting a workspace populates the package list
- Verify search filters packages by name/source/kind
- Verify sort pills (Name, Kind, Scope, Extensions, Skills) reorder the list
- Verify selecting a package shows detail panel with resource breakdown
- Verify empty states render when no workspace selected or no packages installed
- Verify Refresh button triggers runtime refresh
- Verify dev.mjs works on Windows