### PR TITLE
Harden atomic cross-platform release publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Verify install copy
         run: pnpm verify:install-copy
 
+      - name: Test release artifact helpers
+        run: pnpm test:release-helpers
+
+      - name: Verify release configuration
+        run: pnpm verify:release-config
+
   website-build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Test release artifact helpers
         run: pnpm test:release-helpers
 
+      - name: Verify release version consistency
+        run: pnpm verify:release-version
+
       - name: Verify release configuration
         run: pnpm verify:release-config
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-preflight:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Verify release tag and product versions
+        run: node scripts/verify-release-version.mjs --tag "$GITHUB_REF_NAME"
+
   build-macos:
+    needs: release-preflight
     runs-on: macos-latest
 
     steps:
@@ -120,6 +134,7 @@ jobs:
           compression-level: 0
 
   build-linux:
+    needs: release-preflight
     runs-on: ubuntu-latest
 
     steps:
@@ -174,6 +189,7 @@ jobs:
           compression-level: 0
 
   build-windows:
+    needs: release-preflight
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,16 +285,10 @@ jobs:
             --commit "$GITHUB_SHA" \
             --input release-candidate
 
-      - name: Refuse to replace an already-published release
+      - name: Check existing release state
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          if state="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft 2>/dev/null)"; then
-            if [[ "$state" != "true" ]]; then
-              echo "Release $GITHUB_REF_NAME is already published; refusing to replace its assets." >&2
-              exit 1
-            fi
-          fi
+        run: node apps/desktop/scripts/github-release-state.mjs
 
       - name: Upload validated draft
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,13 +247,12 @@ jobs:
           retention-days: 7
           compression-level: 0
 
-  publish:
+  stage-draft:
     needs:
       - build-macos
       - build-linux
       - build-windows
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
 
@@ -299,25 +298,8 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
 
-      - name: Verify uploaded draft bytes
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir draft-download
-          gh release download "$GITHUB_REF_NAME" --dir draft-download
-          node apps/desktop/scripts/release-artifacts.mjs verify \
-            --platform all \
-            --version "${GITHUB_REF_NAME#v}" \
-            --commit "$GITHUB_SHA" \
-            --input draft-download
-
-      - name: Publish validated release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release edit "$GITHUB_REF_NAME" --draft=false
-
-  verify-published-macos:
-    needs: publish
+  verify-draft-macos:
+    needs: stage-draft
     runs-on: macos-latest
 
     steps:
@@ -333,28 +315,28 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Download published release
+      - name: Download draft release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+        run: gh release download "$GITHUB_REF_NAME" --dir draft-release
 
-      - name: Verify published macOS manifest and bytes
+      - name: Verify draft manifests and bytes
         run: |
           node apps/desktop/scripts/release-artifacts.mjs verify \
-            --platform macos \
+            --platform all \
             --version "${GITHUB_REF_NAME#v}" \
             --commit "$GITHUB_SHA" \
-            --input published-release
+            --input draft-release
 
-      - name: Verify published macOS trust
+      - name: Verify draft macOS trust
         run: |
           bash apps/desktop/scripts/finalize-macos-release.sh \
             --verify-only \
-            "$PWD/published-release" \
+            "$PWD/draft-release" \
             "${GITHUB_REF_NAME#v}"
 
-  verify-published-linux:
-    needs: publish
+  verify-draft-linux:
+    needs: stage-draft
     runs-on: ubuntu-latest
 
     steps:
@@ -370,26 +352,26 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Download published release
+      - name: Download draft release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+        run: gh release download "$GITHUB_REF_NAME" --dir draft-release
 
-      - name: Verify published Linux manifest and bytes
+      - name: Verify draft manifests and bytes
         run: |
           node apps/desktop/scripts/release-artifacts.mjs verify \
-            --platform linux \
+            --platform all \
             --version "${GITHUB_REF_NAME#v}" \
             --commit "$GITHUB_SHA" \
-            --input published-release
+            --input draft-release
 
-      - name: Verify published Linux architecture
+      - name: Verify draft Linux architecture
         run: |
-          appimage="published-release/pi-gui-${GITHUB_REF_NAME#v}-x86_64.AppImage"
+          appimage="draft-release/pi-gui-${GITHUB_REF_NAME#v}-x86_64.AppImage"
           readelf -h "$appimage" | grep -F "Advanced Micro Devices X86-64"
 
-  verify-published-windows:
-    needs: publish
+  verify-draft-windows:
+    needs: stage-draft
     runs-on: windows-latest
 
     steps:
@@ -405,33 +387,87 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Download published release
+      - name: Download draft release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+        run: gh release download "$GITHUB_REF_NAME" --dir draft-release
 
-      - name: Verify published Windows manifest and bytes
+      - name: Verify draft manifests and bytes
         shell: bash
         run: |
           node apps/desktop/scripts/release-artifacts.mjs verify \
-            --platform windows \
+            --platform all \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input draft-release
+
+      - name: Verify draft Windows signatures
+        shell: pwsh
+        run: |
+          ./apps/desktop/scripts/verify-windows-release.ps1 `
+            -ReleaseDir "$PWD/draft-release" `
+            -Version "$($env:GITHUB_REF_NAME -replace '^v', '')"
+
+  publish:
+    needs:
+      - verify-draft-macos
+      - verify-draft-linux
+      - verify-draft-windows
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Require the validated draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node apps/desktop/scripts/github-release-state.mjs --require-draft
+
+      - name: Revalidate draft bytes before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir final-draft-check
+          gh release download "$GITHUB_REF_NAME" --dir final-draft-check
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform all \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input final-draft-check
+
+      - name: Publish validated draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false
+
+      - name: Verify published release bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir published-release
+          gh release download "$GITHUB_REF_NAME" --dir published-release
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform all \
             --version "${GITHUB_REF_NAME#v}" \
             --commit "$GITHUB_SHA" \
             --input published-release
 
-      - name: Verify published Windows signatures
-        shell: pwsh
-        run: |
-          ./apps/desktop/scripts/verify-windows-release.ps1 `
-            -ReleaseDir "$PWD/published-release" `
-            -Version "$($env:GITHUB_REF_NAME -replace '^v', '')"
-
   sync-homebrew:
-    needs:
-      - verify-published-macos
-      - verify-published-linux
-      - verify-published-windows
+    needs: publish
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,12 @@ jobs:
             "$PWD/apps/desktop/release" \
             "${GITHUB_REF_NAME#v}"
 
+      - name: Refresh update metadata from final DMG
+        run: |
+          node apps/desktop/scripts/refresh-macos-update-metadata.mjs \
+            "$PWD/apps/desktop/release" \
+            "${GITHUB_REF_NAME#v}"
+
       - name: Stage validated macOS artifacts
         run: |
           node apps/desktop/scripts/release-artifacts.mjs stage \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,14 @@ on:
       - "v[0-9]*"
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release-mac:
+  build-macos:
     runs-on: macos-latest
 
     steps:
@@ -25,28 +29,28 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Validate signing secrets
+      - name: Validate macOS signing credentials
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          for var in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER HOMEBREW_TAP_TOKEN; do
-            if [ -z "${!var}" ]; then
-              echo "Missing required release secret: $var" >&2
+          for variable in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER; do
+            if [[ -z "${!variable}" ]]; then
+              echo "Missing required macOS release secret: $variable" >&2
               exit 1
             fi
           done
 
       - name: Write App Store Connect API key
         env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
         run: |
+          umask 077
           APPLE_API_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
-          printf '%s' "$APPLE_API_KEY" > "$APPLE_API_KEY_PATH"
+          printf '%s' "$APPLE_API_KEY_CONTENT" > "$APPLE_API_KEY_PATH"
           echo "APPLE_API_KEY=$APPLE_API_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Typecheck
@@ -58,14 +62,13 @@ jobs:
       - name: Build website
         run: pnpm --filter @pi-gui/website run build
 
-      - name: Build
+      - name: Build desktop
         run: pnpm --filter @pi-gui/desktop run build
 
-      - name: Package
+      - name: Package macOS
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ env.APPLE_API_KEY }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
@@ -80,51 +83,37 @@ jobs:
       - name: Verify Homebrew tap rewrite
         run: pnpm test:homebrew-tap
 
-      - name: Smoke test the packaged release zip
+      - name: Smoke test packaged release zip
         run: pnpm --dir apps/desktop run test:prod:release-zip-smoke:ci
 
