### PR TITLE
Fix macOS test exit and slash command ordering

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1476,7 +1476,10 @@ app.whenReady().then(async () => {
 });
 
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
+  // macOS normally keeps the app alive after its final window closes. The
+  // Electron harness closes windows to end each isolated run, so let explicit
+  // test-mode launches quit instead of leaving their process behind forever.
+  if (process.platform !== "darwin" || process.env.PI_APP_TEST_MODE !== undefined) {
     stopNotifications?.();
     stopNotifications = undefined;
     notificationManager = undefined;

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -62,7 +62,8 @@ import type { GenerateThreadTitleOptions } from "@pi-gui/pi-sdk-driver";
 import type { SessionRef, WorkspaceRef } from "@pi-gui/session-driver";
 
 const isDev = Boolean(process.env.ELECTRON_RENDERER_URL);
-const windowTestMode = resolveWindowTestMode();
+const appTestMode = resolveAppTestMode(process.env.PI_APP_TEST_MODE);
+const windowTestMode = appTestMode ?? "foreground";
 const devReloadMarkersEnabled = process.env.PI_APP_DEV_RELOAD_MARKERS === "1";
 let store: DesktopAppStore;
 const themeManager = new ThemeManager();
@@ -800,8 +801,8 @@ function canPublishToWindow(window: BrowserWindow): boolean {
   return !window.isDestroyed() && !window.webContents.isDestroyed() && !window.webContents.isCrashed();
 }
 
-function resolveWindowTestMode(): "foreground" | "background" {
-  return process.env.PI_APP_TEST_MODE?.trim().toLowerCase() === "background" ? "background" : "foreground";
+function resolveAppTestMode(value: string | undefined): "foreground" | "background" | undefined {
+  return value === "foreground" || value === "background" ? value : undefined;
 }
 
 function resolveDialogWindow(parentWindow?: BrowserWindow | null): BrowserWindow | undefined {
@@ -1479,7 +1480,7 @@ app.on("window-all-closed", () => {
   // macOS normally keeps the app alive after its final window closes. The
   // Electron harness closes windows to end each isolated run, so let explicit
   // test-mode launches quit instead of leaving their process behind forever.
-  if (process.platform !== "darwin" || process.env.PI_APP_TEST_MODE !== undefined) {
+  if (process.platform !== "darwin" || appTestMode !== undefined) {
     stopNotifications?.();
     stopNotifications = undefined;
     notificationManager = undefined;

--- a/apps/desktop/src/composer-commands.ts
+++ b/apps/desktop/src/composer-commands.ts
@@ -272,18 +272,24 @@ export function buildSlashCommandSections(
     (command) => (allowTreeCommand || command.kind !== "tree") && matchesCommand(command, normalizedQuery),
   );
 
-  const sections: ComposerSlashCommandSection[] = [
-    {
-      id: "runtime",
-      title: runtimeMatches.length > 0 ? "Runtime Commands" : undefined,
-      items: runtimeMatches,
-    },
-    {
-      id: "host",
-      title: hostMatches.length > 0 ? "Host Actions" : undefined,
-      items: hostMatches,
-  },
-];
+  // Prefer a host action when it is a prefix match and runtime skills only
+  // match fuzzily. Otherwise an installed skill such as `observe-state` can
+  // steal `/stat` from the built-in `/status` command on Tab.
+  const hostHasPrefixMatch = hostMatches.some((command) => command.command.startsWith(normalizedQuery));
+  const runtimeHasPrefixMatch = runtimeMatches.some((command) => command.command.startsWith(normalizedQuery));
+  const runtimeSection: ComposerSlashCommandSection = {
+    id: "runtime",
+    title: runtimeMatches.length > 0 ? "Runtime Commands" : undefined,
+    items: runtimeMatches,
+  };
+  const hostSection: ComposerSlashCommandSection = {
+    id: "host",
+    title: hostMatches.length > 0 ? "Host Actions" : undefined,
+    items: hostMatches,
+  };
+  const sections: ComposerSlashCommandSection[] = hostHasPrefixMatch && !runtimeHasPrefixMatch
+    ? [hostSection, runtimeSection]
+    : [runtimeSection, hostSection];
 
   return sections.filter((section) => section.items.length > 0);
 }

--- a/apps/desktop/src/composer-commands.ts
+++ b/apps/desktop/src/composer-commands.ts
@@ -275,8 +275,8 @@ export function buildSlashCommandSections(
   // Prefer a host action when it is a prefix match and runtime skills only
   // match fuzzily. Otherwise an installed skill such as `observe-state` can
   // steal `/stat` from the built-in `/status` command on Tab.
-  const hostHasPrefixMatch = hostMatches.some((command) => command.command.startsWith(normalizedQuery));
-  const runtimeHasPrefixMatch = runtimeMatches.some((command) => command.command.startsWith(normalizedQuery));
+const hostHasPrefixMatch = hostMatches.some((command) => command.command.toLowerCase().startsWith(normalizedQuery));
+const runtimeHasPrefixMatch = runtimeMatches.some((command) => command.command.toLowerCase().startsWith(normalizedQuery));
   const runtimeSection: ComposerSlashCommandSection = {
     id: "runtime",
     title: runtimeMatches.length > 0 ? "Runtime Commands" : undefined,

--- a/apps/desktop/src/composer-commands.ts
+++ b/apps/desktop/src/composer-commands.ts
@@ -275,8 +275,12 @@ export function buildSlashCommandSections(
   // Prefer a host action when it is a prefix match and runtime skills only
   // match fuzzily. Otherwise an installed skill such as `observe-state` can
   // steal `/stat` from the built-in `/status` command on Tab.
-const hostHasPrefixMatch = hostMatches.some((command) => command.command.toLowerCase().startsWith(normalizedQuery));
-const runtimeHasPrefixMatch = runtimeMatches.some((command) => command.command.toLowerCase().startsWith(normalizedQuery));
+  const hostHasPrefixMatch = hostMatches.some((command) =>
+    command.command.toLowerCase().startsWith(normalizedQuery),
+  );
+  const runtimeHasPrefixMatch = runtimeMatches.some((command) =>
+    command.command.toLowerCase().startsWith(normalizedQuery),
+  );
   const runtimeSection: ComposerSlashCommandSection = {
     id: "runtime",
     title: runtimeMatches.length > 0 ? "Runtime Commands" : undefined,
@@ -287,9 +291,10 @@ const runtimeHasPrefixMatch = runtimeMatches.some((command) => command.command.t
     title: hostMatches.length > 0 ? "Host Actions" : undefined,
     items: hostMatches,
   };
-  const sections: ComposerSlashCommandSection[] = hostHasPrefixMatch && !runtimeHasPrefixMatch
-    ? [hostSection, runtimeSection]
-    : [runtimeSection, hostSection];
+  const sections: ComposerSlashCommandSection[] =
+    hostHasPrefixMatch && !runtimeHasPrefixMatch
+      ? [hostSection, runtimeSection]
+      : [runtimeSection, hostSection];
 
   return sections.filter((section) => section.items.length > 0);
 }

--- a/apps/desktop/tests/core/app-lifecycle.spec.ts
+++ b/apps/desktop/tests/core/app-lifecycle.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+import {
+  launchDesktop,
+  makeUserDataDir,
+  type DesktopHarness,
+} from "../helpers/electron-app";
+
+const VALID_TEST_MODES = ["background", "foreground"] as const;
+const NORMAL_LIFECYCLE_CASES = [
+  { label: "unset", value: undefined },
+  { label: "empty", value: "" },
+  { label: "invalid", value: "unsupported" },
+] as const;
+const STAYS_OPEN_ASSERTION_MS = 750;
+
+async function launchLifecycleApp(testMode: string | undefined): Promise<DesktopHarness> {
+  const userDataDir = await makeUserDataDir("pi-gui-lifecycle-");
+  const harness = await launchDesktop(userDataDir, {
+    envOverrides: { PI_APP_TEST_MODE: testMode },
+  });
+  await harness.firstWindow();
+  return harness;
+}
+
+async function closeLastWindow(harness: DesktopHarness): Promise<void> {
+  await harness.electronApp.evaluate(({ BrowserWindow }) => {
+    const windows = BrowserWindow.getAllWindows();
+    if (windows.length !== 1) {
+      throw new Error(`Expected one app window before close, received ${windows.length}.`);
+    }
+    windows[0]?.close();
+  });
+}
+
+async function appClosesWithin(harness: DesktopHarness, timeoutMs: number): Promise<boolean> {
+  return Promise.race([
+    harness.electronApp.waitForEvent("close").then(() => true),
+    new Promise<false>((resolve) => {
+      setTimeout(() => resolve(false), timeoutMs);
+    }),
+  ]);
+}
+
+async function quitDesktop(harness: DesktopHarness): Promise<void> {
+  const closed = harness.electronApp.waitForEvent("close");
+  await harness.electronApp.evaluate(({ app }) => app.quit());
+  await closed;
+}
+
+test.describe("macOS last-window lifecycle", () => {
+  test.skip(process.platform !== "darwin", "macOS keeps a normal app alive after its last window closes.");
+
+  for (const mode of VALID_TEST_MODES) {
+    test(`quits after the last window closes in ${mode} test mode`, async () => {
+      test.setTimeout(30_000);
+      const harness = await launchLifecycleApp(mode);
+      let appClosed = false;
+      harness.electronApp.on("close", () => {
+        appClosed = true;
+      });
+
+      try {
+        const closed = harness.electronApp.waitForEvent("close");
+        await closeLastWindow(harness);
+        await closed;
+      } finally {
+        if (!appClosed) {
+          await quitDesktop(harness);
+        }
+      }
+    });
+  }
+
+  for (const { label, value } of NORMAL_LIFECYCLE_CASES) {
+    test(`retains normal behavior when PI_APP_TEST_MODE is ${label}`, async () => {
+      test.setTimeout(30_000);
+      const harness = await launchLifecycleApp(value);
+      let appClosed = false;
+      harness.electronApp.on("close", () => {
+        appClosed = true;
+      });
+
+      try {
+        await closeLastWindow(harness);
+        expect(await appClosesWithin(harness, STAYS_OPEN_ASSERTION_MS)).toBe(false);
+        expect(
+          await harness.electronApp.evaluate(({ app, BrowserWindow }) => ({
+            appReady: app.isReady(),
+            windowCount: BrowserWindow.getAllWindows().length,
+          })),
+        ).toEqual({
+          appReady: true,
+          windowCount: 0,
+        });
+
+        const reopenedWindow = harness.electronApp.waitForEvent("window");
+        await harness.electronApp.evaluate(({ app }) => {
+          app.emit("activate");
+        });
+        await expect(await reopenedWindow).toHaveURL(/index\.html/);
+      } finally {
+        if (!appClosed) {
+          await quitDesktop(harness);
+        }
+      }
+    });
+  }
+});

--- a/apps/desktop/tests/core/composer-controls.spec.ts
+++ b/apps/desktop/tests/core/composer-controls.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   createNamedThread,
@@ -35,12 +36,26 @@ function contrastRatio(foreground: string, background: string): number {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+async function seedFuzzyStatusSkill(workspacePath: string): Promise<void> {
+  const skillDir = join(workspacePath, ".agents", "skills", "observe-state");
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    join(skillDir, "SKILL.md"),
+    `# Observe State
+
+Inspect the current application state.
+`,
+    "utf8",
+  );
+}
+
 test("supports keyboard shortcuts, slash menus, and topbar controls through the user surface", async () => {
   test.setTimeout(60_000);
   const userDataDir = await makeUserDataDir();
   const agentDir = join(userDataDir, "agent");
   const workspacePath = await makeWorkspace("controls-workspace");
   await seedAgentDir(agentDir);
+  await seedFuzzyStatusSkill(workspacePath);
   const harness = await launchDesktop(userDataDir, {
     agentDir,
     initialWorkspaces: [workspacePath],
@@ -69,6 +84,9 @@ test("supports keyboard shortcuts, slash menus, and topbar controls through the 
     const slashMenu = window.getByTestId("slash-menu");
     await expect(slashMenu).toBeVisible();
     await expect(slashMenu).toContainText("Status");
+    await expect(slashMenu).toContainText("Observe State");
+    await expect(slashMenu).toContainText("/skill:observe-state");
+    await expect(slashMenu.locator(".slash-menu__item").first()).toContainText("/status");
     const slashMenuBox = await slashMenu.boundingBox();
     const composerBox = await composer.boundingBox();
     expect(slashMenuBox).not.toBeNull();


### PR DESCRIPTION
Update the Electron window-all-closed handler to quit on macOS when `PI_APP_TEST_MODE` is set, preventing test runs from leaving background processes alive. In composer slash command sections, reorder host/runtime sections when host has a prefix match and runtime does not, so built-in host commands like `/status` are preferred over fuzzy runtime skill matches.

Result

 The app now builds and launches on the real Electron surface.

  Fixed:

  - Repaired the stale pnpm workspace install and Electron runtime payload.
  - Fixed test-mode macOS shutdown so Electron tests exit cleanly.
  - Fixed slash-command ranking: /stat now selects built-in /status over fuzzy-matched skills.

  Verified:

  - pnpm build passes.
  - Desktop typecheck passes.
  - Electron smoke passes end-to-end.
  - Core Electron lane: 108/111 passed; after the slash fix, its two command failures pass.