### PR TITLE
Fix context rail width under classic scrollbars

### DIFF
--- a/apps/desktop/electron/app-store-session-state.ts
+++ b/apps/desktop/electron/app-store-session-state.ts
@@ -2,6 +2,7 @@ import { sessionKey } from "@pi-gui/pi-sdk-driver";
 import type { SessionDriverEvent, SessionSnapshot } from "@pi-gui/session-driver";
 import type { DesktopAppState, SessionRecord, TranscriptMessage } from "../src/desktop-state";
 import { cloneTranscriptMessage, hasUnseenSessionUpdate, previewFromTranscript } from "./app-store-utils";
+import { NEW_THREAD_PLACEHOLDER_TITLE } from "./thread-title-constants";
 
 export function applySessionEventState(
   state: DesktopAppState,
@@ -55,9 +56,15 @@ export function updateSessionRecord(
 ): SessionRecord {
   const updatedAt = options.snapshot?.updatedAt ?? session.updatedAt;
   const nextStatus = options.status ?? options.snapshot?.status ?? session.status;
+  const snapshotTitle = options.snapshot?.title;
+  // Queued session events may predate a rename; the placeholder must not replace a resolved title.
+  const title =
+    snapshotTitle === NEW_THREAD_PLACEHOLDER_TITLE && session.title !== NEW_THREAD_PLACEHOLDER_TITLE
+      ? session.title
+      : snapshotTitle ?? session.title;
   return {
     ...session,
-    title: options.snapshot?.title ?? session.title,
+    title,
     updatedAt,
     lastViewedAt: options.lastViewedAt,
     archivedAt: options.snapshot?.archivedAt ?? session.archivedAt,

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -67,6 +67,9 @@
   min-height: 0;
   min-width: 0;
   flex-direction: column;
+  /* Preserve the 768px transcript measure beside the prompt rail when macOS
+   * uses classic 15px scrollbars instead of overlay scrollbars. */
+  width: min(927px, 100%);
 }
 
 .conversation--composer {

--- a/apps/desktop/src/styles/timeline.css
+++ b/apps/desktop/src/styles/timeline.css
@@ -139,10 +139,9 @@
 }
 
 /* The rail lives in the outer margin beside the reading column. It only earns
- * its space once the surface is wide enough to hold the full 768px measure plus
- * the rail (768 + 12 gap + 132 rail = 912); below that we drop it so the
- * transcript keeps its measure instead of getting squeezed. */
-@container timeline-surface (max-width: 911px) {
+ * its space once the surface can hold the 768px measure, a classic 15px macOS
+ * scrollbar, the 12px gap, and the 132px rail (927px total). */
+@container timeline-surface (max-width: 926px) {
   .timeline-context-rail {
     display: none;
   }

--- a/apps/desktop/tests/core/context-rail.spec.ts
+++ b/apps/desktop/tests/core/context-rail.spec.ts
@@ -1,4 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test, type Page } from "@playwright/test";
 import {
   createNamedThread,
   getDesktopState,
@@ -10,10 +12,37 @@ import {
 import { appendMessagesToSessionFile, sessionFilePathFromCatalog } from "../helpers/session-file";
 
 const TURN_COUNT = 6;
+const READING_MEASURE_PX = 768;
+const CLASSIC_SCROLLBAR_WIDTH_PX = 15;
+const RAIL_SURFACE_WIDTH_PX = 927;
+
+async function forceTimelineScrollbarWidth(window: Page, width: number): Promise<void> {
+  await window.evaluate((scrollbarWidth) => {
+    const attribute = "data-context-rail-scrollbar-proof";
+    const style = document.querySelector<HTMLStyleElement>(`style[${attribute}]`) ?? document.createElement("style");
+    style.setAttribute(attribute, "");
+    style.textContent = `.timeline-pane--thread::-webkit-scrollbar { width: ${scrollbarWidth}px; }`;
+    if (!style.isConnected) {
+      document.head.append(style);
+    }
+  }, width);
+  await expect
+    .poll(() =>
+      window.getByTestId("timeline-pane").evaluate((el) => {
+        const pane = el as HTMLElement;
+        return pane.offsetWidth - pane.clientWidth;
+      }),
+    )
+    .toBe(width);
+}
 
 test("context rail lists prompts and scrolls to a turn; timing markers render", async () => {
   test.setTimeout(120_000);
   const userDataDir = await makeUserDataDir();
+  const proofDir = process.env.PI_APP_CONTEXT_RAIL_PROOF_DIR?.trim();
+  if (proofDir) {
+    await mkdir(proofDir, { recursive: true });
+  }
   const workspacePath = await makeWorkspace("context-rail-workspace");
 
   const firstRun = await launchDesktop(userDataDir, {
@@ -66,11 +95,6 @@ test("context rail lists prompts and scrolls to a turn; timing markers render", 
     const items = window.getByTestId("timeline-context-rail-item");
     await expect(items).toHaveCount(TURN_COUNT);
 
-    // The rail sits in the outer margin: the transcript keeps its full 768px
-    // measure even while the rail is present beside it.
-    const measure = await window.getByTestId("transcript").evaluate((el) => (el as HTMLElement).clientWidth);
-    expect(measure).toBe(768);
-
     const pane = window.getByTestId("timeline-pane");
     // Start pinned at the bottom, then jump to the first prompt via the rail.
     await pane.evaluate((el) => {
@@ -87,6 +111,34 @@ test("context rail lists prompts and scrolls to a turn; timing markers render", 
     const firstPromptRow = window.locator('[data-message-id]', { hasText: "PROMPT 0 unique-marker-0" });
     await expect(firstPromptRow).toBeInViewport();
 
+    // The rail sits in the outer margin: the transcript keeps its full reading
+    // measure with both overlay-style and space-consuming classic scrollbars.
+    await forceTimelineScrollbarWidth(window, 0);
+    await expect(window.getByTestId("transcript")).toHaveJSProperty("clientWidth", READING_MEASURE_PX);
+    if (proofDir) {
+      await window.screenshot({ path: join(proofDir, "context-rail-overlay-scrollbar.png"), fullPage: false });
+    }
+
+    await forceTimelineScrollbarWidth(window, CLASSIC_SCROLLBAR_WIDTH_PX);
+    await expect(window.getByTestId("transcript")).toHaveJSProperty("clientWidth", READING_MEASURE_PX);
+    if (proofDir) {
+      await window.screenshot({ path: join(proofDir, "context-rail-classic-scrollbar.png"), fullPage: false });
+    }
+
+    const surface = window.locator(".timeline-surface");
+    await expect(surface).toHaveJSProperty("clientWidth", RAIL_SURFACE_WIDTH_PX);
+    const conversation = window.locator(".conversation--thread");
+    await conversation.evaluate((el, width) => {
+      (el as HTMLElement).style.width = `${width}px`;
+    }, RAIL_SURFACE_WIDTH_PX - 1);
+    await expect(surface).toHaveJSProperty("clientWidth", RAIL_SURFACE_WIDTH_PX - 1);
+    await expect(rail).toBeHidden();
+    await expect(window.getByTestId("transcript")).toHaveJSProperty("clientWidth", READING_MEASURE_PX);
+    await conversation.evaluate((el) => {
+      (el as HTMLElement).style.removeProperty("width");
+    });
+    await expect(rail).toBeVisible();
+
     // The topbar toggle hides the rail even on this wide viewport, while the
     // transcript keeps its 768px measure.
     await window.getByRole("button", { name: "Hide prompt navigation" }).click();
@@ -94,7 +146,7 @@ test("context rail lists prompts and scrolls to a turn; timing markers render", 
     const measureAfterHide = await window
       .getByTestId("transcript")
       .evaluate((el) => (el as HTMLElement).clientWidth);
-    expect(measureAfterHide).toBe(768);
+    expect(measureAfterHide).toBe(READING_MEASURE_PX);
   } finally {
     await run.close();
   }

--- a/apps/desktop/tests/core/context-rail.spec.ts
+++ b/apps/desktop/tests/core/context-rail.spec.ts
@@ -7,6 +7,7 @@ import {
   launchDesktop,
   makeUserDataDir,
   makeWorkspace,
+  waitForSelectedSessionReady,
   waitForWorkspaceByPath,
 } from "../helpers/electron-app";
 import { appendMessagesToSessionFile, sessionFilePathFromCatalog } from "../helpers/session-file";
@@ -58,6 +59,7 @@ test("context rail lists prompts and scrolls to a turn; timing markers render", 
     const state = await getDesktopState(window);
     workspaceId = state.selectedWorkspaceId;
     sessionId = state.selectedSessionId;
+    await waitForSelectedSessionReady(window, { workspaceId, sessionId });
   } finally {
     await firstRun.close();
   }
@@ -83,6 +85,7 @@ test("context rail lists prompts and scrolls to a turn; timing markers render", 
       BrowserWindow.getAllWindows()[0]?.setBounds({ x: 40, y: 40, width: 1500, height: 950 });
     });
     await waitForWorkspaceByPath(window, workspacePath);
+    await waitForSelectedSessionReady(window, { workspaceId, sessionId });
     await expect(window.getByTestId("transcript")).toBeVisible({ timeout: 15_000 });
 
     // Timing markers derived from the 8s prompt->answer spans.
@@ -159,6 +162,7 @@ test("context rail lists prompts and scrolls to a turn; timing markers render", 
       BrowserWindow.getAllWindows()[0]?.setBounds({ x: 40, y: 40, width: 1500, height: 950 });
     });
     await waitForWorkspaceByPath(window, workspacePath);
+    await waitForSelectedSessionReady(window, { workspaceId, sessionId });
     await expect(window.getByTestId("transcript")).toBeVisible({ timeout: 15_000 });
     await expect(window.getByTestId("timeline-context-rail")).toBeHidden();
 

--- a/apps/desktop/tests/core/multi-window.spec.ts
+++ b/apps/desktop/tests/core/multi-window.spec.ts
@@ -379,26 +379,33 @@ test("keeps sender dialog actions scoped without blocking another window", async
     });
     await waitForDelayedOpenDialog(harness);
 
-    const secondWindowIndex = await browserWindowIndexForPage(harness, secondWindow);
-    await harness.electronApp.evaluate(({ BrowserWindow }, index) => {
-      const targetWindow = BrowserWindow.getAllWindows()[index];
-      targetWindow?.show();
-      targetWindow?.focus();
-      targetWindow?.emit("focus");
-    }, secondWindowIndex);
+    const settlePick = async () => {
+      await resolveDelayedOpenDialog(harness);
+      await pickPromise;
+    };
+    try {
+      await Promise.race([
+        selectSessionViaIpc(secondWindow, "Attachment sender thread"),
+        secondWindow.waitForTimeout(2_000).then(() => {
+          throw new Error("Second window selection was blocked by the first window attachment dialog.");
+        }),
+      ]);
+      await expectSelected(secondWindow, workspacePath, "Attachment sender thread");
+      await selectSessionViaIpc(secondWindow, "Attachment focused thread");
+      await expectSelected(secondWindow, workspacePath, "Attachment focused thread");
 
-    await Promise.race([
-      selectSessionViaIpc(secondWindow, "Attachment sender thread"),
-      secondWindow.waitForTimeout(2_000).then(() => {
-        throw new Error("Second window selection was blocked by the first window attachment dialog.");
-      }),
-    ]);
-    await expectSelected(secondWindow, workspacePath, "Attachment sender thread");
-    await selectSessionViaIpc(secondWindow, "Attachment focused thread");
-    await expectSelected(secondWindow, workspacePath, "Attachment focused thread");
-
-    await resolveDelayedOpenDialog(harness);
-    await pickPromise;
+      const secondWindowIndex = await browserWindowIndexForPage(harness, secondWindow);
+      await harness.electronApp.evaluate(({ BrowserWindow }, index) => {
+        const targetWindow = BrowserWindow.getAllWindows()[index];
+        targetWindow?.show();
+        targetWindow?.focus();
+        targetWindow?.emit("focus");
+      }, secondWindowIndex);
+    } catch (error) {
+      await settlePick().catch(() => undefined);
+      throw error;
+    }
+    await settlePick();
 
     await expect.poll(async () => (await getDesktopState(firstWindow)).composerAttachments.map((entry) => entry.name)).toEqual([
       "sender-attachment.txt",

--- a/apps/desktop/tests/core/new-thread-auto-title.spec.ts
+++ b/apps/desktop/tests/core/new-thread-auto-title.spec.ts
@@ -14,6 +14,7 @@ import {
   setDeferredThreadTitleMode,
   startThreadViaIpc,
   waitForDeferredThreadTitleRequest,
+  waitForSelectedSessionReady,
   waitForSessionByTitle,
   waitForWorkspaceByPath,
 } from "../helpers/electron-app";
@@ -68,11 +69,20 @@ test("auto-titles a brand-new worktree thread after showing the placeholder firs
       prompt: "Fix the worktree rename race before shipping",
     });
 
+    const startedState = await getDesktopState(window);
+    const startedSession = {
+      workspaceId: startedState.selectedWorkspaceId,
+      sessionId: startedState.selectedSessionId,
+    };
+    await waitForDeferredThreadTitleRequest(harness);
+    await waitForSelectedSessionReady(window, startedSession);
+
     const placeholderRow = window.locator(".session-row__select", { hasText: "New thread" }).first();
     await expect(window.locator(".topbar__session")).toHaveText("New thread");
     await expect(placeholderRow).toBeVisible();
 
-    await resolveDeferredThreadTitleEventually(harness, "Fix worktree rename");
+    await resolveDeferredThreadTitle(harness, "Fix worktree rename");
+    await waitForSessionByTitle(window, startedSession.workspaceId, "Fix worktree rename");
 
     await expect(window.locator(".topbar__session")).toHaveText("Fix worktree rename");
     await expect(window.locator(".session-row__select", { hasText: "Fix worktree rename" }).first()).toBeVisible();

--- a/apps/desktop/tests/core/tree-command.spec.ts
+++ b/apps/desktop/tests/core/tree-command.spec.ts
@@ -9,6 +9,7 @@ import {
   seedBranchedTreeSessionFixture,
   seedToolResultTreeSessionFixture,
   selectSession,
+  waitForSelectedSessionReady,
 } from "../helpers/electron-app";
 
 test("opens /tree from the composer, navigates branches, and blocks it on the new-thread surface", async () => {
@@ -17,7 +18,7 @@ test("opens /tree from the composer, navigates branches, and blocks it on the ne
   const agentDir = join(userDataDir, "agent");
   const workspacePath = await makeWorkspace("tree-command-workspace");
   await seedAgentDir(agentDir);
-  await seedBranchedTreeSessionFixture(agentDir, workspacePath);
+  const fixture = await seedBranchedTreeSessionFixture(agentDir, workspacePath);
 
   const harness = await launchDesktop(userDataDir, {
     agentDir,
@@ -27,7 +28,8 @@ test("opens /tree from the composer, navigates branches, and blocks it on the ne
 
   try {
     const window = await harness.firstWindow();
-    await selectSession(window, "Tree fixture session");
+    await selectSession(window, fixture.title);
+    await waitForSelectedSessionReady(window, fixture);
 
     const composer = window.getByTestId("composer");
     await composer.fill("/tre");
@@ -109,7 +111,7 @@ test("renders tool results with compact previews in the tree modal", async () =>
   const agentDir = join(userDataDir, "agent");
   const workspacePath = await makeWorkspace("tree-tool-command-workspace");
   await seedAgentDir(agentDir);
-  await seedToolResultTreeSessionFixture(agentDir, workspacePath);
+  const fixture = await seedToolResultTreeSessionFixture(agentDir, workspacePath);
 
   const harness = await launchDesktop(userDataDir, {
     agentDir,
@@ -119,7 +121,8 @@ test("renders tool results with compact previews in the tree modal", async () =>
 
   try {
     const window = await harness.firstWindow();
-    await selectSession(window, "Tree tool fixture session");
+    await selectSession(window, fixture.title);
+    await waitForSelectedSessionReady(window, fixture);
 
     const composer = window.getByTestId("composer");
     await composer.fill("/tree");

--- a/apps/desktop/tests/helpers/electron-app.ts
+++ b/apps/desktop/tests/helpers/electron-app.ts
@@ -1176,6 +1176,87 @@ export async function getSelectedTranscript(window: Page): Promise<SelectedTrans
   });
 }
 
+export async function waitForSelectedSessionReady(
+  window: Page,
+  target: {
+    readonly sessionId: string;
+    readonly workspaceId?: string;
+  },
+  timeout = 15_000,
+): Promise<void> {
+  let expectedComposerDraft = "";
+  let expectedTitle = "";
+
+  await expect
+    .poll(
+      async () => {
+        const [state, selectedTranscript] = await Promise.all([
+          getDesktopState(window),
+          getSelectedTranscript(window),
+        ]);
+        const workspace = state.workspaces.find(
+          (entry) =>
+            (!target.workspaceId || entry.id === target.workspaceId) &&
+            entry.sessions.some((session) => session.id === target.sessionId),
+        );
+        const session = workspace?.sessions.find((entry) => entry.id === target.sessionId);
+        if (
+          !workspace ||
+          !session ||
+          !state.runtimeByWorkspace[workspace.id] ||
+          state.selectedWorkspaceId !== workspace.id ||
+          state.selectedSessionId !== session.id ||
+          selectedTranscript?.workspaceId !== workspace.id ||
+          selectedTranscript.sessionId !== session.id
+        ) {
+          return false;
+        }
+        expectedComposerDraft = state.composerDraft;
+        expectedTitle = session.title;
+        return true;
+      },
+      {
+        intervals: [50, 100, 250, 500],
+        message: `wait for selected session ${target.sessionId} to finish hydrating`,
+        timeout,
+      },
+    )
+    .toBe(true);
+
+  await expect(window.locator(".topbar__session")).toHaveText(expectedTitle, { timeout });
+  await expect(window.getByTestId("transcript-skeleton")).toHaveCount(0, { timeout });
+  await expect(window.getByTestId("composer")).toHaveValue(expectedComposerDraft, { timeout });
+
+  let previousLayout = "";
+  await expect
+    .poll(
+      async () => {
+        const layout = await window.evaluate(() => {
+          const composer = document.querySelector<HTMLElement>('[data-testid="composer-surface"]');
+          const timeline = document.querySelector<HTMLElement>('[data-testid="timeline-pane"]');
+          if (!composer || !timeline) {
+            return "";
+          }
+          return [
+            composer.getBoundingClientRect().height,
+            timeline.getBoundingClientRect().height,
+            timeline.clientHeight,
+            timeline.scrollHeight,
+          ].join(":");
+        });
+        const stable = Boolean(layout) && layout === previousLayout;
+        previousLayout = layout;
+        return stable;
+      },
+      {
+        intervals: [50, 100, 250],
+        message: `wait for selected session ${target.sessionId} layout to settle`,
+        timeout,
+      },
+    )
+    .toBe(true);
+}
+
 export interface TimelineScrollMetrics {
   readonly scrollTop: number;
   readonly scrollHeight: number;


### PR DESCRIPTION
## Summary
- preserve the 768px transcript measure when macOS uses a space-consuming scrollbar
- hide the prompt rail before it can squeeze the reading column
- cover overlay and 15px classic scrollbar modes plus the responsive boundary

## Verification
- `git diff --check origin/main..HEAD`
- `pnpm --filter @pi-gui/desktop typecheck`
- `pnpm --filter @pi-gui/desktop test:e2e:runner -- apps/desktop/tests/core/context-rail.spec.ts --repeat-each=20` (20/20)
- proof: `/Users/matthewlam/.codex/proofs/pi-gui-issue-60/`

Closes #60
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/pi-gui/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->