-      - name: Staple macOS artifacts
-        run: |
-          if xcrun stapler staple apps/desktop/release/*.dmg; then
-            xcrun stapler validate apps/desktop/release/*.dmg
-          else
-            echo "::warning::DMG stapling is unavailable for this build; publishing the notarized release artifacts without a stapled DMG wrapper."
-          fi
-
-      - name: Release
-        id: release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            apps/desktop/release/*.dmg
-            apps/desktop/release/*.zip
-            apps/desktop/release/latest-mac.yml
-          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
-          generate_release_notes: true
-
-      - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
-        with:
-          repository: minghinmatthewlam/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          path: homebrew-tap
-          fetch-depth: 0
-
-      - name: Sync Homebrew tap
+      - name: Notarize and verify final macOS artifacts
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: |
-          pnpm release:homebrew-sync \
-            --tap-dir "$PWD/homebrew-tap" \
-            --version "${GITHUB_REF_NAME#v}" \
-            --tag "${GITHUB_REF_NAME}" \
-            --github-repo "${GITHUB_REPOSITORY}" \
-            --asset-name "pi-gui-${GITHUB_REF_NAME#v}-arm64.dmg" \
-            --dmg-path "$PWD/apps/desktop/release/pi-gui-${GITHUB_REF_NAME#v}-arm64.dmg" \
-            --commit \
-            --push
+          bash apps/desktop/scripts/finalize-macos-release.sh \
+            "$PWD/apps/desktop/release" \
+            "${GITHUB_REF_NAME#v}"
 
-  release-linux:
+      - name: Stage validated macOS artifacts
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs stage \
+            --platform macos \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input apps/desktop/release \
+            --output apps/desktop/release-candidate
+
+      - name: Upload immutable macOS candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-${{ github.sha }}
+          path: apps/desktop/release-candidate/
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  build-linux:
     runs-on: ubuntu-latest
 
     steps:
@@ -154,16 +143,30 @@ jobs:
       - name: Verify packaged runtime dependencies
         run: pnpm --dir apps/desktop run verify:packaged-runtime-deps:linux
 
-      - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            apps/desktop/release/*.AppImage
-            apps/desktop/release/latest-linux*.yml
-          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
-          generate_release_notes: true
+      - name: Verify Linux architecture
+        run: |
+          appimage="apps/desktop/release/pi-gui-${GITHUB_REF_NAME#v}-x86_64.AppImage"
+          readelf -h "$appimage" | grep -F "Advanced Micro Devices X86-64"
 
-  release-windows:
+      - name: Stage validated Linux artifacts
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs stage \
+            --platform linux \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input apps/desktop/release \
+            --output apps/desktop/release-candidate
+
+      - name: Upload immutable Linux candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-linux-${{ github.sha }}
+          path: apps/desktop/release-candidate/
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  build-windows:
     runs-on: windows-latest
 
     steps:
@@ -179,26 +182,307 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Validate Windows signing credentials
+        shell: pwsh
+        env:
+          WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          WINDOWS_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
+        run: |
+          foreach ($variable in "WINDOWS_CSC_LINK", "WINDOWS_CSC_KEY_PASSWORD") {
+            if ([string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($variable))) {
+              throw "Missing required Windows release secret: $variable"
+            }
+          }
+
       - name: Typecheck
         run: pnpm typecheck
 
       - name: Package Windows
         shell: bash
         env:
-          GITHUB_REF_NAME: ${{ github.ref_name }}
+          CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
         run: |
           cd apps/desktop
           pnpm run build
-          node scripts/package-windows.mjs --win --publish never --config.npmRebuild=false "-c.extraMetadata.version=${GITHUB_REF_NAME#v}"
+          node scripts/package-windows.mjs \
+            --win \
+            --publish never \
+            --config.npmRebuild=false \
+            "-c.extraMetadata.version=${GITHUB_REF_NAME#v}"
 
       - name: Verify packaged runtime dependencies
         run: pnpm --dir apps/desktop run verify:packaged-runtime-deps:windows
 
-      - name: Release
+      - name: Verify Windows signatures and architecture
+        shell: pwsh
+        run: |
+          ./apps/desktop/scripts/verify-windows-release.ps1 `
+            -ReleaseDir "$PWD/apps/desktop/release" `
+            -Version "$($env:GITHUB_REF_NAME -replace '^v', '')" `
+            -PackagedApp "$PWD/apps/desktop/release/win-unpacked/pi-gui.exe"
+
+      - name: Stage validated Windows artifacts
+        shell: bash
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs stage \
+            --platform windows \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input apps/desktop/release \
+            --output apps/desktop/release-candidate
+
+      - name: Upload immutable Windows candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-windows-${{ github.sha }}
+          path: apps/desktop/release-candidate/
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  publish:
+    needs:
+      - build-macos
+      - build-linux
+      - build-windows
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download immutable platform candidates
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*-${{ github.sha }}
+          path: release-candidate
+          merge-multiple: true
+
+      - name: Validate combined release candidate
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform all \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input release-candidate
+
+      - name: Refuse to replace an already-published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if state="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            if [[ "$state" != "true" ]]; then
+              echo "Release $GITHUB_REF_NAME is already published; refusing to replace its assets." >&2
+              exit 1
+            fi
+          fi
+
+      - name: Upload validated draft
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            apps/desktop/release/*.exe
-            apps/desktop/release/latest.yml
+          files: release-candidate/*
+          draft: true
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'rc') }}
           generate_release_notes: true
+          fail_on_unmatched_files: true
+
+      - name: Verify uploaded draft bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir draft-download
+          gh release download "$GITHUB_REF_NAME" --dir draft-download
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform all \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input draft-download
+
+      - name: Publish validated release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false
+
+  verify-published-macos:
+    needs: publish
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+
+      - name: Verify published macOS manifest and bytes
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform macos \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input published-release
+
+      - name: Verify published macOS trust
+        run: |
+          bash apps/desktop/scripts/finalize-macos-release.sh \
+            --verify-only \
+            "$PWD/published-release" \
+            "${GITHUB_REF_NAME#v}"
+
+  verify-published-linux:
+    needs: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+
+      - name: Verify published Linux manifest and bytes
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform linux \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input published-release
+
+      - name: Verify published Linux architecture
+        run: |
+          appimage="published-release/pi-gui-${GITHUB_REF_NAME#v}-x86_64.AppImage"
+          readelf -h "$appimage" | grep -F "Advanced Micro Devices X86-64"
+
+  verify-published-windows:
+    needs: publish
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+
+      - name: Verify published Windows manifest and bytes
+        shell: bash
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform windows \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input published-release
+
+      - name: Verify published Windows signatures
+        shell: pwsh
+        run: |
+          ./apps/desktop/scripts/verify-windows-release.ps1 `
+            -ReleaseDir "$PWD/published-release" `
+            -Version "$($env:GITHUB_REF_NAME -replace '^v', '')"
+
+  sync-homebrew:
+    needs:
+      - verify-published-macos
+      - verify-published-linux
+      - verify-published-windows
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate Homebrew credential
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [[ -z "$HOMEBREW_TAP_TOKEN" ]]; then
+            echo "Missing required release secret: HOMEBREW_TAP_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Download published DMG
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir release-download
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "pi-gui-${GITHUB_REF_NAME#v}-arm64.dmg" \
+            --dir release-download
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: minghinmatthewlam/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+          fetch-depth: 0
+
+      - name: Sync Homebrew tap
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          pnpm release:homebrew-sync \
+            --tap-dir "$PWD/homebrew-tap" \
+            --version "${GITHUB_REF_NAME#v}" \
+            --tag "$GITHUB_REF_NAME" \
+            --github-repo "$GITHUB_REPOSITORY" \
+            --asset-name "pi-gui-${GITHUB_REF_NAME#v}-arm64.dmg" \
+            --dmg-path "$PWD/release-download/pi-gui-${GITHUB_REF_NAME#v}-arm64.dmg" \
+            --commit \
+            --push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,10 +149,11 @@ jobs:
       - name: Verify packaged runtime dependencies
         run: pnpm --dir apps/desktop run verify:packaged-runtime-deps:linux
 
-      - name: Verify Linux architecture
+      - name: Verify Linux package
         run: |
-          appimage="apps/desktop/release/pi-gui-${GITHUB_REF_NAME#v}-x86_64.AppImage"
-          readelf -h "$appimage" | grep -F "Advanced Micro Devices X86-64"
+          bash apps/desktop/scripts/verify-linux-release.sh \
+            "$PWD/apps/desktop/release" \
+            "${GITHUB_REF_NAME#v}"
 
       - name: Stage validated Linux artifacts
         run: |
@@ -226,7 +227,8 @@ jobs:
           ./apps/desktop/scripts/verify-windows-release.ps1 `
             -ReleaseDir "$PWD/apps/desktop/release" `
             -Version "$($env:GITHUB_REF_NAME -replace '^v', '')" `
-            -PackagedApp "$PWD/apps/desktop/release/win-unpacked/pi-gui.exe"
+            -PackagedApp "$PWD/apps/desktop/release/win-unpacked/pi-gui.exe" `
+            -SmokePackages
 
       - name: Stage validated Windows artifacts
         shell: bash
@@ -365,10 +367,11 @@ jobs:
             --commit "$GITHUB_SHA" \
             --input draft-release
 
-      - name: Verify draft Linux architecture
+      - name: Verify draft Linux package
         run: |
-          appimage="draft-release/pi-gui-${GITHUB_REF_NAME#v}-x86_64.AppImage"
-          readelf -h "$appimage" | grep -F "Advanced Micro Devices X86-64"
+          bash apps/desktop/scripts/verify-linux-release.sh \
+            "$PWD/draft-release" \
+            "${GITHUB_REF_NAME#v}"
 
   verify-draft-windows:
     needs: stage-draft
@@ -407,7 +410,8 @@ jobs:
         run: |
           ./apps/desktop/scripts/verify-windows-release.ps1 `
             -ReleaseDir "$PWD/draft-release" `
-            -Version "$($env:GITHUB_REF_NAME -replace '^v', '')"
+            -Version "$($env:GITHUB_REF_NAME -replace '^v', '')" `
+            -SmokePackages
 
   publish:
     needs:
@@ -466,8 +470,124 @@ jobs:
             --commit "$GITHUB_SHA" \
             --input published-release
 
-  sync-homebrew:
+  verify-published-macos:
     needs: publish
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+
+      - name: Verify published manifests and bytes
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform all \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input published-release
+
+      - name: Verify published macOS trust
+        run: |
+          bash apps/desktop/scripts/finalize-macos-release.sh \
+            --verify-only \
+            "$PWD/published-release" \
+            "${GITHUB_REF_NAME#v}"
+
+  verify-published-linux:
+    needs: publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+
+      - name: Verify published manifests and bytes
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform all \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input published-release
+
+      - name: Verify published Linux package
+        run: |
+          bash apps/desktop/scripts/verify-linux-release.sh \
+            "$PWD/published-release" \
+            "${GITHUB_REF_NAME#v}"
+
+  verify-published-windows:
+    needs: publish
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Download published release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "$GITHUB_REF_NAME" --dir published-release
+
+      - name: Verify published manifests and bytes
+        shell: bash
+        run: |
+          node apps/desktop/scripts/release-artifacts.mjs verify \
+            --platform all \
+            --version "${GITHUB_REF_NAME#v}" \
+            --commit "$GITHUB_SHA" \
+            --input published-release
+
+      - name: Verify published Windows signatures
+        shell: pwsh
+        run: |
+          ./apps/desktop/scripts/verify-windows-release.ps1 `
+            -ReleaseDir "$PWD/published-release" `
+            -Version "$($env:GITHUB_REF_NAME -replace '^v', '')" `
+            -SmokePackages
+
+  sync-homebrew:
+    needs:
+      - verify-published-macos
+      - verify-published-linux
+      - verify-published-windows
     runs-on: macos-latest
 
     steps:

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -27,7 +27,6 @@ artifactName: ${productName}-${version}-${arch}.${ext}
 mac:
   category: public.app-category.developer-tools
   hardenedRuntime: true
-  gatekeeperAssess: false
   entitlements: resources/entitlements.mac.plist
   entitlementsInherit: resources/entitlements.mac.inherit.plist
   notarize: true
@@ -49,7 +48,7 @@ linux:
 
 win:
   executableName: pi-gui
-  signAndEditExecutable: false
+  signAndEditExecutable: true
   target:
     - target: nsis
       arch:
@@ -57,6 +56,12 @@ win:
     - target: portable
       arch:
         - x64
+
+nsis:
+  artifactName: ${productName}-${version}-${arch}-setup.${ext}
+
+portable:
+  artifactName: ${productName}-${version}-${arch}-portable.${ext}
 
 toolsets:
   appimage: "1.0.2"

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -881,7 +881,7 @@ async function runManualUpdateCheck(): Promise<void> {
         cancelId: 1,
       });
       if (choice.response === 0) {
-        await openReleasesPage();
+        await openReleasesPage(result.releaseUrl);
       }
       return;
     }

--- a/apps/desktop/electron/update-checker.ts
+++ b/apps/desktop/electron/update-checker.ts
@@ -2,8 +2,7 @@ import { app, net, Notification, shell } from "electron";
 
 const RELEASES_URL =
   "https://api.github.com/repos/minghinmatthewlam/pi-gui/releases?per_page=1";
-const RELEASES_PAGE =
-  "https://github.com/minghinmatthewlam/pi-gui/releases/latest";
+const RELEASES_PAGE = "https://github.com/minghinmatthewlam/pi-gui/releases";
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const INITIAL_DELAY_MS = 15_000; // 15 seconds after launch
@@ -11,14 +10,28 @@ const FETCH_TIMEOUT_MS = 10_000; // give up on a hung request
 
 export type UpdateCheckResult =
   | { status: "up-to-date"; currentVersion: string; latestVersion: string }
-  | { status: "update-available"; currentVersion: string; latestVersion: string }
+  | {
+      status: "update-available";
+      currentVersion: string;
+      latestVersion: string;
+      releaseUrl: string;
+    }
   | { status: "error"; message: string };
 
-export function openReleasesPage(): Promise<void> {
-  return shell.openExternal(RELEASES_PAGE);
+export type GitHubRelease = {
+  tag_name?: string;
+  html_url?: string;
+};
+
+export function openReleasesPage(releaseUrl = RELEASES_PAGE): Promise<void> {
+  return shell.openExternal(releaseUrl);
 }
 
-export function showUpdateNotification(currentVersion: string, latestVersion: string): void {
+export function showUpdateNotification(
+  currentVersion: string,
+  latestVersion: string,
+  releaseUrl: string,
+): void {
   if (!Notification.isSupported()) {
     return;
   }
@@ -27,7 +40,7 @@ export function showUpdateNotification(currentVersion: string, latestVersion: st
     body: `Version ${latestVersion} is available (you have ${currentVersion}). Click to view the release.`,
   });
   notification.on("click", () => {
-    void shell.openExternal(RELEASES_PAGE);
+    void openReleasesPage(releaseUrl);
   });
   notification.show();
 }
@@ -65,9 +78,9 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
     };
   }
 
-  let releases: Array<{ tag_name?: string }>;
+  let releases: GitHubRelease[];
   try {
-    releases = (await res.json()) as Array<{ tag_name?: string }>;
+    releases = (await res.json()) as GitHubRelease[];
   } catch {
     return { status: "error", message: "GitHub Releases returned an unreadable response." };
   }
@@ -90,6 +103,7 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
       status: "update-available",
       currentVersion: current,
       latestVersion: latest,
+      releaseUrl: releaseUrlFor(release),
     };
   }
 
@@ -112,7 +126,7 @@ export function initUpdateChecker(): () => void {
     }
     if (result.status === "update-available" && result.latestVersion !== lastNotifiedVersion) {
       lastNotifiedVersion = result.latestVersion;
-      showUpdateNotification(result.currentVersion, result.latestVersion);
+      showUpdateNotification(result.currentVersion, result.latestVersion, result.releaseUrl);
     }
   };
 
@@ -123,6 +137,37 @@ export function initUpdateChecker(): () => void {
     clearTimeout(timeout);
     clearInterval(interval);
   };
+}
+
+export function releaseUrlFor(release: GitHubRelease): string {
+  const tag = release.tag_name;
+  if (!tag) {
+    return RELEASES_PAGE;
+  }
+
+  const canonicalUrl = `${RELEASES_PAGE}/tag/${encodeURIComponent(tag)}`;
+  if (!release.html_url) {
+    return canonicalUrl;
+  }
+
+  try {
+    const candidate = new URL(release.html_url);
+    const canonical = new URL(canonicalUrl);
+    if (
+      candidate.protocol === canonical.protocol &&
+      candidate.host === canonical.host &&
+      candidate.pathname === canonical.pathname &&
+      candidate.username === "" &&
+      candidate.password === "" &&
+      candidate.search === "" &&
+      candidate.hash === ""
+    ) {
+      return candidate.toString();
+    }
+  } catch {
+    // Fall through to the repository's canonical URL for this exact tag.
+  }
+  return canonicalUrl;
 }
 
 /**

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -165,6 +165,7 @@
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "app-builder-bin": "5.0.0-alpha.12",
     "cross-env": "^7.0.3",
     "electron": "37.10.3",
     "electron-builder": "^26.8.1",

--- a/apps/desktop/scripts/finalize-macos-release.sh
+++ b/apps/desktop/scripts/finalize-macos-release.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+verify_only=0
+if [[ "${1:-}" == "--verify-only" ]]; then
+  verify_only=1
+  shift
+fi
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: finalize-macos-release.sh [--verify-only] <release-dir> <version>" >&2
+  exit 2
+fi
+
+release_dir="$(cd "$1" && pwd)"
+version="$2"
+dmg="$release_dir/pi-gui-$version-arm64.dmg"
+zip="$release_dir/pi-gui-$version-arm64.zip"
+packaged_app="$release_dir/mac-arm64/pi-gui.app"
+
+for artifact in "$dmg" "$zip"; do
+  if [[ ! -f "$artifact" ]]; then
+    echo "Missing macOS release artifact: $artifact" >&2
+    exit 1
+  fi
+done
+
+if [[ "$verify_only" -eq 0 ]]; then
+  for variable in APPLE_API_KEY APPLE_API_KEY_ID APPLE_API_ISSUER; do
+    if [[ -z "${!variable:-}" ]]; then
+      echo "Missing required notarization credential: $variable" >&2
+      exit 1
+    fi
+  done
+  if [[ ! -f "$APPLE_API_KEY" ]]; then
+    echo "APPLE_API_KEY must point to the App Store Connect API key file" >&2
+    exit 1
+  fi
+
+  xcrun notarytool submit "$dmg" \
+    --key "$APPLE_API_KEY" \
+    --key-id "$APPLE_API_KEY_ID" \
+    --issuer "$APPLE_API_ISSUER" \
+    --wait
+  xcrun stapler staple "$dmg"
+fi
+
+verify_app() {
+  local app_path="$1"
+  if [[ ! -d "$app_path" ]]; then
+    echo "Missing app bundle: $app_path" >&2
+    exit 1
+  fi
+  codesign --verify --deep --strict --verbose=4 "$app_path"
+  xcrun stapler validate "$app_path"
+  spctl --assess --type execute --verbose=4 "$app_path"
+
+  local architectures
+  architectures="$(lipo -archs "$app_path/Contents/MacOS/pi-gui")"
+  if [[ "$architectures" != "arm64" ]]; then
+    echo "Expected an arm64 app, found: $architectures" >&2
+    exit 1
+  fi
+}
+
+xcrun stapler validate "$dmg"
+spctl --assess --type open --context context:primary-signature --verbose=4 "$dmg"
+hdiutil verify "$dmg"
+
+temporary_root="$(mktemp -d)"
+mount_point="$temporary_root/dmg"
+zip_root="$temporary_root/zip"
+mounted=0
+cleanup() {
+  if [[ "$mounted" -eq 1 ]]; then
+    hdiutil detach "$mount_point" >/dev/null
+  fi
+  rm -rf "$temporary_root"
+}
+trap cleanup EXIT
+
+mkdir "$mount_point" "$zip_root"
+ditto -x -k "$zip" "$zip_root"
+verify_app "$zip_root/pi-gui.app"
+
+hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_point"
+mounted=1
+verify_app "$mount_point/pi-gui.app"
+
+if [[ "$verify_only" -eq 0 ]]; then
+  verify_app "$packaged_app"
+fi
+
+echo "Verified notarization, stapling, Gatekeeper, signatures, and architecture for macOS $version"

--- a/apps/desktop/scripts/github-release-state.mjs
+++ b/apps/desktop/scripts/github-release-state.mjs
@@ -12,6 +12,46 @@ async function responseMessage(response) {
   }
 }
 
+async function requestGithub(fetchImpl, url, token) {
+  try {
+    return await fetchImpl(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch (error) {
+    throw new Error(
+      `GitHub release lookup failed before an authoritative response: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function readJson(response) {
+  try {
+    return await response.json();
+  } catch {
+    throw new Error("GitHub release lookup returned unreadable JSON");
+  }
+}
+
+function validateDraft(release, tag) {
+  if (release?.tag_name !== tag) {
+    throw new Error("GitHub release lookup returned the wrong tag");
+  }
+  if (release.draft !== true) {
+    if (release.draft === false) {
+      throw new Error(`Release ${tag} is already published; refusing to replace its assets`);
+    }
+    throw new Error("GitHub release lookup did not return a boolean draft state");
+  }
+  if (!Number.isSafeInteger(release.id) || release.id <= 0) {
+    throw new Error("GitHub release lookup did not return a valid release id");
+  }
+  return { state: "draft", id: release.id };
+}
+
 export async function checkGithubReleaseState({
   repository,
   tag,
@@ -29,52 +69,58 @@ export async function checkGithubReleaseState({
     throw new Error("GH_TOKEN is required for an authoritative release lookup");
   }
 
-  let response;
-  try {
-    response = await fetchImpl(
-      `${GITHUB_API}/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
-      {
-        headers: {
-          Accept: "application/vnd.github+json",
-          Authorization: `Bearer ${token}`,
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-      },
-    );
-  } catch (error) {
-    throw new Error(
-      `GitHub release lookup failed before an authoritative response: ${error instanceof Error ? error.message : String(error)}`,
-    );
+  const releaseUrl = `${GITHUB_API}/repos/${repository}/releases`;
+  const publishedResponse = await requestGithub(
+    fetchImpl,
+    `${releaseUrl}/tags/${encodeURIComponent(tag)}`,
+    token,
+  );
+  if (publishedResponse.status !== 404) {
+    if (!publishedResponse.ok) {
+      throw new Error(
+        `GitHub published-release lookup returned HTTP ${publishedResponse.status}${await responseMessage(publishedResponse)}`,
+      );
+    }
+    const published = await readJson(publishedResponse);
+    if (published?.tag_name !== tag || published?.draft !== false) {
+      throw new Error("GitHub published-release lookup returned malformed state");
+    }
+    throw new Error(`Release ${tag} is already published; refusing to replace its assets`);
   }
 
-  if (response.status === 404) {
-    if (requireDraft) {
-      throw new Error(`Required draft release ${tag} does not exist`);
-    }
-    return { state: "absent" };
-  }
-  if (!response.ok) {
-    throw new Error(
-      `GitHub release lookup returned HTTP ${response.status}${await responseMessage(response)}`,
+  for (let page = 1; page <= 100; page += 1) {
+    const response = await requestGithub(
+      fetchImpl,
+      `${releaseUrl}?per_page=100&page=${page}`,
+      token,
     );
+    if (!response.ok) {
+      throw new Error(
+        `GitHub draft-release lookup returned HTTP ${response.status}${await responseMessage(response)}`,
+      );
+    }
+    const releases = await readJson(response);
+    if (!Array.isArray(releases)) {
+      throw new Error("GitHub draft-release lookup did not return a release list");
+    }
+    const matches = releases.filter((release) => release?.tag_name === tag);
+    if (matches.length > 1) {
+      throw new Error(`GitHub returned multiple releases for tag ${tag}`);
+    }
+    if (matches.length === 1) {
+      return validateDraft(matches[0], tag);
+    }
+    if (releases.length < 100) {
+      if (requireDraft) {
+        throw new Error(`Required draft release ${tag} does not exist`);
+      }
+      return { state: "absent" };
+    }
   }
 
-  let release;
-  try {
-    release = await response.json();
-  } catch {
-    throw new Error("GitHub release lookup returned unreadable JSON");
-  }
-  if (release?.draft !== true) {
-    if (release?.draft === false) {
-      throw new Error(`Release ${tag} is already published; refusing to replace its assets`);
-    }
-    throw new Error("GitHub release lookup did not return a boolean draft state");
-  }
-  if (!Number.isSafeInteger(release.id) || release.id <= 0) {
-    throw new Error("GitHub release lookup did not return a valid release id");
-  }
-  return { state: "draft", id: release.id };
+  throw new Error(
+    `GitHub release lookup exceeded 100 pages without proving the state of ${tag}`,
+  );
 }
 
 async function main() {

--- a/apps/desktop/scripts/github-release-state.mjs
+++ b/apps/desktop/scripts/github-release-state.mjs
@@ -1,0 +1,104 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const GITHUB_API = "https://api.github.com";
+
+async function responseMessage(response) {
+  try {
+    const body = await response.json();
+    return typeof body?.message === "string" ? `: ${body.message}` : "";
+  } catch {
+    return "";
+  }
+}
+
+export async function checkGithubReleaseState({
+  repository,
+  tag,
+  token,
+  requireDraft = false,
+  fetchImpl = fetch,
+}) {
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) {
+    throw new Error(`Invalid GitHub repository: ${repository}`);
+  }
+  if (!tag) {
+    throw new Error("GitHub release tag is required");
+  }
+  if (!token) {
+    throw new Error("GH_TOKEN is required for an authoritative release lookup");
+  }
+
+  let response;
+  try {
+    response = await fetchImpl(
+      `${GITHUB_API}/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+  } catch (error) {
+    throw new Error(
+      `GitHub release lookup failed before an authoritative response: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (response.status === 404) {
+    if (requireDraft) {
+      throw new Error(`Required draft release ${tag} does not exist`);
+    }
+    return { state: "absent" };
+  }
+  if (!response.ok) {
+    throw new Error(
+      `GitHub release lookup returned HTTP ${response.status}${await responseMessage(response)}`,
+    );
+  }
+
+  let release;
+  try {
+    release = await response.json();
+  } catch {
+    throw new Error("GitHub release lookup returned unreadable JSON");
+  }
+  if (release?.draft !== true) {
+    if (release?.draft === false) {
+      throw new Error(`Release ${tag} is already published; refusing to replace its assets`);
+    }
+    throw new Error("GitHub release lookup did not return a boolean draft state");
+  }
+  if (!Number.isSafeInteger(release.id) || release.id <= 0) {
+    throw new Error("GitHub release lookup did not return a valid release id");
+  }
+  return { state: "draft", id: release.id };
+}
+
+async function main() {
+  const args = new Set(process.argv.slice(2));
+  const unknown = [...args].filter((arg) => arg !== "--require-draft");
+  if (unknown.length > 0) {
+    throw new Error(`Unknown argument: ${unknown[0]}`);
+  }
+  const result = await checkGithubReleaseState({
+    repository: process.env.GITHUB_REPOSITORY ?? "",
+    tag: process.env.GITHUB_REF_NAME ?? "",
+    token: process.env.GH_TOKEN ?? "",
+    requireDraft: args.has("--require-draft"),
+  });
+  console.log(
+    result.state === "draft"
+      ? `Release ${process.env.GITHUB_REF_NAME} exists as draft ${String(result.id)}`
+      : `Release ${process.env.GITHUB_REF_NAME} does not exist`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/desktop/scripts/github-release-state.mjs
+++ b/apps/desktop/scripts/github-release-state.mjs
@@ -108,7 +108,11 @@ export async function checkGithubReleaseState({
       throw new Error(`GitHub returned multiple releases for tag ${tag}`);
     }
     if (matches.length === 1) {
-      return validateDraft(matches[0], tag);
+      const draft = validateDraft(matches[0], tag);
+      if (!requireDraft) {
+        throw new Error(`Draft release ${tag} already exists; refusing to replace its assets`);
+      }
+      return draft;
     }
     if (releases.length < 100) {
       if (requireDraft) {

--- a/apps/desktop/scripts/github-release-state.test.mjs
+++ b/apps/desktop/scripts/github-release-state.test.mjs
@@ -15,36 +15,59 @@ function jsonResponse(status, body) {
   });
 }
 
+function sequenceFetch(...responses) {
+  let index = 0;
+  return async () => {
+    const response = responses[index];
+    index += 1;
+    if (response instanceof Error) {
+      throw response;
+    }
+    assert(response, `Unexpected request ${index}`);
+    return response;
+  };
+}
+
 test("accepts an authoritative 404 when no release may exist yet", async () => {
   const result = await checkGithubReleaseState({
     ...baseOptions,
-    fetchImpl: async () => jsonResponse(404, { message: "Not Found" }),
+    fetchImpl: sequenceFetch(
+      jsonResponse(404, { message: "Not Found" }),
+      jsonResponse(200, []),
+    ),
   });
   assert.deepEqual(result, { state: "absent" });
 });
 
 test("accepts an existing draft and authenticates the lookup", async () => {
-  let request;
+  const requests = [];
   const result = await checkGithubReleaseState({
     ...baseOptions,
     fetchImpl: async (url, options) => {
-      request = { url, options };
-      return jsonResponse(200, { id: 59, draft: true });
+      requests.push({ url, options });
+      return requests.length === 1
+        ? jsonResponse(404, { message: "Not Found" })
+        : jsonResponse(200, [{ id: 59, tag_name: baseOptions.tag, draft: true }]);
     },
   });
   assert.deepEqual(result, { state: "draft", id: 59 });
   assert.equal(
-    request.url,
+    requests[0].url,
     "https://api.github.com/repos/minghinmatthewlam/pi-gui/releases/tags/v0.1.0-beta.34",
   );
-  assert.equal(request.options.headers.Authorization, "Bearer test-token");
+  assert.equal(
+    requests[1].url,
+    "https://api.github.com/repos/minghinmatthewlam/pi-gui/releases?per_page=100&page=1",
+  );
+  assert.equal(requests[1].options.headers.Authorization, "Bearer test-token");
 });
 
 test("rejects an already-published release", async () => {
   await assert.rejects(
     checkGithubReleaseState({
       ...baseOptions,
-      fetchImpl: async () => jsonResponse(200, { id: 59, draft: false }),
+      fetchImpl: async () =>
+        jsonResponse(200, { id: 59, tag_name: baseOptions.tag, draft: false }),
     }),
     /already published/,
   );
@@ -70,6 +93,17 @@ test("fails closed on transport, auth, rate-limit, and API errors", async () => 
       new RegExp(`HTTP ${status}`),
     );
   }
+
+  await assert.rejects(
+    checkGithubReleaseState({
+      ...baseOptions,
+      fetchImpl: sequenceFetch(
+        jsonResponse(404, { message: "Not Found" }),
+        jsonResponse(403, { message: "rate limited" }),
+      ),
+    }),
+    /draft-release lookup returned HTTP 403/,
+  );
 });
 
 test("fails closed on malformed success responses", async () => {
@@ -78,12 +112,15 @@ test("fails closed on malformed success responses", async () => {
       ...baseOptions,
       fetchImpl: async () => jsonResponse(200, { id: 59 }),
     }),
-    /boolean draft state/,
+    /malformed state/,
   );
   await assert.rejects(
     checkGithubReleaseState({
       ...baseOptions,
-      fetchImpl: async () => jsonResponse(200, { draft: true }),
+      fetchImpl: sequenceFetch(
+        jsonResponse(404, { message: "Not Found" }),
+        jsonResponse(200, [{ tag_name: baseOptions.tag, draft: true }]),
+      ),
     }),
     /valid release id/,
   );
@@ -94,8 +131,28 @@ test("requires an existing draft before final publication", async () => {
     checkGithubReleaseState({
       ...baseOptions,
       requireDraft: true,
-      fetchImpl: async () => jsonResponse(404, { message: "Not Found" }),
+      fetchImpl: sequenceFetch(
+        jsonResponse(404, { message: "Not Found" }),
+        jsonResponse(200, []),
+      ),
     }),
     /Required draft release/,
   );
+});
+
+test("paginates authenticated release listings before proving absence", async () => {
+  const firstPage = Array.from({ length: 100 }, (_, index) => ({
+    id: index + 1,
+    tag_name: `v0.0.${index}`,
+    draft: false,
+  }));
+  const result = await checkGithubReleaseState({
+    ...baseOptions,
+    fetchImpl: sequenceFetch(
+      jsonResponse(404, { message: "Not Found" }),
+      jsonResponse(200, firstPage),
+      jsonResponse(200, [{ id: 999, tag_name: baseOptions.tag, draft: true }]),
+    ),
+  });
+  assert.deepEqual(result, { state: "draft", id: 999 });
 });

--- a/apps/desktop/scripts/github-release-state.test.mjs
+++ b/apps/desktop/scripts/github-release-state.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { checkGithubReleaseState } from "./github-release-state.mjs";
+
+const baseOptions = {
+  repository: "minghinmatthewlam/pi-gui",
+  tag: "v0.1.0-beta.34",
+  token: "test-token",
+};
+
+function jsonResponse(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("accepts an authoritative 404 when no release may exist yet", async () => {
+  const result = await checkGithubReleaseState({
+    ...baseOptions,
+    fetchImpl: async () => jsonResponse(404, { message: "Not Found" }),
+  });
+  assert.deepEqual(result, { state: "absent" });
+});
+
+test("accepts an existing draft and authenticates the lookup", async () => {
+  let request;
+  const result = await checkGithubReleaseState({
+    ...baseOptions,
+    fetchImpl: async (url, options) => {
+      request = { url, options };
+      return jsonResponse(200, { id: 59, draft: true });
+    },
+  });
+  assert.deepEqual(result, { state: "draft", id: 59 });
+  assert.equal(
+    request.url,
+    "https://api.github.com/repos/minghinmatthewlam/pi-gui/releases/tags/v0.1.0-beta.34",
+  );
+  assert.equal(request.options.headers.Authorization, "Bearer test-token");
+});
+
+test("rejects an already-published release", async () => {
+  await assert.rejects(
+    checkGithubReleaseState({
+      ...baseOptions,
+      fetchImpl: async () => jsonResponse(200, { id: 59, draft: false }),
+    }),
+    /already published/,
+  );
+});
+
+test("fails closed on transport, auth, rate-limit, and API errors", async () => {
+  await assert.rejects(
+    checkGithubReleaseState({
+      ...baseOptions,
+      fetchImpl: async () => {
+        throw new Error("socket closed");
+      },
+    }),
+    /before an authoritative response/,
+  );
+
+  for (const status of [401, 403, 429, 500]) {
+    await assert.rejects(
+      checkGithubReleaseState({
+        ...baseOptions,
+        fetchImpl: async () => jsonResponse(status, { message: `status ${status}` }),
+      }),
+      new RegExp(`HTTP ${status}`),
+    );
+  }
+});
+
+test("fails closed on malformed success responses", async () => {
+  await assert.rejects(
+    checkGithubReleaseState({
+      ...baseOptions,
+      fetchImpl: async () => jsonResponse(200, { id: 59 }),
+    }),
+    /boolean draft state/,
+  );
+  await assert.rejects(
+    checkGithubReleaseState({
+      ...baseOptions,
+      fetchImpl: async () => jsonResponse(200, { draft: true }),
+    }),
+    /valid release id/,
+  );
+});
+
+test("requires an existing draft before final publication", async () => {
+  await assert.rejects(
+    checkGithubReleaseState({
+      ...baseOptions,
+      requireDraft: true,
+      fetchImpl: async () => jsonResponse(404, { message: "Not Found" }),
+    }),
+    /Required draft release/,
+  );
+});

--- a/apps/desktop/scripts/github-release-state.test.mjs
+++ b/apps/desktop/scripts/github-release-state.test.mjs
@@ -39,10 +39,11 @@ test("accepts an authoritative 404 when no release may exist yet", async () => {
   assert.deepEqual(result, { state: "absent" });
 });
 
-test("accepts an existing draft and authenticates the lookup", async () => {
+test("accepts an existing draft only when publication requires it", async () => {
   const requests = [];
   const result = await checkGithubReleaseState({
     ...baseOptions,
+    requireDraft: true,
     fetchImpl: async (url, options) => {
       requests.push({ url, options });
       return requests.length === 1
@@ -60,6 +61,19 @@ test("accepts an existing draft and authenticates the lookup", async () => {
     "https://api.github.com/repos/minghinmatthewlam/pi-gui/releases?per_page=100&page=1",
   );
   assert.equal(requests[1].options.headers.Authorization, "Bearer test-token");
+});
+
+test("rejects an existing draft before the sole asset upload", async () => {
+  await assert.rejects(
+    checkGithubReleaseState({
+      ...baseOptions,
+      fetchImpl: sequenceFetch(
+        jsonResponse(404, { message: "Not Found" }),
+        jsonResponse(200, [{ id: 59, tag_name: baseOptions.tag, draft: true }]),
+      ),
+    }),
+    /already exists; refusing to replace its assets/,
+  );
 });
 
 test("rejects an already-published release", async () => {
@@ -140,7 +154,7 @@ test("requires an existing draft before final publication", async () => {
   );
 });
 
-test("paginates authenticated release listings before proving absence", async () => {
+test("paginates authenticated release listings before finding the required draft", async () => {
   const firstPage = Array.from({ length: 100 }, (_, index) => ({
     id: index + 1,
     tag_name: `v0.0.${index}`,
@@ -148,6 +162,7 @@ test("paginates authenticated release listings before proving absence", async ()
   }));
   const result = await checkGithubReleaseState({
     ...baseOptions,
+    requireDraft: true,
     fetchImpl: sequenceFetch(
       jsonResponse(404, { message: "Not Found" }),
       jsonResponse(200, firstPage),

--- a/apps/desktop/scripts/refresh-macos-update-metadata.mjs
+++ b/apps/desktop/scripts/refresh-macos-update-metadata.mjs
@@ -1,0 +1,124 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { readFile, rename, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseDocument, stringify } from "yaml";
+import { hashFile } from "./release-artifacts.mjs";
+
+const require = createRequire(import.meta.url);
+const { appBuilderPath } = require("app-builder-bin");
+
+function parseManifest(contents, manifestPath) {
+  const document = parseDocument(contents, { uniqueKeys: true });
+  if (document.errors.length > 0) {
+    throw new Error(
+      `Invalid update manifest ${manifestPath}: ${document.errors.map((error) => error.message).join("; ")}`,
+    );
+  }
+  return document.toJS();
+}
+
+function rebuildBlockmap(dmgPath, blockmapPath) {
+  const temporaryPath = `${blockmapPath}.final-${process.pid}`;
+  const result = spawnSync(
+    appBuilderPath,
+    ["blockmap", "--input", dmgPath, "--output", temporaryPath],
+    { encoding: "utf8" },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to regenerate ${path.basename(blockmapPath)}: ${result.stderr.trim() || `exit ${String(result.status)}`}`,
+    );
+  }
+
+  let metadata;
+  try {
+    metadata = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`app-builder returned invalid blockmap metadata for ${dmgPath}`);
+  }
+  return { metadata, temporaryPath };
+}
+
+export async function refreshMacUpdateMetadata({ releaseDir, version }) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+  }
+  const base = `pi-gui-${version}-arm64`;
+  const dmgName = `${base}.dmg`;
+  const zipName = `${base}.zip`;
+  const dmgPath = path.join(releaseDir, dmgName);
+  const blockmapPath = `${dmgPath}.blockmap`;
+  const manifestPath = path.join(releaseDir, "latest-mac.yml");
+
+  const { metadata, temporaryPath } = rebuildBlockmap(dmgPath, blockmapPath);
+  const [dmgDigest, zipDigest, blockmapStat] = await Promise.all([
+    hashFile(dmgPath),
+    hashFile(path.join(releaseDir, zipName)),
+    stat(temporaryPath),
+  ]);
+  if (metadata.size !== dmgDigest.size || metadata.sha512 !== dmgDigest.sha512) {
+    throw new Error("Regenerated DMG blockmap metadata does not match the final DMG bytes");
+  }
+
+  const manifest = parseManifest(await readFile(manifestPath, "utf8"), manifestPath);
+  if (manifest?.version !== version || !Array.isArray(manifest.files)) {
+    throw new Error(`latest-mac.yml does not describe macOS ${version}`);
+  }
+  const dmgEntries = manifest.files.filter((entry) => entry?.url === dmgName);
+  const zipEntries = manifest.files.filter((entry) => entry?.url === zipName);
+  if (dmgEntries.length !== 1 || zipEntries.length !== 1) {
+    throw new Error("latest-mac.yml must contain exactly one DMG and one ZIP entry");
+  }
+  if (
+    zipEntries[0].size !== zipDigest.size ||
+    zipEntries[0].sha512 !== zipDigest.sha512 ||
+    manifest.path !== zipName ||
+    manifest.sha512 !== zipDigest.sha512
+  ) {
+    throw new Error("latest-mac.yml ZIP metadata changed before final DMG refresh");
+  }
+
+  dmgEntries[0].size = dmgDigest.size;
+  dmgEntries[0].sha512 = dmgDigest.sha512;
+  if (dmgEntries[0].blockMapSize !== undefined) {
+    dmgEntries[0].blockMapSize = blockmapStat.size;
+  }
+
+  const temporaryManifest = `${manifestPath}.final-${process.pid}`;
+  await writeFile(temporaryManifest, stringify(manifest), "utf8");
+  await rename(temporaryPath, blockmapPath);
+  await rename(temporaryManifest, manifestPath);
+
+  return {
+    dmg: dmgName,
+    size: dmgDigest.size,
+    sha512: dmgDigest.sha512,
+    blockMapSize: blockmapStat.size,
+  };
+}
+
+async function main() {
+  const [releaseDir, version] = process.argv.slice(2);
+  if (!releaseDir || !version) {
+    throw new Error("Usage: refresh-macos-update-metadata.mjs <release-dir> <version>");
+  }
+  const result = await refreshMacUpdateMetadata({
+    releaseDir: path.resolve(releaseDir),
+    version,
+  });
+  console.log(
+    `Refreshed ${result.dmg} metadata from final bytes (${result.size} bytes, blockmap ${result.blockMapSize} bytes)`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/desktop/scripts/release-artifacts.mjs
+++ b/apps/desktop/scripts/release-artifacts.mjs
@@ -162,11 +162,20 @@ async function verifyUpdateManifest(inputDir, platform, version) {
 
     if (entry.blockMapSize !== undefined) {
       const blockmapName = `${entry.url}.blockmap`;
-      const blockmap = await hashFile(path.join(inputDir, blockmapName));
-      if (entry.blockMapSize !== blockmap.size) {
-        throw new Error(
-          `${spec.updateManifest} blockmap size mismatch for ${entry.url}: expected ${blockmap.size}, got ${String(entry.blockMapSize)}`,
-        );
+      if (spec.files.some(({ name }) => name === blockmapName)) {
+        const blockmap = await hashFile(path.join(inputDir, blockmapName));
+        if (entry.blockMapSize !== blockmap.size) {
+          throw new Error(
+            `${spec.updateManifest} blockmap size mismatch for ${entry.url}: expected ${blockmap.size}, got ${String(entry.blockMapSize)}`,
+          );
+        }
+      } else if (
+        platform !== "linux" ||
+        !Number.isSafeInteger(entry.blockMapSize) ||
+        entry.blockMapSize <= 0 ||
+        entry.blockMapSize > digest.size
+      ) {
+        throw new Error(`${spec.updateManifest} has an invalid embedded blockmap size for ${entry.url}`);
       }
     }
   }

--- a/apps/desktop/scripts/release-artifacts.mjs
+++ b/apps/desktop/scripts/release-artifacts.mjs
@@ -1,0 +1,405 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseDocument } from "yaml";
+
+const PRODUCT_NAME = "pi-gui";
+const SCHEMA_VERSION = 1;
+const PLATFORMS = ["macos", "linux", "windows"];
+
+function platformSpec(platform, version) {
+  const base = `${PRODUCT_NAME}-${version}`;
+  switch (platform) {
+    case "macos":
+      return {
+        manifestName: "release-manifest-macos.json",
+        updateManifest: "latest-mac.yml",
+        primaryUpdateAsset: `${base}-arm64.zip`,
+        updateAssets: [`${base}-arm64.zip`, `${base}-arm64.dmg`],
+        files: [
+          { name: `${base}-arm64.dmg`, role: "dmg" },
+          { name: `${base}-arm64.dmg.blockmap`, role: "dmg-blockmap" },
+          { name: `${base}-arm64.zip`, role: "update-archive" },
+          { name: `${base}-arm64.zip.blockmap`, role: "update-blockmap" },
+          { name: "latest-mac.yml", role: "update-manifest" },
+        ],
+      };
+    case "linux":
+      return {
+        manifestName: "release-manifest-linux.json",
+        updateManifest: "latest-linux.yml",
+        primaryUpdateAsset: `${base}-x86_64.AppImage`,
+        updateAssets: [`${base}-x86_64.AppImage`],
+        files: [
+          { name: `${base}-x86_64.AppImage`, role: "appimage" },
+          { name: "latest-linux.yml", role: "update-manifest" },
+        ],
+      };
+    case "windows":
+      return {
+        manifestName: "release-manifest-windows.json",
+        updateManifest: "latest.yml",
+        primaryUpdateAsset: `${base}-x64-setup.exe`,
+        updateAssets: [`${base}-x64-setup.exe`],
+        files: [
+          { name: `${base}-x64-setup.exe`, role: "installer" },
+          { name: `${base}-x64-setup.exe.blockmap`, role: "installer-blockmap" },
+          { name: `${base}-x64-portable.exe`, role: "portable" },
+          { name: "latest.yml", role: "update-manifest" },
+        ],
+      };
+    default:
+      throw new Error(`Unsupported release platform: ${platform}`);
+  }
+}
+
+export function expectedFiles(platform, version) {
+  return platformSpec(platform, version).files.map(({ name }) => name);
+}
+
+export async function hashFile(filePath) {
+  const sha256 = createHash("sha256");
+  const sha512 = createHash("sha512");
+  let size = 0;
+
+  for await (const chunk of createReadStream(filePath)) {
+    size += chunk.length;
+    sha256.update(chunk);
+    sha512.update(chunk);
+  }
+
+  return {
+    size,
+    sha256: sha256.digest("hex"),
+    sha512: sha512.digest("base64"),
+  };
+}
+
+async function assertRegularFile(filePath) {
+  let fileStat;
+  try {
+    fileStat = await stat(filePath);
+  } catch {
+    throw new Error(`Missing release artifact: ${filePath}`);
+  }
+  if (!fileStat.isFile()) {
+    throw new Error(`Release artifact is not a regular file: ${filePath}`);
+  }
+}
+
+function parseUpdateManifest(contents, manifestPath) {
+  const document = parseDocument(contents, { uniqueKeys: true });
+  if (document.errors.length > 0) {
+    throw new Error(
+      `Invalid update manifest ${manifestPath}: ${document.errors.map((error) => error.message).join("; ")}`,
+    );
+  }
+  const value = document.toJS();
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Update manifest must contain a mapping: ${manifestPath}`);
+  }
+  return value;
+}
+
+function assertFileName(value, field, manifestPath) {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    path.basename(value) !== value ||
+    value.includes("\\")
+  ) {
+    throw new Error(`${field} must be a plain artifact filename in ${manifestPath}`);
+  }
+}
+
+async function verifyUpdateManifest(inputDir, platform, version) {
+  const spec = platformSpec(platform, version);
+  const manifestPath = path.join(inputDir, spec.updateManifest);
+  const manifest = parseUpdateManifest(await readFile(manifestPath, "utf8"), manifestPath);
+
+  if (manifest.version !== version) {
+    throw new Error(
+      `${spec.updateManifest} version mismatch: expected ${version}, got ${String(manifest.version)}`,
+    );
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length === 0) {
+    throw new Error(`${spec.updateManifest} must list update payloads`);
+  }
+
+  const expectedUpdateAssets = new Set(spec.updateAssets);
+  const seenUpdateAssets = new Set();
+  for (const entry of manifest.files) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`${spec.updateManifest} contains an invalid files entry`);
+    }
+    assertFileName(entry.url, "files[].url", manifestPath);
+    if (!expectedUpdateAssets.has(entry.url)) {
+      throw new Error(`${spec.updateManifest} references unexpected payload ${entry.url}`);
+    }
+    if (seenUpdateAssets.has(entry.url)) {
+      throw new Error(`${spec.updateManifest} references ${entry.url} more than once`);
+    }
+    seenUpdateAssets.add(entry.url);
+
+    const digest = await hashFile(path.join(inputDir, entry.url));
+    if (entry.size !== digest.size) {
+      throw new Error(
+        `${spec.updateManifest} size mismatch for ${entry.url}: expected ${digest.size}, got ${String(entry.size)}`,
+      );
+    }
+    if (entry.sha512 !== digest.sha512) {
+      throw new Error(`${spec.updateManifest} SHA-512 mismatch for ${entry.url}`);
+    }
+
+    if (entry.blockMapSize !== undefined) {
+      const blockmapName = `${entry.url}.blockmap`;
+      const blockmap = await hashFile(path.join(inputDir, blockmapName));
+      if (entry.blockMapSize !== blockmap.size) {
+        throw new Error(
+          `${spec.updateManifest} blockmap size mismatch for ${entry.url}: expected ${blockmap.size}, got ${String(entry.blockMapSize)}`,
+        );
+      }
+    }
+  }
+
+  for (const expected of expectedUpdateAssets) {
+    if (!seenUpdateAssets.has(expected)) {
+      throw new Error(`${spec.updateManifest} does not reference required payload ${expected}`);
+    }
+  }
+
+  if (manifest.path !== spec.primaryUpdateAsset) {
+    throw new Error(
+      `${spec.updateManifest} primary path must be ${spec.primaryUpdateAsset}, got ${String(manifest.path)}`,
+    );
+  }
+  const primaryDigest = await hashFile(path.join(inputDir, spec.primaryUpdateAsset));
+  if (manifest.sha512 !== primaryDigest.sha512) {
+    throw new Error(`${spec.updateManifest} primary SHA-512 does not match ${spec.primaryUpdateAsset}`);
+  }
+}
+
+function validateVersion(version) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`Invalid release version: ${version}`);
+  }
+}
+
+function validateCommit(commit) {
+  if (!/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(`Release commit must be a 40-character Git SHA: ${commit}`);
+  }
+}
+
+async function buildPlatformManifest(inputDir, platform, version, commit) {
+  const spec = platformSpec(platform, version);
+  const files = [];
+  for (const entry of spec.files) {
+    const digest = await hashFile(path.join(inputDir, entry.name));
+    files.push({ name: entry.name, role: entry.role, ...digest });
+  }
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    platform,
+    version,
+    commit: commit.toLowerCase(),
+    updateManifest: spec.updateManifest,
+    files,
+  };
+}
+
+export async function stageArtifacts({ platform, version, commit, inputDir, outputDir }) {
+  validateVersion(version);
+  validateCommit(commit);
+  const spec = platformSpec(platform, version);
+
+  await mkdir(outputDir, { recursive: true });
+  const existing = await readdir(outputDir);
+  if (existing.length > 0) {
+    throw new Error(`Release staging directory must be empty: ${outputDir}`);
+  }
+
+  for (const entry of spec.files) {
+    const source = path.join(inputDir, entry.name);
+    const destination = path.join(outputDir, entry.name);
+    await assertRegularFile(source);
+    await copyFile(source, destination);
+  }
+
+  await verifyUpdateManifest(outputDir, platform, version);
+  const manifest = await buildPlatformManifest(outputDir, platform, version, commit);
+  await writeFile(
+    path.join(outputDir, spec.manifestName),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+  await verifyArtifacts({ platform, version, commit, inputDir: outputDir });
+  return manifest;
+}
+
+async function readPlatformManifest(inputDir, platform, version) {
+  const manifestName = platformSpec(platform, version).manifestName;
+  const manifestPath = path.join(inputDir, manifestName);
+  await assertRegularFile(manifestPath);
+
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Invalid release manifest ${manifestPath}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return { manifest, manifestName };
+}
+
+async function verifyPlatformArtifacts({ platform, version, commit, inputDir }) {
+  const spec = platformSpec(platform, version);
+  const { manifest, manifestName } = await readPlatformManifest(inputDir, platform, version);
+
+  if (
+    manifest.schemaVersion !== SCHEMA_VERSION ||
+    manifest.platform !== platform ||
+    manifest.version !== version ||
+    manifest.commit !== commit.toLowerCase() ||
+    manifest.updateManifest !== spec.updateManifest
+  ) {
+    throw new Error(`${manifestName} release identity does not match the requested candidate`);
+  }
+  if (!Array.isArray(manifest.files) || manifest.files.length !== spec.files.length) {
+    throw new Error(`${manifestName} does not contain the expected file set`);
+  }
+
+  for (let index = 0; index < spec.files.length; index += 1) {
+    const expected = spec.files[index];
+    const recorded = manifest.files[index];
+    if (recorded?.name !== expected.name || recorded?.role !== expected.role) {
+      throw new Error(`${manifestName} entry ${index} does not match ${expected.name}`);
+    }
+    await assertRegularFile(path.join(inputDir, expected.name));
+    const actual = await hashFile(path.join(inputDir, expected.name));
+    if (
+      recorded.size !== actual.size ||
+      recorded.sha256 !== actual.sha256 ||
+      recorded.sha512 !== actual.sha512
+    ) {
+      throw new Error(`${manifestName} digest mismatch for ${expected.name}`);
+    }
+  }
+
+  await verifyUpdateManifest(inputDir, platform, version);
+  return manifest;
+}
+
+export async function verifyArtifacts({ platform, version, commit, inputDir }) {
+  validateVersion(version);
+  validateCommit(commit);
+  const platforms = platform === "all" ? PLATFORMS : [platform];
+  const manifests = [];
+
+  for (const item of platforms) {
+    manifests.push(
+      await verifyPlatformArtifacts({ platform: item, version, commit, inputDir }),
+    );
+  }
+
+  if (platform === "all") {
+    const expected = new Set();
+    for (const item of PLATFORMS) {
+      const spec = platformSpec(item, version);
+      expected.add(spec.manifestName);
+      for (const file of spec.files) {
+        if (expected.has(file.name)) {
+          throw new Error(`Release platforms produce a colliding filename: ${file.name}`);
+        }
+        expected.add(file.name);
+      }
+    }
+
+    const actual = new Set();
+    for (const entry of await readdir(inputDir, { withFileTypes: true })) {
+      if (entry.isFile()) {
+        actual.add(entry.name);
+      }
+    }
+    const missing = [...expected].filter((name) => !actual.has(name));
+    const extra = [...actual].filter((name) => !expected.has(name));
+    if (missing.length > 0 || extra.length > 0) {
+      throw new Error(
+        `Combined release candidate file set mismatch (missing: ${missing.join(", ") || "none"}; extra: ${extra.join(", ") || "none"})`,
+      );
+    }
+  }
+
+  return manifests;
+}
+
+function parseArguments(argv) {
+  const [command, ...rest] = argv;
+  const options = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument list near ${key ?? "<end>"}`);
+    }
+    options[key.slice(2)] = value;
+  }
+  return { command, options };
+}
+
+async function main() {
+  const { command, options } = parseArguments(process.argv.slice(2));
+  const required = ["platform", "version", "commit", "input"];
+  if (command === "stage") {
+    required.push("output");
+  }
+  for (const name of required) {
+    if (!options[name]) {
+      throw new Error(`Missing required --${name}`);
+    }
+  }
+
+  if (command === "stage") {
+    const manifest = await stageArtifacts({
+      platform: options.platform,
+      version: options.version,
+      commit: options.commit,
+      inputDir: path.resolve(options.input),
+      outputDir: path.resolve(options.output),
+    });
+    console.log(
+      `Staged ${manifest.platform} ${manifest.version} artifacts at ${path.resolve(options.output)}`,
+    );
+    return;
+  }
+  if (command === "verify") {
+    const manifests = await verifyArtifacts({
+      platform: options.platform,
+      version: options.version,
+      commit: options.commit,
+      inputDir: path.resolve(options.input),
+    });
+    console.log(
+      `Verified ${manifests.map(({ platform }) => platform).join(", ")} release artifacts at ${path.resolve(options.input)}`,
+    );
+    return;
+  }
+  throw new Error("Usage: release-artifacts.mjs <stage|verify> --platform <name|all> --version <version> --commit <sha> --input <dir> [--output <dir>]");
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/desktop/scripts/release-artifacts.test.mjs
+++ b/apps/desktop/scripts/release-artifacts.test.mjs
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { cp, mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parse, stringify } from "yaml";
+import {
+  expectedFiles,
+  hashFile,
+  stageArtifacts,
+  verifyArtifacts,
+} from "./release-artifacts.mjs";
+
+const VERSION = "0.1.0-beta.34";
+const COMMIT = "a".repeat(40);
+
+function updateManifestName(platform) {
+  if (platform === "macos") {
+    return "latest-mac.yml";
+  }
+  if (platform === "linux") {
+    return "latest-linux.yml";
+  }
+  return "latest.yml";
+}
+
+function primaryUpdateAsset(platform) {
+  if (platform === "macos") {
+    return `pi-gui-${VERSION}-arm64.zip`;
+  }
+  if (platform === "linux") {
+    return `pi-gui-${VERSION}-x86_64.AppImage`;
+  }
+  return `pi-gui-${VERSION}-x64-setup.exe`;
+}
+
+function updateAssets(platform) {
+  if (platform === "macos") {
+    return [
+      `pi-gui-${VERSION}-arm64.zip`,
+      `pi-gui-${VERSION}-arm64.dmg`,
+    ];
+  }
+  return [primaryUpdateAsset(platform)];
+}
+
+async function createFixture(root, platform, override = {}) {
+  const source = path.join(root, `${platform}-source`);
+  await mkdir(source, { recursive: true });
+  const manifestName = updateManifestName(platform);
+
+  for (const name of expectedFiles(platform, VERSION)) {
+    if (name !== manifestName) {
+      await writeFile(path.join(source, name), `${platform}:${name}\n`, "utf8");
+    }
+  }
+
+  const files = [];
+  for (const name of updateAssets(platform)) {
+    const digest = await hashFile(path.join(source, name));
+    files.push({ url: name, sha512: digest.sha512, size: digest.size });
+  }
+  const primary = override.primary ?? primaryUpdateAsset(platform);
+  const primaryDigest = await hashFile(path.join(source, primary));
+  const updateManifest = {
+    version: VERSION,
+    files,
+    path: primary,
+    sha512: primaryDigest.sha512,
+    releaseDate: "2026-07-27T00:00:00.000Z",
+    ...override.manifest,
+  };
+  await writeFile(path.join(source, manifestName), stringify(updateManifest), "utf8");
+  return source;
+}
+
+async function stageFixture(root, platform, override) {
+  const inputDir = await createFixture(root, platform, override);
+  const outputDir = path.join(root, `${platform}-staged`);
+  await stageArtifacts({ platform, version: VERSION, commit: COMMIT, inputDir, outputDir });
+  return outputDir;
+}
+
+test("stages immutable platform manifests and verifies the combined candidate", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi-gui-release-artifacts-"));
+  const combined = path.join(root, "combined");
+  await mkdir(combined);
+
+  for (const platform of ["macos", "linux", "windows"]) {
+    const staged = await stageFixture(root, platform);
+    await cp(staged, combined, { recursive: true });
+  }
+
+  const manifests = await verifyArtifacts({
+    platform: "all",
+    version: VERSION,
+    commit: COMMIT,
+    inputDir: combined,
+  });
+  assert.deepEqual(
+    manifests.map(({ platform }) => platform),
+    ["macos", "linux", "windows"],
+  );
+});
+
+test("rejects bytes changed after the platform manifest was written", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi-gui-release-tamper-"));
+  const staged = await stageFixture(root, "windows");
+  await writeFile(
+    path.join(staged, `pi-gui-${VERSION}-x64-setup.exe`),
+    "changed after staging\n",
+    "utf8",
+  );
+
+  await assert.rejects(
+    verifyArtifacts({
+      platform: "windows",
+      version: VERSION,
+      commit: COMMIT,
+      inputDir: staged,
+    }),
+    /digest mismatch/,
+  );
+});
+
+test("rejects latest.yml when it selects the portable executable", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi-gui-release-portable-"));
+  const portable = `pi-gui-${VERSION}-x64-portable.exe`;
+  const source = await createFixture(root, "windows");
+  const manifestPath = path.join(source, "latest.yml");
+  const parsed = parse(await readFile(manifestPath, "utf8"));
+  const portableDigest = await hashFile(path.join(source, portable));
+  parsed.files = [{ url: portable, sha512: portableDigest.sha512, size: portableDigest.size }];
+  parsed.path = portable;
+  parsed.sha512 = portableDigest.sha512;
+  await writeFile(manifestPath, stringify(parsed), "utf8");
+
+  await assert.rejects(
+    stageArtifacts({
+      platform: "windows",
+      version: VERSION,
+      commit: COMMIT,
+      inputDir: source,
+      outputDir: path.join(root, "staged"),
+    }),
+    /unexpected payload|primary path/,
+  );
+});
+
+test("rejects undeclared files in the combined release candidate", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi-gui-release-extra-"));
+  const combined = path.join(root, "combined");
+  await mkdir(combined);
+  for (const platform of ["macos", "linux", "windows"]) {
+    await cp(await stageFixture(root, platform), combined, { recursive: true });
+  }
+  await writeFile(path.join(combined, "stale-installer.exe"), "stale\n", "utf8");
+
+  await assert.rejects(
+    verifyArtifacts({
+      platform: "all",
+      version: VERSION,
+      commit: COMMIT,
+      inputDir: combined,
+    }),
+    /file set mismatch/,
+  );
+});

--- a/apps/desktop/scripts/release-artifacts.test.mjs
+++ b/apps/desktop/scripts/release-artifacts.test.mjs
@@ -10,6 +10,7 @@ import {
   stageArtifacts,
   verifyArtifacts,
 } from "./release-artifacts.mjs";
+import { refreshMacUpdateMetadata } from "./refresh-macos-update-metadata.mjs";
 
 const VERSION = "0.1.0-beta.34";
 const COMMIT = "a".repeat(40);
@@ -172,4 +173,31 @@ test("rejects undeclared files in the combined release candidate", async () => {
     }),
     /file set mismatch/,
   );
+});
+
+test("refreshes macOS metadata and blockmap from final DMG bytes", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "pi-gui-release-final-dmg-"));
+  const source = await createFixture(root, "macos");
+  const manifestPath = path.join(source, "latest-mac.yml");
+  const manifest = parse(await readFile(manifestPath, "utf8"));
+  const dmgEntry = manifest.files.find(({ url }) => url.endsWith(".dmg"));
+  dmgEntry.size = 1;
+  dmgEntry.sha512 = "stale-before-stapling";
+  dmgEntry.blockMapSize = 1;
+  await writeFile(manifestPath, stringify(manifest), "utf8");
+
+  const refreshed = await refreshMacUpdateMetadata({ releaseDir: source, version: VERSION });
+  const finalManifest = parse(await readFile(manifestPath, "utf8"));
+  const finalDmg = finalManifest.files.find(({ url }) => url === refreshed.dmg);
+  assert.equal(finalDmg.size, refreshed.size);
+  assert.equal(finalDmg.sha512, refreshed.sha512);
+  assert.equal(finalDmg.blockMapSize, refreshed.blockMapSize);
+
+  await stageArtifacts({
+    platform: "macos",
+    version: VERSION,
+    commit: COMMIT,
+    inputDir: source,
+    outputDir: path.join(root, "staged"),
+  });
 });

--- a/apps/desktop/scripts/release-artifacts.test.mjs
+++ b/apps/desktop/scripts/release-artifacts.test.mjs
@@ -58,7 +58,14 @@ async function createFixture(root, platform, override = {}) {
   const files = [];
   for (const name of updateAssets(platform)) {
     const digest = await hashFile(path.join(source, name));
-    files.push({ url: name, sha512: digest.sha512, size: digest.size });
+    const entry = { url: name, sha512: digest.sha512, size: digest.size };
+    const blockmapName = `${name}.blockmap`;
+    if (expectedFiles(platform, VERSION).includes(blockmapName)) {
+      entry.blockMapSize = (await hashFile(path.join(source, blockmapName))).size;
+    } else if (platform === "linux") {
+      entry.blockMapSize = Math.min(8, digest.size);
+    }
+    files.push(entry);
   }
   const primary = override.primary ?? primaryUpdateAsset(platform);
   const primaryDigest = await hashFile(path.join(source, primary));

--- a/apps/desktop/scripts/verify-linux-release.sh
+++ b/apps/desktop/scripts/verify-linux-release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "Usage: verify-linux-release.sh <release-dir> <version>" >&2
+  exit 2
+fi
+
+release_dir="$(cd "$1" && pwd)"
+version="$2"
+appimage="$release_dir/pi-gui-$version-x86_64.AppImage"
+
+if [[ ! -f "$appimage" ]]; then
+  echo "Missing Linux release artifact: $appimage" >&2
+  exit 1
+fi
+
+readelf -h "$appimage" | grep -F "Advanced Micro Devices X86-64"
+chmod +x "$appimage"
+
+temporary_root="$(mktemp -d)"
+cleanup() {
+  rm -rf "$temporary_root"
+}
+trap cleanup EXIT
+
+(
+  cd "$temporary_root"
+  "$appimage" --appimage-extract >/dev/null
+)
+
+extracted="$temporary_root/squashfs-root"
+for executable in "$extracted/AppRun" "$extracted/pi-gui"; do
+  if [[ ! -x "$executable" ]]; then
+    echo "AppImage is missing executable payload: $executable" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "$extracted/resources/app.asar" ]]; then
+  echo "AppImage is missing resources/app.asar" >&2
+  exit 1
+fi
+
+readelf -h "$extracted/pi-gui" | grep -F "Advanced Micro Devices X86-64"
+echo "Verified x64 architecture and extracted AppImage payload for Linux $version"

--- a/apps/desktop/scripts/verify-release-config.mjs
+++ b/apps/desktop/scripts/verify-release-config.mjs
@@ -201,6 +201,7 @@ function validateWorkflow(
     '"t", $setup',
     '"t", $portable',
     '"x", "-y"',
+    '"app-*.7z"',
     "Assert-X64Pe $installedApp",
     "Assert-X64Pe $portableApp",
   ]) {

--- a/apps/desktop/scripts/verify-release-config.mjs
+++ b/apps/desktop/scripts/verify-release-config.mjs
@@ -81,7 +81,11 @@ function validateWorkflow(workflow, finalizerSource) {
       .map((step) => ({ jobName, step })),
   );
   assert(releaseSteps.length === 1, "Release workflow must have exactly one GitHub release action");
-  assert(releaseSteps[0].jobName === "publish", "Only the publish job may mutate a release");
+  assert(
+    releaseSteps[0].jobName === "stage-draft",
+    "Only the draft staging job may upload release assets",
+  );
+  assert(workflow.permissions?.contents === "read", "Release workflow must default to read access");
 
   validateBuildJob(jobs["build-macos"], "macOS");
   validateBuildJob(jobs["build-linux"], "Linux");
@@ -134,27 +138,27 @@ function validateWorkflow(workflow, finalizerSource) {
   );
   stepNamed(windowsJob, "Verify Windows signatures and architecture");
 
-  const publish = jobs.publish;
+  const stageDraft = jobs["stage-draft"];
   assert(
-    JSON.stringify(publish.needs) ===
+    JSON.stringify(stageDraft.needs) ===
       JSON.stringify(["build-macos", "build-linux", "build-windows"]),
-    "Publish job must wait for every platform candidate",
+    "Draft staging must wait for every platform candidate",
   );
-  assert(publish.environment === "release", "Publish job must use the release environment gate");
-  assert(publish.permissions?.contents === "write", "Only publish needs release write permission");
+  assert(
+    stageDraft.permissions?.contents === "write",
+    "Draft staging needs release write permission",
+  );
 
-  const steps = publish.steps ?? [];
+  const steps = stageDraft.steps ?? [];
   const candidateIndex = steps.findIndex(({ name }) => name === "Validate combined release candidate");
-  const stateCheck = stepNamed(publish, "Check existing release state");
+  const stateCheck = stepNamed(stageDraft, "Check existing release state");
+  const stateCheckIndex = steps.indexOf(stateCheck);
   const uploadIndex = steps.findIndex(({ uses }) => uses === "softprops/action-gh-release@v2");
-  const draftVerifyIndex = steps.findIndex(({ name }) => name === "Verify uploaded draft bytes");
-  const publishIndex = steps.findIndex(({ name }) => name === "Publish validated release");
   assert(
     candidateIndex >= 0 &&
-      candidateIndex < uploadIndex &&
-      uploadIndex < draftVerifyIndex &&
-      draftVerifyIndex < publishIndex,
-    "Candidate, draft upload, remote byte validation, and publication must remain ordered",
+      candidateIndex < stateCheckIndex &&
+      stateCheckIndex < uploadIndex,
+    "Candidate validation and fail-closed state lookup must precede draft upload",
   );
   assert(
     runText(stateCheck).includes("github-release-state.mjs") &&
@@ -168,18 +172,86 @@ function validateWorkflow(workflow, finalizerSource) {
     release.with?.fail_on_unmatched_files === true,
     "Draft upload must fail on unmatched artifact paths",
   );
+
+  const draftVerifiers = [
+    ["verify-draft-macos", "Verify draft macOS trust"],
+    ["verify-draft-linux", "Verify draft Linux architecture"],
+    ["verify-draft-windows", "Verify draft Windows signatures"],
+  ];
+  for (const [jobName, trustStep] of draftVerifiers) {
+    const job = jobs[jobName];
+    assert(job?.needs === "stage-draft", `${jobName} must wait for draft staging`);
+    assert(
+      runText(stepNamed(job, "Download draft release")).includes("gh release download"),
+      `${jobName} must download the draft release`,
+    );
+    assert(
+      runText(stepNamed(job, "Verify draft manifests and bytes")).includes("--platform all"),
+      `${jobName} must verify the complete draft byte set`,
+    );
+    stepNamed(job, trustStep);
+  }
+
+  const publish = jobs.publish;
   assert(
-    runText(steps[publishIndex]).includes("--draft=false"),
-    "The final gated step must publish the validated draft",
+    JSON.stringify(publish.needs) ===
+      JSON.stringify(["verify-draft-macos", "verify-draft-linux", "verify-draft-windows"]),
+    "Final publication must wait for all native draft trust checks",
+  );
+  assert(publish.environment === "release", "Final publication must use the release environment gate");
+  assert(publish.permissions?.contents === "write", "Final publication needs release write permission");
+
+  const publishSteps = publish.steps ?? [];
+  const requireIndex = publishSteps.findIndex(({ name }) => name === "Require the validated draft");
+  const revalidateIndex = publishSteps.findIndex(
+    ({ name }) => name === "Revalidate draft bytes before publication",
+  );
+  const publishIndex = publishSteps.findIndex(({ name }) => name === "Publish validated draft");
+  const publishedVerifyIndex = publishSteps.findIndex(
+    ({ name }) => name === "Verify published release bytes",
+  );
+  assert(
+    requireIndex >= 0 &&
+      requireIndex < revalidateIndex &&
+      revalidateIndex < publishIndex &&
+      publishIndex < publishedVerifyIndex,
+    "Draft state, bytes, publication, and public-byte verification must remain ordered",
+  );
+  assert(
+    runText(publishSteps[requireIndex]).includes("github-release-state.mjs --require-draft"),
+    "Final publication must fail closed unless the validated draft still exists",
+  );
+  assert(
+    runText(publishSteps[revalidateIndex]).includes("--platform all"),
+    "Final publication must revalidate unchanged draft bytes",
+  );
+  assert(
+    runText(publishSteps[publishIndex]).includes("--draft=false"),
+    "Only the final gated job may publish the validated draft",
+  );
+  assert(
+    runText(publishSteps[publishedVerifyIndex]).includes("--platform all"),
+    "Published release bytes must be redownloaded and verified",
   );
 
-  for (const jobName of [
-    "verify-published-macos",
-    "verify-published-linux",
-    "verify-published-windows",
-  ]) {
-    assert(jobs[jobName]?.needs === "publish", `${jobName} must validate the published release`);
-  }
+  const draftClears = Object.entries(jobs).flatMap(([jobName, job]) =>
+    (job.steps ?? [])
+      .filter((step) => runText(step).includes("--draft=false"))
+      .map(() => jobName),
+  );
+  assert(
+    JSON.stringify(draftClears) === JSON.stringify(["publish"]),
+    "Exactly one final job may clear the draft flag",
+  );
+
+  const writeJobs = Object.entries(jobs)
+    .filter(([, job]) => job.permissions?.contents === "write")
+    .map(([jobName]) => jobName);
+  assert(
+    JSON.stringify(writeJobs) === JSON.stringify(["stage-draft", "publish"]),
+    "Only draft staging and final publication may have release write permission",
+  );
+  assert(jobs["sync-homebrew"]?.needs === "publish", "Homebrew sync must wait for publication");
 }
 
 const [builderConfig, workflow, finalizerSource] = await Promise.all([

--- a/apps/desktop/scripts/verify-release-config.mjs
+++ b/apps/desktop/scripts/verify-release-config.mjs
@@ -33,6 +33,17 @@ function runText(step) {
   return typeof step.run === "string" ? step.run : "";
 }
 
+function validateCiWorkflow(workflow) {
+  const versionCheck = stepNamed(
+    workflow.jobs?.typecheck,
+    "Verify release version consistency",
+  );
+  assert(
+    runText(versionCheck).includes("pnpm verify:release-version"),
+    "CI must reject drift between product package versions",
+  );
+}
+
 function validateBuilderConfig(config) {
   assert(config.mac?.notarize === true, "electron-builder must notarize the macOS app");
   assert(
@@ -80,6 +91,23 @@ function validateWorkflow(
   windowsVerifierSource,
 ) {
   const jobs = workflow.jobs ?? {};
+  const releasePreflight = jobs["release-preflight"];
+  const versionCheck = stepNamed(
+    releasePreflight,
+    "Verify release tag and product versions",
+  );
+  assert(
+    runText(versionCheck).includes("verify-release-version.mjs") &&
+      runText(versionCheck).includes('--tag "$GITHUB_REF_NAME"'),
+    "Release preflight must require the exact tag across product package versions",
+  );
+  for (const jobName of ["build-macos", "build-linux", "build-windows"]) {
+    assert(
+      jobs[jobName]?.needs === "release-preflight",
+      `${jobName} must wait for release version preflight`,
+    );
+  }
+
   const releaseSteps = Object.entries(jobs).flatMap(([jobName, job]) =>
     (job.steps ?? [])
       .filter(({ uses }) => uses === "softprops/action-gh-release@v2")
@@ -352,12 +380,14 @@ function validateWorkflow(
 
 const [
   builderConfig,
+  ciWorkflow,
   workflow,
   finalizerSource,
   linuxVerifierSource,
   windowsVerifierSource,
 ] = await Promise.all([
   parseYaml("apps/desktop/electron-builder.yml"),
+  parseYaml(".github/workflows/ci.yml"),
   parseYaml(".github/workflows/release.yml"),
   readFile(path.join(scriptDir, "finalize-macos-release.sh"), "utf8"),
   readFile(path.join(scriptDir, "verify-linux-release.sh"), "utf8"),
@@ -365,6 +395,7 @@ const [
 ]);
 
 validateBuilderConfig(builderConfig);
+validateCiWorkflow(ciWorkflow);
 validateWorkflow(
   workflow,
   finalizerSource,

--- a/apps/desktop/scripts/verify-release-config.mjs
+++ b/apps/desktop/scripts/verify-release-config.mjs
@@ -145,6 +145,7 @@ function validateWorkflow(workflow, finalizerSource) {
 
   const steps = publish.steps ?? [];
   const candidateIndex = steps.findIndex(({ name }) => name === "Validate combined release candidate");
+  const stateCheck = stepNamed(publish, "Check existing release state");
   const uploadIndex = steps.findIndex(({ uses }) => uses === "softprops/action-gh-release@v2");
   const draftVerifyIndex = steps.findIndex(({ name }) => name === "Verify uploaded draft bytes");
   const publishIndex = steps.findIndex(({ name }) => name === "Publish validated release");
@@ -154,6 +155,11 @@ function validateWorkflow(workflow, finalizerSource) {
       uploadIndex < draftVerifyIndex &&
       draftVerifyIndex < publishIndex,
     "Candidate, draft upload, remote byte validation, and publication must remain ordered",
+  );
+  assert(
+    runText(stateCheck).includes("github-release-state.mjs") &&
+      !runText(stateCheck).includes("gh release view"),
+    "Existing release lookup must use the fail-closed API state checker",
   );
 
   const release = releaseSteps[0].step;

--- a/apps/desktop/scripts/verify-release-config.mjs
+++ b/apps/desktop/scripts/verify-release-config.mjs
@@ -73,7 +73,12 @@ function validateBuildJob(job, platform) {
   );
 }
 
-function validateWorkflow(workflow, finalizerSource) {
+function validateWorkflow(
+  workflow,
+  finalizerSource,
+  linuxVerifierSource,
+  windowsVerifierSource,
+) {
   const jobs = workflow.jobs ?? {};
   const releaseSteps = Object.entries(jobs).flatMap(([jobName, job]) =>
     (job.steps ?? [])
@@ -123,6 +128,23 @@ function validateWorkflow(workflow, finalizerSource) {
     "macOS metadata refresh must run after stapling and before artifact staging",
   );
 
+  const linuxBuildVerification = stepNamed(jobs["build-linux"], "Verify Linux package");
+  assert(
+    runText(linuxBuildVerification).includes("verify-linux-release.sh"),
+    "Linux build must extract and validate the AppImage",
+  );
+  for (const marker of [
+    "--appimage-extract",
+    '"$extracted/AppRun"',
+    '"$extracted/pi-gui"',
+    "resources/app.asar",
+  ]) {
+    assert(
+      linuxVerifierSource.includes(marker),
+      `Linux package verifier must contain: ${marker}`,
+    );
+  }
+
   const windowsJob = jobs["build-windows"];
   const signingCheck = stepNamed(windowsJob, "Validate Windows signing credentials");
   const packageStep = stepNamed(windowsJob, "Package Windows");
@@ -136,7 +158,29 @@ function validateWorkflow(workflow, finalizerSource) {
       JSON.stringify(packageStep.env).includes("secrets.WINDOWS_CSC_KEY_PASSWORD"),
     "Windows signing secrets must map to electron-builder CSC variables",
   );
-  stepNamed(windowsJob, "Verify Windows signatures and architecture");
+  const windowsBuildVerification = stepNamed(
+    windowsJob,
+    "Verify Windows signatures and architecture",
+  );
+  assert(
+    runText(windowsBuildVerification).includes("-SmokePackages"),
+    "Windows build must smoke-test both downloadable packages",
+  );
+  for (const marker of [
+    "Get-AuthenticodeSignature",
+    'Start-Process `',
+    '"/S"',
+    '"t", $setup',
+    '"t", $portable',
+    '"x", "-y"',
+    "Assert-X64Pe $installedApp",
+    "Assert-X64Pe $portableApp",
+  ]) {
+    assert(
+      windowsVerifierSource.includes(marker),
+      `Windows package verifier must contain: ${marker}`,
+    );
+  }
 
   const stageDraft = jobs["stage-draft"];
   assert(
@@ -175,7 +219,7 @@ function validateWorkflow(workflow, finalizerSource) {
 
   const draftVerifiers = [
     ["verify-draft-macos", "Verify draft macOS trust"],
-    ["verify-draft-linux", "Verify draft Linux architecture"],
+    ["verify-draft-linux", "Verify draft Linux package"],
     ["verify-draft-windows", "Verify draft Windows signatures"],
   ];
   for (const [jobName, trustStep] of draftVerifiers) {
@@ -191,6 +235,18 @@ function validateWorkflow(workflow, finalizerSource) {
     );
     stepNamed(job, trustStep);
   }
+  assert(
+    runText(stepNamed(jobs["verify-draft-linux"], "Verify draft Linux package")).includes(
+      "verify-linux-release.sh",
+    ),
+    "Downloaded draft AppImage must be extracted and validated",
+  );
+  assert(
+    runText(stepNamed(jobs["verify-draft-windows"], "Verify draft Windows signatures")).includes(
+      "-SmokePackages",
+    ),
+    "Downloaded draft Windows packages must be installed and extracted",
+  );
 
   const publish = jobs.publish;
   assert(
@@ -251,15 +307,68 @@ function validateWorkflow(workflow, finalizerSource) {
     JSON.stringify(writeJobs) === JSON.stringify(["stage-draft", "publish"]),
     "Only draft staging and final publication may have release write permission",
   );
-  assert(jobs["sync-homebrew"]?.needs === "publish", "Homebrew sync must wait for publication");
+
+  const publishedVerifiers = [
+    ["verify-published-macos", "Verify published macOS trust"],
+    ["verify-published-linux", "Verify published Linux package"],
+    ["verify-published-windows", "Verify published Windows signatures"],
+  ];
+  for (const [jobName, trustStep] of publishedVerifiers) {
+    const job = jobs[jobName];
+    assert(job?.needs === "publish", `${jobName} must wait for publication`);
+    assert(
+      runText(stepNamed(job, "Download published release")).includes("gh release download"),
+      `${jobName} must redownload the published release`,
+    );
+    assert(
+      runText(stepNamed(job, "Verify published manifests and bytes")).includes("--platform all"),
+      `${jobName} must verify the complete published byte set`,
+    );
+    stepNamed(job, trustStep);
+  }
+  assert(
+    runText(
+      stepNamed(jobs["verify-published-linux"], "Verify published Linux package"),
+    ).includes("verify-linux-release.sh"),
+    "Published AppImage must be extracted and validated",
+  );
+  assert(
+    runText(
+      stepNamed(jobs["verify-published-windows"], "Verify published Windows signatures"),
+    ).includes("-SmokePackages"),
+    "Published Windows packages must be installed and extracted",
+  );
+
+  assert(
+    JSON.stringify(jobs["sync-homebrew"]?.needs) ===
+      JSON.stringify([
+        "verify-published-macos",
+        "verify-published-linux",
+        "verify-published-windows",
+      ]),
+    "Homebrew sync must wait for every post-publication native verification",
+  );
 }
 
-const [builderConfig, workflow, finalizerSource] = await Promise.all([
+const [
+  builderConfig,
+  workflow,
+  finalizerSource,
+  linuxVerifierSource,
+  windowsVerifierSource,
+] = await Promise.all([
   parseYaml("apps/desktop/electron-builder.yml"),
   parseYaml(".github/workflows/release.yml"),
   readFile(path.join(scriptDir, "finalize-macos-release.sh"), "utf8"),
+  readFile(path.join(scriptDir, "verify-linux-release.sh"), "utf8"),
+  readFile(path.join(scriptDir, "verify-windows-release.ps1"), "utf8"),
 ]);
 
 validateBuilderConfig(builderConfig);
-validateWorkflow(workflow, finalizerSource);
+validateWorkflow(
+  workflow,
+  finalizerSource,
+  linuxVerifierSource,
+  windowsVerifierSource,
+);
 console.log("Release package and workflow configuration are valid.");

--- a/apps/desktop/scripts/verify-release-config.mjs
+++ b/apps/desktop/scripts/verify-release-config.mjs
@@ -1,0 +1,174 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseDocument } from "yaml";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoDir = path.resolve(scriptDir, "..", "..", "..");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function parseYaml(relativePath) {
+  const filePath = path.join(repoDir, relativePath);
+  const document = parseDocument(await readFile(filePath, "utf8"), { uniqueKeys: true });
+  if (document.errors.length > 0) {
+    throw new Error(
+      `${relativePath} is invalid YAML: ${document.errors.map((error) => error.message).join("; ")}`,
+    );
+  }
+  return document.toJS();
+}
+
+function stepNamed(job, name) {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  assert(step, `Missing workflow step "${name}"`);
+  return step;
+}
+
+function runText(step) {
+  return typeof step.run === "string" ? step.run : "";
+}
+
+function validateBuilderConfig(config) {
+  assert(config.mac?.notarize === true, "electron-builder must notarize the macOS app");
+  assert(
+    config.win?.signAndEditExecutable === true,
+    "electron-builder must sign and edit the packaged Windows executable",
+  );
+
+  const targets = new Set((config.win?.target ?? []).map(({ target }) => target));
+  assert(targets.has("nsis"), "Windows packaging must include NSIS");
+  assert(targets.has("portable"), "Windows packaging must include portable");
+
+  const setupName = "${productName}-${version}-${arch}-setup.${ext}";
+  const portableName = "${productName}-${version}-${arch}-portable.${ext}";
+  assert(config.nsis?.artifactName === setupName, `NSIS artifactName must be ${setupName}`);
+  assert(
+    config.portable?.artifactName === portableName,
+    `portable artifactName must be ${portableName}`,
+  );
+  assert(
+    config.nsis.artifactName !== config.portable.artifactName,
+    "NSIS and portable artifacts must not share a filename",
+  );
+}
+
+function validateBuildJob(job, platform) {
+  const upload = stepNamed(job, `Upload immutable ${platform} candidate`);
+  assert(upload.uses === "actions/upload-artifact@v4", `${platform} must use upload-artifact v4`);
+  assert(
+    upload.with?.["if-no-files-found"] === "error",
+    `${platform} candidate upload must fail when files are missing`,
+  );
+  assert(upload.with?.overwrite !== true, `${platform} candidate upload must remain immutable`);
+
+  const stage = stepNamed(job, `Stage validated ${platform} artifacts`);
+  assert(
+    runText(stage).includes("release-artifacts.mjs stage"),
+    `${platform} candidate must be staged through the release manifest helper`,
+  );
+}
+
+function validateWorkflow(workflow, finalizerSource) {
+  const jobs = workflow.jobs ?? {};
+  const releaseSteps = Object.entries(jobs).flatMap(([jobName, job]) =>
+    (job.steps ?? [])
+      .filter(({ uses }) => uses === "softprops/action-gh-release@v2")
+      .map((step) => ({ jobName, step })),
+  );
+  assert(releaseSteps.length === 1, "Release workflow must have exactly one GitHub release action");
+  assert(releaseSteps[0].jobName === "publish", "Only the publish job may mutate a release");
+
+  validateBuildJob(jobs["build-macos"], "macOS");
+  validateBuildJob(jobs["build-linux"], "Linux");
+  validateBuildJob(jobs["build-windows"], "Windows");
+
+  const macFinalize = stepNamed(jobs["build-macos"], "Notarize and verify final macOS artifacts");
+  assert(
+    runText(macFinalize).includes("finalize-macos-release.sh"),
+    "macOS build must run final DMG notarization and trust validation",
+  );
+  assert(
+    macFinalize["continue-on-error"] !== true,
+    "Final macOS validation must be fatal",
+  );
+  for (const command of [
+    "set -euo pipefail",
+    "notarytool submit",
+    "stapler staple",
+    "stapler validate",
+    "spctl --assess --type open",
+  ]) {
+    assert(finalizerSource.includes(command), `macOS finalizer must contain: ${command}`);
+  }
+
+  const windowsJob = jobs["build-windows"];
+  const signingCheck = stepNamed(windowsJob, "Validate Windows signing credentials");
+  const packageStep = stepNamed(windowsJob, "Package Windows");
+  assert(
+    JSON.stringify(signingCheck.env).includes("secrets.WINDOWS_CSC_LINK") &&
+      JSON.stringify(signingCheck.env).includes("secrets.WINDOWS_CSC_KEY_PASSWORD"),
+    "Windows build must require dedicated signing secrets",
+  );
+  assert(
+    JSON.stringify(packageStep.env).includes("secrets.WINDOWS_CSC_LINK") &&
+      JSON.stringify(packageStep.env).includes("secrets.WINDOWS_CSC_KEY_PASSWORD"),
+    "Windows signing secrets must map to electron-builder CSC variables",
+  );
+  stepNamed(windowsJob, "Verify Windows signatures and architecture");
+
+  const publish = jobs.publish;
+  assert(
+    JSON.stringify(publish.needs) ===
+      JSON.stringify(["build-macos", "build-linux", "build-windows"]),
+    "Publish job must wait for every platform candidate",
+  );
+  assert(publish.environment === "release", "Publish job must use the release environment gate");
+  assert(publish.permissions?.contents === "write", "Only publish needs release write permission");
+
+  const steps = publish.steps ?? [];
+  const candidateIndex = steps.findIndex(({ name }) => name === "Validate combined release candidate");
+  const uploadIndex = steps.findIndex(({ uses }) => uses === "softprops/action-gh-release@v2");
+  const draftVerifyIndex = steps.findIndex(({ name }) => name === "Verify uploaded draft bytes");
+  const publishIndex = steps.findIndex(({ name }) => name === "Publish validated release");
+  assert(
+    candidateIndex >= 0 &&
+      candidateIndex < uploadIndex &&
+      uploadIndex < draftVerifyIndex &&
+      draftVerifyIndex < publishIndex,
+    "Candidate, draft upload, remote byte validation, and publication must remain ordered",
+  );
+
+  const release = releaseSteps[0].step;
+  assert(release.with?.draft === true, "Release assets must be uploaded to a draft");
+  assert(
+    release.with?.fail_on_unmatched_files === true,
+    "Draft upload must fail on unmatched artifact paths",
+  );
+  assert(
+    runText(steps[publishIndex]).includes("--draft=false"),
+    "The final gated step must publish the validated draft",
+  );
+
+  for (const jobName of [
+    "verify-published-macos",
+    "verify-published-linux",
+    "verify-published-windows",
+  ]) {
+    assert(jobs[jobName]?.needs === "publish", `${jobName} must validate the published release`);
+  }
+}
+
+const [builderConfig, workflow, finalizerSource] = await Promise.all([
+  parseYaml("apps/desktop/electron-builder.yml"),
+  parseYaml(".github/workflows/release.yml"),
+  readFile(path.join(scriptDir, "finalize-macos-release.sh"), "utf8"),
+]);
+
+validateBuilderConfig(builderConfig);
+validateWorkflow(workflow, finalizerSource);
+console.log("Release package and workflow configuration are valid.");

--- a/apps/desktop/scripts/verify-release-config.mjs
+++ b/apps/desktop/scripts/verify-release-config.mjs
@@ -88,6 +88,8 @@ function validateWorkflow(workflow, finalizerSource) {
   validateBuildJob(jobs["build-windows"], "Windows");
 
   const macFinalize = stepNamed(jobs["build-macos"], "Notarize and verify final macOS artifacts");
+  const macRefresh = stepNamed(jobs["build-macos"], "Refresh update metadata from final DMG");
+  const macStage = stepNamed(jobs["build-macos"], "Stage validated macOS artifacts");
   assert(
     runText(macFinalize).includes("finalize-macos-release.sh"),
     "macOS build must run final DMG notarization and trust validation",
@@ -105,6 +107,17 @@ function validateWorkflow(workflow, finalizerSource) {
   ]) {
     assert(finalizerSource.includes(command), `macOS finalizer must contain: ${command}`);
   }
+  assert(
+    runText(macRefresh).includes("refresh-macos-update-metadata.mjs"),
+    "macOS build must regenerate update metadata from the stapled DMG",
+  );
+  assert(
+    jobs["build-macos"].steps.indexOf(macFinalize) <
+      jobs["build-macos"].steps.indexOf(macRefresh) &&
+      jobs["build-macos"].steps.indexOf(macRefresh) <
+        jobs["build-macos"].steps.indexOf(macStage),
+    "macOS metadata refresh must run after stapling and before artifact staging",
+  );
 
   const windowsJob = jobs["build-windows"];
   const signingCheck = stepNamed(windowsJob, "Validate Windows signing credentials");

--- a/apps/desktop/scripts/verify-windows-release.ps1
+++ b/apps/desktop/scripts/verify-windows-release.ps1
@@ -1,0 +1,54 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ReleaseDir,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Version,
+
+  [string]$PackagedApp
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Assert-ValidSignature([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Missing Windows release artifact: $Path"
+  }
+  $signature = Get-AuthenticodeSignature -LiteralPath $Path
+  if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+    throw "Authenticode validation failed for $Path with status $($signature.Status)"
+  }
+  Write-Host "Valid Authenticode signature: $Path ($($signature.SignerCertificate.Subject))"
+}
+
+function Assert-X64Pe([string]$Path) {
+  $stream = [System.IO.File]::OpenRead($Path)
+  $reader = [System.IO.BinaryReader]::new($stream)
+  try {
+    $stream.Position = 0x3c
+    $peOffset = $reader.ReadInt32()
+    $stream.Position = $peOffset
+    if ($reader.ReadUInt32() -ne 0x00004550) {
+      throw "Invalid PE signature: $Path"
+    }
+    if ($reader.ReadUInt16() -ne 0x8664) {
+      throw "Packaged application is not x64: $Path"
+    }
+  }
+  finally {
+    $reader.Dispose()
+    $stream.Dispose()
+  }
+  Write-Host "Valid x64 PE application: $Path"
+}
+
+$setup = Join-Path $ReleaseDir "pi-gui-$Version-x64-setup.exe"
+$portable = Join-Path $ReleaseDir "pi-gui-$Version-x64-portable.exe"
+Assert-ValidSignature $setup
+Assert-ValidSignature $portable
+
+if ($PackagedApp) {
+  Assert-ValidSignature $PackagedApp
+  Assert-X64Pe $PackagedApp
+}

--- a/apps/desktop/scripts/verify-windows-release.ps1
+++ b/apps/desktop/scripts/verify-windows-release.ps1
@@ -5,7 +5,9 @@ param(
   [Parameter(Mandatory = $true)]
   [string]$Version,
 
-  [string]$PackagedApp
+  [string]$PackagedApp,
+
+  [switch]$SmokePackages
 )
 
 $ErrorActionPreference = "Stop"
@@ -43,6 +45,27 @@ function Assert-X64Pe([string]$Path) {
   Write-Host "Valid x64 PE application: $Path"
 }
 
+function Get-SevenZip() {
+  $command = Get-Command 7z.exe -ErrorAction SilentlyContinue
+  if ($command) {
+    return $command.Source
+  }
+
+  $fallback = Join-Path $env:ProgramFiles "7-Zip\7z.exe"
+  if (Test-Path -LiteralPath $fallback -PathType Leaf) {
+    return $fallback
+  }
+
+  throw "7-Zip is required to validate Windows release packages"
+}
+
+function Invoke-SevenZip([string]$SevenZip, [string[]]$Arguments) {
+  & $SevenZip @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "7-Zip failed with exit code $LASTEXITCODE: $($Arguments -join ' ')"
+  }
+}
+
 $setup = Join-Path $ReleaseDir "pi-gui-$Version-x64-setup.exe"
 $portable = Join-Path $ReleaseDir "pi-gui-$Version-x64-portable.exe"
 Assert-ValidSignature $setup
@@ -51,4 +74,40 @@ Assert-ValidSignature $portable
 if ($PackagedApp) {
   Assert-ValidSignature $PackagedApp
   Assert-X64Pe $PackagedApp
+}
+
+if ($SmokePackages) {
+  $sevenZip = Get-SevenZip
+  $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) "pi-gui-release-$([guid]::NewGuid())"
+  $installRoot = Join-Path $temporaryRoot "installed"
+  $portableRoot = Join-Path $temporaryRoot "portable"
+  New-Item -ItemType Directory -Path $installRoot, $portableRoot | Out-Null
+
+  try {
+    Invoke-SevenZip $sevenZip @("t", $setup)
+    Invoke-SevenZip $sevenZip @("t", $portable)
+
+    $installer = Start-Process `
+      -FilePath $setup `
+      -ArgumentList @("/S", "/D=$installRoot") `
+      -Wait `
+      -PassThru
+    if ($installer.ExitCode -ne 0) {
+      throw "NSIS silent install failed with exit code $($installer.ExitCode)"
+    }
+
+    $installedApp = Join-Path $installRoot "pi-gui.exe"
+    Assert-ValidSignature $installedApp
+    Assert-X64Pe $installedApp
+
+    Invoke-SevenZip $sevenZip @("x", "-y", "-o$portableRoot", $portable)
+    $portableApp = Join-Path $portableRoot "pi-gui.exe"
+    Assert-ValidSignature $portableApp
+    Assert-X64Pe $portableApp
+  }
+  finally {
+    Remove-Item -LiteralPath $temporaryRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+
+  Write-Host "Verified NSIS install and portable extraction for Windows $Version"
 }

--- a/apps/desktop/scripts/verify-windows-release.ps1
+++ b/apps/desktop/scripts/verify-windows-release.ps1
@@ -62,7 +62,7 @@ function Get-SevenZip() {
 function Invoke-SevenZip([string]$SevenZip, [string[]]$Arguments) {
   & $SevenZip @Arguments
   if ($LASTEXITCODE -ne 0) {
-    throw "7-Zip failed with exit code $LASTEXITCODE: $($Arguments -join ' ')"
+    throw "7-Zip failed with exit code ${LASTEXITCODE}: $($Arguments -join ' ')"
   }
 }
 
@@ -101,7 +101,33 @@ if ($SmokePackages) {
     Assert-X64Pe $installedApp
 
     Invoke-SevenZip $sevenZip @("x", "-y", "-o$portableRoot", $portable)
-    $portableApp = Join-Path $portableRoot "pi-gui.exe"
+    $portableAppFile = Get-ChildItem `
+      -LiteralPath $portableRoot `
+      -Filter "pi-gui.exe" `
+      -File `
+      -Recurse | Select-Object -First 1
+    if (-not $portableAppFile) {
+      $embeddedArchive = Get-ChildItem `
+        -LiteralPath $portableRoot `
+        -Filter "app-*.7z" `
+        -File `
+        -Recurse | Select-Object -First 1
+      if (-not $embeddedArchive) {
+        throw "Portable package did not contain pi-gui.exe or an embedded application archive"
+      }
+      $embeddedRoot = Join-Path $portableRoot "embedded"
+      New-Item -ItemType Directory -Path $embeddedRoot | Out-Null
+      Invoke-SevenZip $sevenZip @("x", "-y", "-o$embeddedRoot", $embeddedArchive.FullName)
+      $portableAppFile = Get-ChildItem `
+        -LiteralPath $embeddedRoot `
+        -Filter "pi-gui.exe" `
+        -File `
+        -Recurse | Select-Object -First 1
+    }
+    if (-not $portableAppFile) {
+      throw "Portable application archive did not contain pi-gui.exe"
+    }
+    $portableApp = $portableAppFile.FullName
     Assert-ValidSignature $portableApp
     Assert-X64Pe $portableApp
   }

--- a/apps/desktop/tests/core/update-checker.spec.ts
+++ b/apps/desktop/tests/core/update-checker.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { compareSemver } from "../../electron/update-checker";
+import { compareSemver, releaseUrlFor } from "../../electron/update-checker";
 
 /**
  * Unit coverage for the version comparison that gates update notifications.
@@ -32,4 +32,25 @@ test("compareSemver does not flag a newer-local build as an update", () => {
 test("compareSemver returns equal for unparseable input so no update is claimed", () => {
   expect(compareSemver("weird", "0.80.3")).toBe(0);
   expect(compareSemver("0.80.3", "also-weird")).toBe(0);
+});
+
+test("releaseUrlFor keeps the selected repository release URL", () => {
+  expect(
+    releaseUrlFor({
+      tag_name: "v0.1.0-beta.34",
+      html_url: "https://github.com/minghinmatthewlam/pi-gui/releases/tag/v0.1.0-beta.34",
+    }),
+  ).toBe("https://github.com/minghinmatthewlam/pi-gui/releases/tag/v0.1.0-beta.34");
+});
+
+test("releaseUrlFor falls back to the exact tag instead of the generic latest route", () => {
+  expect(releaseUrlFor({ tag_name: "v0.1.0-beta.34" })).toBe(
+    "https://github.com/minghinmatthewlam/pi-gui/releases/tag/v0.1.0-beta.34",
+  );
+  expect(
+    releaseUrlFor({
+      tag_name: "v0.1.0-beta.34",
+      html_url: "https://example.com/releases/tag/v0.1.0-beta.34",
+    }),
+  ).toBe("https://github.com/minghinmatthewlam/pi-gui/releases/tag/v0.1.0-beta.34");
 });

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pi-gui/website",
   "private": true,
-  "version": "0.1.0-beta.32",
+  "version": "0.1.0-beta.33",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "apps/desktop": {
       "name": "@pi-gui/desktop",
-      "version": "0.1.0-beta.32",
+      "version": "0.1.0-beta.33",
       "dependencies": {
         "@aws-sdk/token-providers": "^3.1036.0",
         "@earendil-works/pi-coding-agent": "^0.74.0",
@@ -67,7 +67,7 @@
     },
     "apps/website": {
       "name": "@pi-gui/website",
-      "version": "0.1.0-beta.32",
+      "version": "0.1.0-beta.33",
       "dependencies": {
         "next": "^15.3.0",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "bun:test": "for dir in apps/* packages/*; do (cd \"$dir\" && (grep -q '\"bun:test\":' package.json && bun run bun:test || (grep -q '\"test\":' package.json && bun run test))); done",
     "e2e": "playwright test",
     "test:homebrew-tap": "node scripts/test-update-homebrew-tap.mjs",
+    "test:release-helpers": "node --test apps/desktop/scripts/release-artifacts.test.mjs",
     "verify:install-copy": "node scripts/verify-install-copy.mjs",
+    "verify:release-config": "node apps/desktop/scripts/verify-release-config.mjs",
     "verify:homebrew-flow": "node scripts/verify-homebrew-flow.mjs",
     "release:homebrew-sync": "node scripts/release-homebrew-sync.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-gui",
   "private": true,
-  "version": "0.1.0-beta.32",
+  "version": "0.1.0-beta.33",
   "license": "MIT",
   "packageManager": "pnpm@10.25.0",
   "scripts": {
@@ -25,9 +25,10 @@
     "bun:test": "for dir in apps/* packages/*; do (cd \"$dir\" && (grep -q '\"bun:test\":' package.json && bun run bun:test || (grep -q '\"test\":' package.json && bun run test))); done",
     "e2e": "playwright test",
     "test:homebrew-tap": "node scripts/test-update-homebrew-tap.mjs",
-    "test:release-helpers": "node --test apps/desktop/scripts/release-artifacts.test.mjs apps/desktop/scripts/github-release-state.test.mjs",
+    "test:release-helpers": "node --test apps/desktop/scripts/release-artifacts.test.mjs apps/desktop/scripts/github-release-state.test.mjs scripts/verify-release-version.test.mjs",
     "verify:install-copy": "node scripts/verify-install-copy.mjs",
     "verify:release-config": "node apps/desktop/scripts/verify-release-config.mjs",
+    "verify:release-version": "node scripts/verify-release-version.mjs",
     "verify:homebrew-flow": "node scripts/verify-homebrew-flow.mjs",
     "release:homebrew-sync": "node scripts/release-homebrew-sync.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bun:test": "for dir in apps/* packages/*; do (cd \"$dir\" && (grep -q '\"bun:test\":' package.json && bun run bun:test || (grep -q '\"test\":' package.json && bun run test))); done",
     "e2e": "playwright test",
     "test:homebrew-tap": "node scripts/test-update-homebrew-tap.mjs",
-    "test:release-helpers": "node --test apps/desktop/scripts/release-artifacts.test.mjs",
+    "test:release-helpers": "node --test apps/desktop/scripts/release-artifacts.test.mjs apps/desktop/scripts/github-release-state.test.mjs",
     "verify:install-copy": "node scripts/verify-install-copy.mjs",
     "verify:release-config": "node apps/desktop/scripts/verify-release-config.mjs",
     "verify:homebrew-flow": "node scripts/verify-homebrew-flow.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -276,6 +276,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
+      app-builder-bin:
+        specifier: 5.0.0-alpha.12
+        version: 5.0.0-alpha.12
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3

--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -1,0 +1,62 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+
+export const RELEASE_PACKAGE_PATHS = [
+  "package.json",
+  "apps/desktop/package.json",
+  "apps/website/package.json",
+];
+
+const VERSION_PATTERN =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?(?:\+[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$/;
+
+export function verifyReleaseVersions(packages, tag) {
+  const versions = new Set();
+  for (const { file, version } of packages) {
+    if (typeof version !== "string" || !VERSION_PATTERN.test(version)) {
+      throw new Error(`${file} has an invalid release version: ${String(version)}`);
+    }
+    versions.add(version);
+  }
+
+  if (versions.size !== 1) {
+    throw new Error(
+      `Release version drift: ${packages.map(({ file, version }) => `${file}=${String(version)}`).join(", ")}`,
+    );
+  }
+
+  const [version] = versions;
+  if (tag !== undefined && tag !== `v${version}`) {
+    throw new Error(`Release tag ${tag} does not match product version v${version}`);
+  }
+  return version;
+}
+
+export async function readReleasePackages(repoDir) {
+  return Promise.all(
+    RELEASE_PACKAGE_PATHS.map(async (file) => {
+      const packageJson = JSON.parse(await readFile(path.join(repoDir, file), "utf8"));
+      return { file, version: packageJson.version };
+    }),
+  );
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      tag: { type: "string" },
+    },
+  });
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const repoDir = path.resolve(scriptDir, "..");
+  const packages = await readReleasePackages(repoDir);
+  const version = verifyReleaseVersions(packages, values.tag);
+  const tagSuffix = values.tag ? ` and tag ${values.tag}` : "";
+  console.log(`Release version contract valid for ${version}${tagSuffix}.`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/verify-release-version.test.mjs
+++ b/scripts/verify-release-version.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { verifyReleaseVersions } from "./verify-release-version.mjs";
+
+const aligned = [
+  { file: "package.json", version: "1.2.3-beta.4" },
+  { file: "apps/desktop/package.json", version: "1.2.3-beta.4" },
+  { file: "apps/website/package.json", version: "1.2.3-beta.4" },
+];
+
+test("accepts aligned product versions and an exact release tag", () => {
+  assert.equal(verifyReleaseVersions(aligned, "v1.2.3-beta.4"), "1.2.3-beta.4");
+});
+
+test("rejects drift between product package manifests", () => {
+  assert.throws(
+    () =>
+      verifyReleaseVersions([
+        ...aligned.slice(0, 2),
+        { file: "apps/website/package.json", version: "1.2.3-beta.3" },
+      ]),
+    /Release version drift/,
+  );
+});
+
+test("rejects a tag that does not exactly match the product version", () => {
+  assert.throws(
+    () => verifyReleaseVersions(aligned, "v1.2.3-beta.5"),
+    /does not match product version/,
+  );
+});
+
+test("rejects invalid package versions", () => {
+  assert.throws(
+    () =>
+      verifyReleaseVersions([
+        ...aligned.slice(0, 2),
+        { file: "apps/website/package.json", version: "not-a-version" },
+      ]),
+    /invalid release version/,
+  );
+});


### PR DESCRIPTION
## Summary

- build and verify immutable macOS, Linux, and Windows release candidates before upload
- stage exactly one draft release, then re-download and verify its manifests, bytes, signatures/notarization, architecture, and package contents on each native platform
- publish only after all draft checks pass; re-verify public artifacts before Homebrew synchronization
- fail closed on existing/published release state, API/auth/transport errors, artifact drift, and product/tag version drift
- keep update links pinned to the selected release instead of the generic latest route

Addresses #59. Keep #59 and #52 open until the next real tagged release completes the native draft/public verification and an external macOS install is confirmed.

## Verification

- `git diff --check origin/main..HEAD`
- `pnpm test:release-helpers` (17/17)
- `pnpm verify:release-version`
- `pnpm verify:release-config`
- `pnpm --filter @pi-gui/desktop typecheck`
- `pnpm --filter @pi-gui/desktop test:e2e:runner -- apps/desktop/tests/core/update-checker.spec.ts` (6/6)
- independent autoreview: clean at P1 threshold

Proof logs: `/Users/matthewlam/.codex/proofs/pi-gui-issue-59/`

## Residual risk / merge policy

The source and local artifact contracts are verified, but macOS notarization/Gatekeeper, Windows Authenticode and installer/portable smoke, Linux AppImage extraction, draft publication, and public-byte verification require GitHub-hosted native runners plus release secrets. Do not create a new tag solely to test this PR. Merge only after normal PR CI, then use the next intended release tag as the final acceptance surface.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/pi-gui/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->