### PR TITLE
Add AGENTS.md smoke marker for Cursor review check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,4 @@ These rules apply for the full session.
 ## Source Of Truth
 - Root `AGENTS.md` is the repo instruction source of truth.
 - Root `CLAUDE.md` should remain a symlink to `AGENTS.md`.
+- Cloud-agent smoke marker: leave this line so diffs/review can be checked end-to-end.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Tiny intentional change to root `AGENTS.md` so you can verify Cursor diffs / Agents Window review / cloud-agent PR flow end-to-end.

## Change
- Added one smoke-marker bullet under **Source Of Truth**.

## Computer-use e2e (same run)
No cloud provider keys on the VM (Ollama also segfaults here), so a local OpenAI-compatible stub on `:8787` was wired into `~/.pi/agent` as `stub/stub-smoketest`.

Electron UI driven with computer use:
1. **Message 1** — “Reply with only the uppercase word READY.” → transcript showed **READY**
2. **Message 2** — asked to spin up another thread via `create_child_thread` → tool ran (**done**), child thread(s) appeared in the sidebar, confirmation text shown

Artifacts: screenshots under the agent run (`e2e-message1-ready`, `e2e-message2-child-thread`).

## Notes
No product behavior change in the PR itself. Safe to close after the review/e2e check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a15b2035-f277-4a20-9837-c145518ba89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a15b2035-f277-4a20-9837-c145518ba89b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

