### PR TITLE
fix: keep custom endpoint actions reachable with long model lists

### DIFF
--- a/apps/desktop/src/settings-custom-endpoints-section.tsx
+++ b/apps/desktop/src/settings-custom-endpoints-section.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { CUSTOM_PROVIDER_ID_PATTERN, isValidHttpBaseUrl } from "@pi-gui/pi-sdk-driver/custom-provider-types";
+import { trapDialogFocus } from "./dialog-focus";
 import type { CustomProviderConfig, CustomProviderModelConfig } from "./ipc";
 import { SettingsGroup } from "./settings-utils";
 
@@ -148,6 +149,7 @@ interface CustomEndpointDialogProps {
 }
 
 function CustomEndpointDialog({ mode, existingProviderIds, onClose, onSave }: CustomEndpointDialogProps) {
+  const titleId = useId();
   const initial = mode.kind === "edit" ? mode.original : undefined;
   const [providerId, setProviderId] = useState(initial?.providerId ?? "");
   const [baseUrl, setBaseUrl] = useState(initial?.baseUrl ?? "");
@@ -160,6 +162,9 @@ function CustomEndpointDialog({ mode, existingProviderIds, onClose, onSave }: Cu
   const [probePending, setProbePending] = useState(false);
   const [formError, setFormError] = useState<string | undefined>();
   const [savePending, setSavePending] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const probeButtonRef = useRef<HTMLButtonElement>(null);
+  const restoreProbeFocusRef = useRef(false);
 
   const selectedModelIds = useMemo(() => new Set(models.map((model) => model.id)), [models]);
   const isEdit = mode.kind === "edit";
@@ -169,6 +174,13 @@ function CustomEndpointDialog({ mode, existingProviderIds, onClose, onSave }: Cu
     existingProviderIds,
     initial?.providerId,
   ]);
+
+  useEffect(() => {
+    if (!probePending && restoreProbeFocusRef.current) {
+      restoreProbeFocusRef.current = false;
+      probeButtonRef.current?.focus();
+    }
+  }, [probePending]);
 
   const handleProbe = async () => {
     const api = window.piApp;
@@ -180,6 +192,7 @@ function CustomEndpointDialog({ mode, existingProviderIds, onClose, onSave }: Cu
       setProbeError("Base URL must start with http:// or https://");
       return;
     }
+    restoreProbeFocusRef.current = document.activeElement === probeButtonRef.current;
     setProbePending(true);
     setProbeError(undefined);
     const result = await api.probeCustomProviderModels({
@@ -248,111 +261,126 @@ function CustomEndpointDialog({ mode, existingProviderIds, onClose, onSave }: Cu
   return (
     <div className="extension-dialog-backdrop">
       <div
-        className="extension-dialog"
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="extension-dialog custom-endpoint-dialog"
         data-testid="custom-endpoint-dialog"
         onKeyDown={(event) => {
           if (event.key === "Escape" && !savePending) {
             event.preventDefault();
             onClose();
+            return;
+          }
+          if (event.key === "Tab") {
+            trapDialogFocus(event, dialogRef.current);
           }
         }}
+        ref={dialogRef}
+        role="dialog"
       >
-        <div className="extension-dialog__title">{isEdit ? "Edit custom endpoint" : "Add custom endpoint"}</div>
-        <p className="extension-dialog__body">
-          Configure an OpenAI-compatible server. The endpoint and API key are stored in plaintext at
-          <code> ~/.pi/agent/models.json</code>.
-        </p>
-        <label className="settings-field">
-          <span>Provider ID</span>
-          <input
-            aria-label="Provider ID"
-            autoFocus={!isEdit}
-            className="settings-search"
-            disabled={isEdit || savePending}
-            placeholder="ollama-local"
-            value={providerId}
-            onChange={(event) => setProviderId(event.target.value.trim().toLowerCase())}
-          />
-          {idValidationError ? (
-            <span className="settings-row__description settings-warning">{idValidationError}</span>
-          ) : (
-            <span className="settings-row__description">
-              Lowercase letters, digits, and dashes. Cannot be changed later.
-            </span>
-          )}
-        </label>
-        <label className="settings-field">
-          <span>Base URL</span>
-          <input
-            aria-label="Base URL"
-            className="settings-search"
-            disabled={savePending}
-            placeholder="http://localhost:11434/v1"
-            value={baseUrl}
-            onChange={(event) => setBaseUrl(event.target.value)}
-          />
-          <span className="settings-row__description">
-            Include the <code>/v1</code> suffix. Ollama: <code>http://localhost:11434/v1</code>. vLLM:{" "}
-            <code>http://localhost:8000/v1</code>.
-          </span>
-        </label>
-        <label className="settings-field">
-          <span>API key</span>
-          <input
-            aria-label="API key"
-            className="settings-search"
-            disabled={savePending}
-            placeholder="vLLM: pass through; Ollama: leave blank"
-            type="password"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-          />
-          <span className="settings-row__description">
-            Required by the storage format. For vLLM started with <code>--api-key</code>, enter that key. For Ollama
-            or other servers without auth, leave blank and a placeholder is saved.
-          </span>
-        </label>
-
-        <div className="settings-field">
-          <div className="settings-field__header">
-            <span>Models</span>
-            <button
-              className="button button--secondary"
-              disabled={probePending || savePending}
-              type="button"
-              onClick={() => void handleProbe()}
-            >
-              {probePending ? "Detecting…" : "Detect models"}
-            </button>
+        <div className="custom-endpoint-dialog__content" data-testid="custom-endpoint-dialog-content">
+          <div className="extension-dialog__title" id={titleId}>
+            {isEdit ? "Edit custom endpoint" : "Add custom endpoint"}
           </div>
-          {probeError ? (
-            <p className="settings-row__description settings-warning">{probeError}</p>
-          ) : null}
-          <ModelChecklist
-            probed={probeCandidates}
-            selected={models}
-            onToggle={toggleModel}
-            onManualAdd={handleManualAdd}
-            disabled={savePending}
-          />
-          <p className="settings-row__description">
-            Tool calling is required. Smaller models (&lt; 7B) often do not emit OpenAI-style function calls cleanly.
+          <p className="extension-dialog__body">
+            Configure an OpenAI-compatible server. The endpoint and API key are stored in plaintext at
+            <code> ~/.pi/agent/models.json</code>.
           </p>
+          <label className="settings-field">
+            <span>Provider ID</span>
+            <input
+              aria-label="Provider ID"
+              autoFocus={!isEdit}
+              className="settings-search"
+              disabled={isEdit || savePending}
+              placeholder="ollama-local"
+              value={providerId}
+              onChange={(event) => setProviderId(event.target.value.trim().toLowerCase())}
+            />
+            {idValidationError ? (
+              <span className="settings-row__description settings-warning">{idValidationError}</span>
+            ) : (
+              <span className="settings-row__description">
+                Lowercase letters, digits, and dashes. Cannot be changed later.
+              </span>
+            )}
+          </label>
+          <label className="settings-field">
+            <span>Base URL</span>
+            <input
+              aria-label="Base URL"
+              className="settings-search"
+              disabled={savePending}
+              placeholder="http://localhost:11434/v1"
+              value={baseUrl}
+              onChange={(event) => setBaseUrl(event.target.value)}
+            />
+            <span className="settings-row__description">
+              Include the <code>/v1</code> suffix. Ollama: <code>http://localhost:11434/v1</code>. vLLM:{" "}
+              <code>http://localhost:8000/v1</code>.
+            </span>
+          </label>
+          <label className="settings-field">
+            <span>API key</span>
+            <input
+              aria-label="API key"
+              className="settings-search"
+              disabled={savePending}
+              placeholder="vLLM: pass through; Ollama: leave blank"
+              type="password"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+            />
+            <span className="settings-row__description">
+              Required by the storage format. For vLLM started with <code>--api-key</code>, enter that key. For Ollama
+              or other servers without auth, leave blank and a placeholder is saved.
+            </span>
+          </label>
+
+          <div className="settings-field">
+            <div className="settings-field__header">
+              <span>Models</span>
+              <button
+                className="button button--secondary"
+                disabled={probePending || savePending}
+                ref={probeButtonRef}
+                type="button"
+                onClick={() => void handleProbe()}
+              >
+                {probePending ? "Detecting…" : "Detect models"}
+              </button>
+            </div>
+            {probeError ? (
+              <p className="settings-row__description settings-warning">{probeError}</p>
+            ) : null}
+            <ModelChecklist
+              probed={probeCandidates}
+              selected={models}
+              onToggle={toggleModel}
+              onManualAdd={handleManualAdd}
+              disabled={savePending}
+            />
+            <p className="settings-row__description">
+              Tool calling is required. Smaller models (&lt; 7B) often do not emit OpenAI-style function calls cleanly.
+            </p>
+          </div>
         </div>
 
-        {formError ? <p className="extension-dialog__body settings-warning">{formError}</p> : null}
-        <div className="extension-dialog__actions">
-          <button className="button button--secondary" disabled={savePending} type="button" onClick={onClose}>
-            Cancel
-          </button>
-          <button
-            className="button"
-            disabled={savePending || Boolean(idValidationError) || models.length === 0 || !baseUrl.trim()}
-            type="button"
-            onClick={() => void handleSave()}
-          >
-            {isEdit ? "Save changes" : "Add endpoint"}
-          </button>
+        <div className="custom-endpoint-dialog__footer" data-testid="custom-endpoint-dialog-footer">
+          {formError ? <p className="extension-dialog__body settings-warning">{formError}</p> : null}
+          <div className="extension-dialog__actions">
+            <button className="button button--secondary" disabled={savePending} type="button" onClick={onClose}>
+              Cancel
+            </button>
+            <button
+              className="button"
+              disabled={savePending || Boolean(idValidationError) || models.length === 0 || !baseUrl.trim()}
+              type="button"
+              onClick={() => void handleSave()}
+            >
+              {isEdit ? "Save changes" : "Add endpoint"}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/settings-custom-endpoints-section.tsx
+++ b/apps/desktop/src/settings-custom-endpoints-section.tsx
@@ -384,7 +384,7 @@ function ModelChecklist({ probed, selected, onToggle, onManualAdd, disabled }: M
           Click &ldquo;Detect models&rdquo; or type a model ID below to add one manually.
         </p>
       ) : (
-        <ul className="settings-list">
+        <ul className="settings-list custom-endpoint-model-list">
           {[...knownIds].sort((a, b) => a.localeCompare(b)).map((id) => (
             <li key={id} className="settings-row">
               <label className="settings-row__label">

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -2246,13 +2246,25 @@
 
 .extension-dialog {
   width: min(560px, 100%);
+  max-height: calc(100vh - 48px);
   display: grid;
   gap: 14px;
   padding: 22px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   border-radius: var(--radius-composer);
   background: var(--surface);
   border: 1px solid var(--line);
   box-shadow: var(--shadow-xl);
+}
+
+.custom-endpoint-model-list {
+  max-height: min(320px, 35vh);
+  margin: 0;
+  padding: 0 4px 0 0;
+  overflow-y: auto;
+  list-style: none;
+  scrollbar-gutter: stable;
 }
 
 .extension-dialog__title {

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -2246,25 +2246,51 @@
 
 .extension-dialog {
   width: min(560px, 100%);
-  max-height: calc(100vh - 48px);
   display: grid;
   gap: 14px;
   padding: 22px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
   border-radius: var(--radius-composer);
   background: var(--surface);
   border: 1px solid var(--line);
   box-shadow: var(--shadow-xl);
 }
 
-.custom-endpoint-model-list {
-  max-height: min(320px, 35vh);
-  margin: 0;
-  padding: 0 4px 0 0;
+.custom-endpoint-dialog {
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.custom-endpoint-dialog__content {
+  min-height: 0;
+  display: grid;
+  flex: 1 1 auto;
+  gap: 14px;
+  padding: 22px;
   overflow-y: auto;
-  list-style: none;
+  overscroll-behavior: contain;
   scrollbar-gutter: stable;
+}
+
+.custom-endpoint-model-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.custom-endpoint-dialog__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  display: grid;
+  flex: 0 0 auto;
+  gap: 10px;
+  padding: 14px 22px 18px;
+  border-top: 1px solid var(--line);
+  background: var(--surface);
 }
 
 .extension-dialog__title {

--- a/apps/desktop/tests/core/custom-endpoints.spec.ts
+++ b/apps/desktop/tests/core/custom-endpoints.spec.ts
@@ -1,3 +1,5 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
@@ -15,6 +17,36 @@ import {
 async function readModelsJson(agentDir: string): Promise<Record<string, unknown>> {
   const raw = await readFile(join(agentDir, "models.json"), "utf8");
   return JSON.parse(raw) as Record<string, unknown>;
+}
+
+async function startModelListServer(modelCount: number): Promise<{
+  readonly baseUrl: string;
+  readonly authorization: () => string | undefined;
+  readonly close: () => Promise<void>;
+}> {
+  let authorization: string | undefined;
+  const server = createServer((request, response) => {
+    authorization = request.headers.authorization;
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({
+      data: Array.from({ length: modelCount }, (_, index) => ({ id: `detected-model-${index + 1}` })),
+    }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    authorization: () => authorization,
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    }),
+  };
 }
 
 async function openProvidersSettings(window: Awaited<ReturnType<Awaited<ReturnType<typeof launchDesktop>>["firstWindow"]>>) {
@@ -271,5 +303,68 @@ test("custom endpoint dialog blocks colliding provider IDs and invalid base URLs
     await expect(customEndpoints).toContainText("No custom endpoints yet.");
   } finally {
     await harness.close();
+  }
+});
+
+test("custom endpoint dialog keeps long detected model lists and actions reachable", async () => {
+  test.setTimeout(60_000);
+  const modelServer = await startModelListServer(50);
+  const userDataDir = await makeUserDataDir();
+  const agentDir = join(userDataDir, "agent");
+  const workspacePath = await makeWorkspace("custom-endpoints-long-model-list-workspace");
+  await seedAgentDir(agentDir, { enabledModels: [] });
+
+  const harness = await launchDesktop(userDataDir, {
+    agentDir,
+    initialWorkspaces: [workspacePath],
+    scrubProviderEnv: true,
+    testMode: "background",
+  });
+
+  try {
+    const window = await harness.firstWindow();
+    await harness.electronApp.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0]?.setSize(900, 600);
+    });
+    await expect.poll(() => window.evaluate(() => window.innerHeight)).toBe(600);
+    await openProvidersSettings(window);
+
+    const customEndpoints = window.locator(".settings-section", {
+      has: window.locator(".settings-section__title", { hasText: "Custom endpoints" }),
+    });
+    await customEndpoints.getByRole("button", { name: "Add endpoint", exact: true }).click();
+
+    const dialog = window.getByTestId("custom-endpoint-dialog");
+    await dialog.getByLabel("Provider ID").fill("many-models");
+    await dialog.getByLabel("Base URL").fill(modelServer.baseUrl);
+    await dialog.getByLabel("API key").fill("test-api-key");
+    await dialog.getByRole("button", { name: "Detect models", exact: true }).click();
+
+    const modelList = dialog.locator(".custom-endpoint-model-list");
+    await expect(modelList.locator("li")).toHaveCount(50);
+    expect(modelServer.authorization()).toBe("Bearer test-api-key");
+    const layout = await dialog.evaluate((element) => {
+      const list = element.querySelector<HTMLElement>(".custom-endpoint-model-list");
+      const rect = element.getBoundingClientRect();
+      return {
+        dialogBottom: rect.bottom,
+        dialogTop: rect.top,
+        listClientHeight: list?.clientHeight ?? 0,
+        listScrollHeight: list?.scrollHeight ?? 0,
+        viewportHeight: window.innerHeight,
+      };
+    });
+    expect(layout.dialogTop).toBeGreaterThanOrEqual(23);
+    expect(layout.dialogBottom).toBeLessThanOrEqual(layout.viewportHeight - 23);
+    expect(layout.listScrollHeight).toBeGreaterThan(layout.listClientHeight);
+
+    await modelList.hover();
+    await window.mouse.wheel(0, 5_000);
+    await window.mouse.wheel(0, 5_000);
+    const addEndpoint = dialog.getByRole("button", { name: "Add endpoint", exact: true });
+    await expect(addEndpoint).toBeInViewport();
+  } finally {
+    await harness.close();
+    await modelServer.close();
   }
 });

--- a/apps/desktop/tests/core/custom-endpoints.spec.ts
+++ b/apps/desktop/tests/core/custom-endpoints.spec.ts
@@ -1,8 +1,8 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page, type Video } from "@playwright/test";
 import {
   desktopShortcut,
   getDesktopState,
@@ -54,6 +54,18 @@ async function openProvidersSettings(window: Awaited<ReturnType<Awaited<ReturnTy
   await expect(window.getByTestId("settings-surface")).toBeVisible();
   await window.getByRole("button", { name: "Providers", exact: true }).click();
   await expect(window.locator(".view-header__title")).toHaveText("Providers");
+}
+
+async function saveCustomEndpointProof(window: Page, proofDir: string | undefined, fileName: string): Promise<void> {
+  if (proofDir) {
+    await window.screenshot({ path: join(proofDir, fileName), fullPage: false });
+  }
+}
+
+async function saveCustomEndpointVideo(video: Video | null, proofDir: string | undefined): Promise<void> {
+  if (proofDir && video) {
+    await video.saveAs(join(proofDir, "custom-endpoint-keyboard-flow.webm"));
+  }
 }
 
 test("settings lets the user add, edit, and delete an OpenAI-compatible custom endpoint", async () => {
@@ -306,8 +318,12 @@ test("custom endpoint dialog blocks colliding provider IDs and invalid base URLs
   }
 });
 
-test("custom endpoint dialog keeps long detected model lists and actions reachable", async () => {
-  test.setTimeout(60_000);
+test("custom endpoint dialog supports a long-list keyboard flow with sticky actions", async () => {
+  test.setTimeout(90_000);
+  const proofDir = process.env.PI_APP_CUSTOM_ENDPOINT_PROOF_DIR?.trim();
+  if (proofDir) {
+    await mkdir(proofDir, { recursive: true });
+  }
   const modelServer = await startModelListServer(50);
   const userDataDir = await makeUserDataDir();
   const agentDir = join(userDataDir, "agent");
@@ -319,52 +335,148 @@ test("custom endpoint dialog keeps long detected model lists and actions reachab
     initialWorkspaces: [workspacePath],
     scrubProviderEnv: true,
     testMode: "background",
+    ...(proofDir
+      ? {
+          recordVideoDir: join(proofDir, "raw-video"),
+          recordVideoSize: { width: 900, height: 600 },
+        }
+      : {}),
   });
+  let video: Video | null = null;
 
   try {
     const window = await harness.firstWindow();
+    video = window.video();
     await harness.electronApp.evaluate(({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()[0]?.setSize(900, 600);
     });
-    await expect.poll(() => window.evaluate(() => window.innerHeight)).toBe(600);
+    await expect.poll(() => window.evaluate(() => ({
+      height: window.innerHeight,
+      width: window.innerWidth,
+    }))).toEqual({ height: 600, width: 900 });
     await openProvidersSettings(window);
 
     const customEndpoints = window.locator(".settings-section", {
       has: window.locator(".settings-section__title", { hasText: "Custom endpoints" }),
     });
-    await customEndpoints.getByRole("button", { name: "Add endpoint", exact: true }).click();
+    const openDialogButton = customEndpoints.getByRole("button", { name: "Add endpoint", exact: true });
+    await openDialogButton.click();
 
     const dialog = window.getByTestId("custom-endpoint-dialog");
+    const providerIdInput = dialog.getByLabel("Provider ID");
+    const cancelButton = dialog.getByRole("button", { name: "Cancel", exact: true });
+    await expect(providerIdInput).toBeFocused();
+    await providerIdInput.press("Shift+Tab");
+    await expect(cancelButton).toBeFocused();
+    await cancelButton.press("Tab");
+    await expect(providerIdInput).toBeFocused();
+    await window.keyboard.press("Escape");
+    await expect(dialog).toHaveCount(0);
+    await expect(customEndpoints).toContainText("No custom endpoints yet.");
+
+    await openDialogButton.click();
+    await expect(dialog.getByLabel("Provider ID")).toBeFocused();
+    await cancelButton.click();
+    await expect(dialog).toHaveCount(0);
+    await expect(customEndpoints).toContainText("No custom endpoints yet.");
+
+    await openDialogButton.click();
+    await expect(dialog.getByLabel("Provider ID")).toBeFocused();
     await dialog.getByLabel("Provider ID").fill("many-models");
     await dialog.getByLabel("Base URL").fill(modelServer.baseUrl);
     await dialog.getByLabel("API key").fill("test-api-key");
-    await dialog.getByRole("button", { name: "Detect models", exact: true }).click();
+    const addEndpointButton = dialog.getByRole("button", { name: "Add endpoint", exact: true });
+    await expect(addEndpointButton).toBeDisabled();
+    const detectModelsButton = dialog.getByRole("button", { name: "Detect models", exact: true });
+    await detectModelsButton.click();
 
     const modelList = dialog.locator(".custom-endpoint-model-list");
     await expect(modelList.locator("li")).toHaveCount(50);
     expect(modelServer.authorization()).toBe("Bearer test-api-key");
+    await expect(addEndpointButton).toBeDisabled();
+
     const layout = await dialog.evaluate((element) => {
+      const content = element.querySelector<HTMLElement>(".custom-endpoint-dialog__content");
+      const footer = element.querySelector<HTMLElement>(".custom-endpoint-dialog__footer");
       const list = element.querySelector<HTMLElement>(".custom-endpoint-model-list");
       const rect = element.getBoundingClientRect();
+      const scrollableElements = [...element.querySelectorAll<HTMLElement>("*")].filter((candidate) => {
+        const overflowY = getComputedStyle(candidate).overflowY;
+        return (overflowY === "auto" || overflowY === "scroll")
+          && candidate.scrollHeight > candidate.clientHeight + 1;
+      });
       return {
+        contentClientHeight: content?.clientHeight ?? 0,
+        contentIsOnlyScrollable: scrollableElements.length === 1 && scrollableElements[0] === content,
+        contentOverflowY: content ? getComputedStyle(content).overflowY : "",
+        contentScrollHeight: content?.scrollHeight ?? 0,
         dialogBottom: rect.bottom,
         dialogTop: rect.top,
+        footerPosition: footer ? getComputedStyle(footer).position : "",
         listClientHeight: list?.clientHeight ?? 0,
+        listOverflowY: list ? getComputedStyle(list).overflowY : "",
         listScrollHeight: list?.scrollHeight ?? 0,
+        scrollableElementCount: scrollableElements.length,
         viewportHeight: window.innerHeight,
       };
     });
     expect(layout.dialogTop).toBeGreaterThanOrEqual(23);
     expect(layout.dialogBottom).toBeLessThanOrEqual(layout.viewportHeight - 23);
-    expect(layout.listScrollHeight).toBeGreaterThan(layout.listClientHeight);
+    expect(layout.contentScrollHeight).toBeGreaterThan(layout.contentClientHeight);
+    expect(layout.contentOverflowY).toBe("auto");
+    expect(layout.footerPosition).toBe("sticky");
+    expect(layout.listScrollHeight).toBeLessThanOrEqual(layout.listClientHeight + 1);
+    expect(layout.listOverflowY).toBe("visible");
+    expect(layout.scrollableElementCount).toBe(1);
+    expect(layout.contentIsOnlyScrollable).toBe(true);
 
-    await modelList.hover();
-    await window.mouse.wheel(0, 5_000);
-    await window.mouse.wheel(0, 5_000);
-    const addEndpoint = dialog.getByRole("button", { name: "Add endpoint", exact: true });
-    await expect(addEndpoint).toBeInViewport();
+    await expect(detectModelsButton).toBeFocused();
+    await window.keyboard.press("Tab");
+    const firstDetectedModel = dialog.getByLabel("Enable detected-model-1", { exact: true });
+    await expect(firstDetectedModel).toBeFocused();
+    await saveCustomEndpointProof(window, proofDir, "01-long-model-list.png");
+    await window.keyboard.press("Space");
+    await expect(firstDetectedModel).toBeChecked();
+    await expect(addEndpointButton).toBeEnabled();
+    await expect(addEndpointButton).toHaveCSS("opacity", "1");
+    await saveCustomEndpointProof(window, proofDir, "02-keyboard-selection.png");
+
+    const content = dialog.getByTestId("custom-endpoint-dialog-content");
+    const footer = dialog.getByTestId("custom-endpoint-dialog-footer");
+    const footerBeforeScroll = await footer.boundingBox();
+    await content.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+    });
+    await expect.poll(() => content.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    const footerAfterScroll = await footer.boundingBox();
+    expect(footerBeforeScroll).not.toBeNull();
+    expect(footerAfterScroll).not.toBeNull();
+    expect(footerAfterScroll?.y).toBeCloseTo(footerBeforeScroll?.y ?? 0, 0);
+    await expect(addEndpointButton).toBeInViewport();
+    await saveCustomEndpointProof(window, proofDir, "03-sticky-actions.png");
+
+    await addEndpointButton.click();
+    await expect(dialog).toHaveCount(0);
+    const entryRow = customEndpoints.locator(".settings-row", {
+      has: window.locator(".settings-row__title", { hasText: /^many-models$/ }),
+    });
+    await expect(entryRow).toBeVisible();
+    await expect(entryRow).toContainText(modelServer.baseUrl);
+    await expect(entryRow).toContainText("1 model");
+
+    const savedModels = await readModelsJson(agentDir);
+    const savedProviders = savedModels.providers as Record<string, Record<string, unknown>>;
+    expect(savedProviders["many-models"]).toMatchObject({
+      api: "openai-completions",
+      apiKey: "test-api-key",
+      baseUrl: modelServer.baseUrl,
+      models: [{ id: "detected-model-1" }],
+      piGuiCustomEndpoint: true,
+    });
+    await saveCustomEndpointProof(window, proofDir, "04-final-added-endpoint.png");
   } finally {
     await harness.close();
+    await saveCustomEndpointVideo(video, proofDir);
     await modelServer.close();
   }
 });


### PR DESCRIPTION
Long detected-model lists could push Add endpoint and Cancel outside the viewport. This change constrains only the custom endpoint dialog, gives its content one scrollable area, and keeps its footer actions reachable. It also supports keyboard focus trapping, selection, Escape/Cancel, and manual model entry. After a slow detection response, focus returns to Detect models only if the user has not moved to another control.

Validation on current main (including #49): desktop build and typecheck passed; all five custom-endpoint Electron regression tests passed. Two additional visible Electron runs with test mode disabled verified the 50-model list at 900×600, keyboard selection, stationary actions during scrolling, saving the selected model, and preserving manual-entry focus during delayed detection. The focus regression was reproduced before the fix. Structured code review reported no actionable findings.

Original contributor commits are retained; the maintainer update adds the focus correction and its regression test.