### PR TITLE
Prevent startup and catalog persistence data loss

### DIFF
--- a/apps/desktop/electron/app-store-persistence.ts
+++ b/apps/desktop/electron/app-store-persistence.ts
@@ -22,7 +22,7 @@ export interface PersistedUiState {
   readonly composerDraft?: string;
   readonly composerDraftsBySession?: Record<string, string>;
   readonly extensionCommandCompatibilityByWorkspace?: Record<string, readonly ExtensionCommandCompatibilityRecord[]>;
-  readonly notificationPreferences?: NotificationPreferences;
+  readonly notificationPreferences?: Partial<NotificationPreferences>;
   readonly integratedTerminalShell?: string;
   readonly lastViewedAtBySession?: Record<string, string>;
   readonly pinnedAtBySession?: Record<string, string>;
@@ -44,7 +44,7 @@ export interface LegacyPersistedUiState extends PersistedUiState {
 }
 
 export async function readPersistedUiState(uiStateFilePath: string): Promise<LegacyPersistedUiState> {
-  const result = await readJsonWithBackup<LegacyPersistedUiState>(uiStateFilePath);
+  const result = await readJsonWithBackup<unknown>(uiStateFilePath);
   if (result.corrupted) {
     // Surface corruption instead of silently returning `{}` (which the next
     // write would then persist over the last good state, losing pins, drafts,
@@ -56,67 +56,41 @@ export async function readPersistedUiState(uiStateFilePath: string): Promise<Leg
     );
   }
   const parsed = result.value;
-  if (!parsed || typeof parsed !== "object") {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     return {};
   }
+  const candidate = parsed as Record<string, unknown>;
 
   return {
-      version:
-        parsed.version === 15
-          ? 15
-          : parsed.version === 14
-          ? 14
-          : parsed.version === 13
-          ? 13
-          : parsed.version === 12
-          ? 12
-          : parsed.version === 11
-          ? 11
-          : parsed.version === 10
-          ? 10
-          : parsed.version === 9
-          ? 9
-          : parsed.version === 8
-            ? 8
-            : parsed.version === 7
-            ? 7
-            : parsed.version === 6
-              ? 6
-              : parsed.version === 5
-                ? 5
-                : parsed.version === 4
-                  ? 4
-                  : parsed.version === 3
-                    ? 3
-                    : parsed.version === 2
-                      ? 2
-                      : undefined,
-      selectedWorkspaceId: parsed.selectedWorkspaceId,
-      selectedSessionId: parsed.selectedSessionId,
-      activeView: parsed.activeView,
-      composerDraft: parsed.composerDraft ?? "",
-      composerDraftsBySession: parsed.composerDraftsBySession,
-      extensionCommandCompatibilityByWorkspace: parsed.extensionCommandCompatibilityByWorkspace,
-      notificationPreferences: parsed.notificationPreferences,
+      version: toPersistedVersion(candidate.version),
+      selectedWorkspaceId: stringValue(candidate.selectedWorkspaceId),
+      selectedSessionId: stringValue(candidate.selectedSessionId),
+      activeView: toAppView(candidate.activeView),
+      composerDraft: stringValue(candidate.composerDraft) ?? "",
+      composerDraftsBySession: toStringRecord(candidate.composerDraftsBySession),
+      extensionCommandCompatibilityByWorkspace: toPersistedCompatibilityByWorkspace(
+        candidate.extensionCommandCompatibilityByWorkspace,
+      ),
+      notificationPreferences: toNotificationPreferences(candidate.notificationPreferences),
       integratedTerminalShell:
-        typeof parsed.integratedTerminalShell === "string" ? parsed.integratedTerminalShell : undefined,
-      lastViewedAtBySession: parsed.lastViewedAtBySession,
-      pinnedAtBySession: toStringRecord(parsed.pinnedAtBySession),
-      pinnedSessionOrder: toStringArray(parsed.pinnedSessionOrder),
-      workspaceOrder: Array.isArray(parsed.workspaceOrder) ? parsed.workspaceOrder : undefined,
+        typeof candidate.integratedTerminalShell === "string" ? candidate.integratedTerminalShell : undefined,
+      lastViewedAtBySession: toStringRecord(candidate.lastViewedAtBySession),
+      pinnedAtBySession: toStringRecord(candidate.pinnedAtBySession),
+      pinnedSessionOrder: toStringArray(candidate.pinnedSessionOrder),
+      workspaceOrder: toStringArray(candidate.workspaceOrder),
       modelSettingsScopeMode:
-        parsed.modelSettingsScopeMode === "per-repo" || parsed.modelSettingsScopeMode === "app-global"
-          ? parsed.modelSettingsScopeMode
+        candidate.modelSettingsScopeMode === "per-repo" || candidate.modelSettingsScopeMode === "app-global"
+          ? candidate.modelSettingsScopeMode
           : undefined,
-      appGlobalModelSettings: toPersistedModelSettingsSnapshot(parsed.appGlobalModelSettings),
-      sidebarCollapsed: typeof parsed.sidebarCollapsed === "boolean" ? parsed.sidebarCollapsed : undefined,
-      allowMultiple: typeof parsed.allowMultiple === "boolean" ? parsed.allowMultiple : undefined,
-      enableTransparency: typeof parsed.enableTransparency === "boolean" ? parsed.enableTransparency : undefined,
-      themeMode: toThemeMode(parsed.themeMode),
-      themePresetId: toThemePresetId(parsed.themePresetId),
-      orchestrationChildren: toPersistedOrchestrationChildren(parsed.orchestrationChildren),
-      composerAttachmentsBySession: parsed.composerAttachmentsBySession,
-      transcripts: parsed.transcripts,
+      appGlobalModelSettings: toPersistedModelSettingsSnapshot(candidate.appGlobalModelSettings),
+      sidebarCollapsed: typeof candidate.sidebarCollapsed === "boolean" ? candidate.sidebarCollapsed : undefined,
+      allowMultiple: typeof candidate.allowMultiple === "boolean" ? candidate.allowMultiple : undefined,
+      enableTransparency: typeof candidate.enableTransparency === "boolean" ? candidate.enableTransparency : undefined,
+      themeMode: toThemeMode(candidate.themeMode),
+      themePresetId: toThemePresetId(candidate.themePresetId),
+      orchestrationChildren: toPersistedOrchestrationChildren(candidate.orchestrationChildren),
+      composerAttachmentsBySession: toObjectArrayRecord(candidate.composerAttachmentsBySession),
+      transcripts: toObjectArrayRecord(candidate.transcripts),
     };
 }
 
@@ -141,6 +115,22 @@ function toThemeMode(value: unknown): ThemeMode | undefined {
 
 function toThemePresetId(value: unknown): ThemePresetId | undefined {
   return isThemePresetId(value) ? value : undefined;
+}
+
+function toAppView(value: unknown): AppView | undefined {
+  return value === "threads" ||
+    value === "new-thread" ||
+    value === "skills" ||
+    value === "extensions" ||
+    value === "settings"
+    ? value
+    : undefined;
+}
+
+function toPersistedVersion(value: unknown): NonNullable<PersistedUiState["version"]> | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 2 && value <= 15
+    ? value as NonNullable<PersistedUiState["version"]>
+    : undefined;
 }
 
 function toStringArray(value: unknown): string[] | undefined {
@@ -366,14 +356,96 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+function toNotificationPreferences(value: unknown): Partial<NotificationPreferences> | undefined {
+  const candidate = objectRecord(value);
+  if (!candidate) {
+    return undefined;
+  }
+  const preferences = {
+    ...(typeof candidate.backgroundCompletion === "boolean"
+      ? { backgroundCompletion: candidate.backgroundCompletion }
+      : {}),
+    ...(typeof candidate.backgroundFailure === "boolean" ? { backgroundFailure: candidate.backgroundFailure } : {}),
+    ...(typeof candidate.attentionNeeded === "boolean" ? { attentionNeeded: candidate.attentionNeeded } : {}),
+  };
+  return Object.keys(preferences).length > 0 ? preferences : undefined;
+}
+
 function toStringRecord(value: unknown): Record<string, string> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
+  const candidate = objectRecord(value);
+  if (!candidate) {
     return undefined;
   }
 
-  const entries = Object.entries(value as Record<string, unknown>)
+  const entries = Object.entries(candidate)
     .filter((entry): entry is [string, string] => Boolean(entry[0]) && typeof entry[1] === "string" && Boolean(entry[1]));
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function toPersistedCompatibilityByWorkspace(
+  value: unknown,
+): Record<string, readonly ExtensionCommandCompatibilityRecord[]> | undefined {
+  const candidate = objectRecord(value);
+  if (!candidate) {
+    return undefined;
+  }
+
+  const entries = Object.entries(candidate).flatMap(([workspaceId, records]) => {
+    if (!workspaceId || !Array.isArray(records)) {
+      return [];
+    }
+    const validRecords = records.flatMap((record) => {
+      const parsed = toPersistedCompatibilityRecord(record);
+      return parsed ? [parsed] : [];
+    });
+    return validRecords.length > 0 ? [[workspaceId, validRecords] as const] : [];
+  });
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function toPersistedCompatibilityRecord(value: unknown): ExtensionCommandCompatibilityRecord | undefined {
+  const candidate = objectRecord(value);
+  if (
+    !candidate ||
+    typeof candidate.commandName !== "string" ||
+    typeof candidate.extensionPath !== "string" ||
+    (candidate.status !== "supported" && candidate.status !== "terminal-only") ||
+    typeof candidate.message !== "string" ||
+    typeof candidate.capability !== "string" ||
+    typeof candidate.updatedAt !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    commandName: candidate.commandName,
+    extensionPath: candidate.extensionPath,
+    status: candidate.status,
+    message: candidate.message,
+    capability: candidate.capability,
+    updatedAt: candidate.updatedAt,
+  };
+}
+
+function toObjectArrayRecord(value: unknown): Record<string, readonly unknown[]> | undefined {
+  const candidate = objectRecord(value);
+  if (!candidate) {
+    return undefined;
+  }
+
+  const entries = Object.entries(candidate).flatMap(([key, values]) => {
+    if (!key || !Array.isArray(values)) {
+      return [];
+    }
+    const objectValues = values.filter((entry) => Boolean(objectRecord(entry)));
+    return objectValues.length > 0 ? [[key, objectValues] as const] : [];
+  });
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }
 
 function toOrchestrationStatus(value: unknown): OrchestrationChildThread["status"] {
@@ -387,10 +459,10 @@ function toOptionalOrchestrationStatus(value: unknown): OrchestrationChildThread
 }
 
 function toPersistedModelSettingsSnapshot(value: unknown): ModelSettingsSnapshot | undefined {
-  if (!value || typeof value !== "object") {
+  const candidate = objectRecord(value);
+  if (!candidate) {
     return undefined;
   }
-  const candidate = value as Record<string, unknown>;
   const enabledModelPatterns = Array.isArray(candidate.enabledModelPatterns)
     ? candidate.enabledModelPatterns.filter((entry): entry is string => typeof entry === "string")
     : [];

--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -195,8 +195,9 @@ export class DesktopAppStore implements AppStoreInternals {
 
   constructor(options: DesktopAppStoreOptions) {
     const catalogFilePath = join(options.userDataDir, "catalogs.json");
+    this.catalogStore = new JsonCatalogStore({ catalogFilePath });
     const driverOptions: PiSdkDriverConfig = {
-      catalogFilePath,
+      catalogStorage: this.catalogStore,
       ...(options.driverOptions ?? {}),
       ...(options.generateThreadTitleOverride
         ? { generateThreadTitleOverride: options.generateThreadTitleOverride }
@@ -204,7 +205,6 @@ export class DesktopAppStore implements AppStoreInternals {
     };
 
     this.driver = new PiSdkDriver(driverOptions);
-    this.catalogStore = new JsonCatalogStore({ catalogFilePath });
     this.worktreeManager = new GitWorktreeManager({ catalogStorage: this.catalogStore });
     this.uiStateFilePath = join(options.userDataDir, "ui-state.json");
     this.attachmentStore = new JsonFileStore<ComposerAttachment[]>(options.userDataDir, "attachments");

--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -54,6 +54,7 @@ import {
   type SetChildSupervisionLoopInput,
   type SelectedTranscriptRecord,
   type StartThreadInput,
+  type StartupDiagnostic,
   type ThemeMode,
   type ThemePresetId,
   type TranscriptMessage,
@@ -1116,56 +1117,10 @@ export class DesktopAppStore implements AppStoreInternals {
 
   private async initializeInternal(): Promise<void> {
     const persisted = await this.readUiState();
+    this.restorePersistedUiState(persisted);
+    const startupDiagnostics: StartupDiagnostic[] = [];
     try {
-      this.state = {
-        ...this.state,
-        activeView: persisted.activeView ?? this.state.activeView,
-        modelSettingsScopeMode: persisted.modelSettingsScopeMode ?? this.state.modelSettingsScopeMode,
-        globalModelSettings: persisted.appGlobalModelSettings ?? this.state.globalModelSettings,
-        notificationPreferences: {
-          ...this.state.notificationPreferences,
-          ...persisted.notificationPreferences,
-        },
-        integratedTerminalShell: persisted.integratedTerminalShell ?? this.state.integratedTerminalShell,
-        lastViewedAtBySession: persisted.lastViewedAtBySession ?? {},
-        pinnedAtBySession: persisted.pinnedAtBySession ?? {},
-        pinnedSessionOrder: persisted.pinnedSessionOrder ?? [],
-        workspaceOrder: persisted.workspaceOrder ?? [],
-        themeMode: persisted.themeMode ?? this.state.themeMode,
-        themePresetId: persisted.themePresetId ?? this.state.themePresetId,
-        sidebarCollapsed: persisted.sidebarCollapsed ?? this.state.sidebarCollapsed,
-        enableTransparency: persisted.enableTransparency ?? this.state.enableTransparency,
-        orchestrationChildren: persisted.orchestrationChildren ?? [],
-      };
       await this.migrateLegacyPersistence(persisted);
-      this.sessionState.lastViewedAtBySession.clear();
-      for (const [key, viewedAt] of Object.entries(persisted.lastViewedAtBySession ?? {})) {
-        if (viewedAt) {
-          this.sessionState.lastViewedAtBySession.set(key, viewedAt);
-        }
-      }
-      this.sessionState.pinnedAtBySession.clear();
-      for (const [key, pinnedAt] of Object.entries(persisted.pinnedAtBySession ?? {})) {
-        if (pinnedAt) {
-          this.sessionState.pinnedAtBySession.set(key, pinnedAt);
-        }
-      }
-      this.sessionState.pinnedSessionOrder = reconcilePinnedSessionOrder(
-        this.sessionState.pinnedAtBySession,
-        persisted.pinnedSessionOrder ?? [],
-      ).slice();
-      this.sessionState.composerDraftsBySession.clear();
-      for (const [key, draft] of Object.entries(persisted.composerDraftsBySession ?? {})) {
-        if (draft) {
-          this.sessionState.composerDraftsBySession.set(key, draft);
-        }
-      }
-      this.extensionCommandCompatibilityByWorkspace.clear();
-      for (const [workspaceId, records] of restoreCompatibilityByWorkspace(
-        persisted.extensionCommandCompatibilityByWorkspace,
-      )) {
-        this.extensionCommandCompatibilityByWorkspace.set(workspaceId, records);
-      }
       const initialWorkspacePaths = this.initialWorkspacePaths.map((path) => path.trim()).filter(Boolean);
       const knownWorkspaces = await this.driver.listWorkspaces();
       const workspacesToSync = new Map<string, string | undefined>();
@@ -1178,10 +1133,13 @@ export class DesktopAppStore implements AppStoreInternals {
         workspacesToSync.set(ws.path, ws.displayName);
       }
 
-      await Promise.all(
+      const syncDiagnostics = await Promise.all(
         [...workspacesToSync.entries()].map(([workspacePath, displayName]) =>
-          this.driver.syncWorkspace(workspacePath, displayName),
+          this.syncStartupWorkspace(workspacePath, displayName),
         ),
+      );
+      startupDiagnostics.push(
+        ...syncDiagnostics.filter((diagnostic): diagnostic is StartupDiagnostic => Boolean(diagnostic)),
       );
 
       await this.refreshState({
@@ -1202,18 +1160,111 @@ export class DesktopAppStore implements AppStoreInternals {
       }
       this.startSelectedSessionHydration(restoredSessionRef, { markViewed: false });
       this.scheduleOrchestrationSupervision();
+      this.publishStartupDiagnostics(startupDiagnostics);
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("[app-store] startup recovery failed", error);
+      startupDiagnostics.push({
+        scope: "application",
+        message,
+      });
       this.state = {
-        ...createEmptyDesktopAppState(),
-        themeMode: persisted.themeMode ?? "system",
-        themePresetId: persisted.themePresetId ?? "default",
-        enableTransparency: persisted.enableTransparency ?? false,
-        lastError: error instanceof Error ? error.message : String(error),
-        revision: 1,
+        ...this.state,
+        startupDiagnostics,
+        lastError: message,
+        revision: this.state.revision + 1,
       };
-      await this.persistUiState();
       this.emit();
     }
+  }
+
+  private restorePersistedUiState(persisted: LegacyPersistedUiState): void {
+    this.state = {
+      ...this.state,
+      selectedWorkspaceId: persisted.selectedWorkspaceId ?? this.state.selectedWorkspaceId,
+      selectedSessionId: persisted.selectedSessionId ?? this.state.selectedSessionId,
+      activeView: persisted.activeView ?? this.state.activeView,
+      composerDraft: persisted.composerDraft ?? this.state.composerDraft,
+      modelSettingsScopeMode: persisted.modelSettingsScopeMode ?? this.state.modelSettingsScopeMode,
+      globalModelSettings: persisted.appGlobalModelSettings ?? this.state.globalModelSettings,
+      notificationPreferences: {
+        ...this.state.notificationPreferences,
+        ...persisted.notificationPreferences,
+      },
+      integratedTerminalShell: persisted.integratedTerminalShell ?? this.state.integratedTerminalShell,
+      lastViewedAtBySession: persisted.lastViewedAtBySession ?? {},
+      pinnedAtBySession: persisted.pinnedAtBySession ?? {},
+      pinnedSessionOrder: persisted.pinnedSessionOrder ?? [],
+      workspaceOrder: persisted.workspaceOrder ?? [],
+      themeMode: persisted.themeMode ?? this.state.themeMode,
+      themePresetId: persisted.themePresetId ?? this.state.themePresetId,
+      sidebarCollapsed: persisted.sidebarCollapsed ?? this.state.sidebarCollapsed,
+      enableTransparency: persisted.enableTransparency ?? this.state.enableTransparency,
+      orchestrationChildren: persisted.orchestrationChildren ?? [],
+    };
+
+    this.sessionState.lastViewedAtBySession.clear();
+    for (const [key, viewedAt] of Object.entries(persisted.lastViewedAtBySession ?? {})) {
+      if (viewedAt) {
+        this.sessionState.lastViewedAtBySession.set(key, viewedAt);
+      }
+    }
+    this.sessionState.pinnedAtBySession.clear();
+    for (const [key, pinnedAt] of Object.entries(persisted.pinnedAtBySession ?? {})) {
+      if (pinnedAt) {
+        this.sessionState.pinnedAtBySession.set(key, pinnedAt);
+      }
+    }
+    this.sessionState.pinnedSessionOrder = reconcilePinnedSessionOrder(
+      this.sessionState.pinnedAtBySession,
+      persisted.pinnedSessionOrder ?? [],
+    ).slice();
+    this.sessionState.composerDraftsBySession.clear();
+    for (const [key, draft] of Object.entries(persisted.composerDraftsBySession ?? {})) {
+      if (draft) {
+        this.sessionState.composerDraftsBySession.set(key, draft);
+      }
+    }
+    this.extensionCommandCompatibilityByWorkspace.clear();
+    for (const [workspaceId, records] of restoreCompatibilityByWorkspace(
+      persisted.extensionCommandCompatibilityByWorkspace,
+    )) {
+      this.extensionCommandCompatibilityByWorkspace.set(workspaceId, records);
+    }
+  }
+
+  private async syncStartupWorkspace(
+    workspacePath: string,
+    displayName: string | undefined,
+  ): Promise<StartupDiagnostic | undefined> {
+    try {
+      const workspaceStat = await stat(workspacePath);
+      if (!workspaceStat.isDirectory()) {
+        throw new Error("Path is not a directory.");
+      }
+      await this.driver.syncWorkspace(workspacePath, displayName);
+      return undefined;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[app-store] workspace unavailable during startup: ${workspacePath}: ${message}`);
+      return {
+        scope: "workspace",
+        workspacePath,
+        message,
+      };
+    }
+  }
+
+  private publishStartupDiagnostics(diagnostics: readonly StartupDiagnostic[]): void {
+    if (diagnostics.length === 0) {
+      return;
+    }
+    this.state = {
+      ...this.state,
+      startupDiagnostics: [...diagnostics],
+      revision: this.state.revision + 1,
+    };
+    this.emit();
   }
 
   private async migrateLegacyPersistence(persisted: LegacyPersistedUiState): Promise<void> {

--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -1120,7 +1120,26 @@ export class DesktopAppStore implements AppStoreInternals {
     const startupDiagnostics: StartupDiagnostic[] = [];
     try {
       this.restorePersistedUiState(persisted);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn("[app-store] ignoring malformed persisted UI state", error);
+      startupDiagnostics.push({
+        scope: "application",
+        message: `Persisted UI state could not be fully restored: ${message}`,
+      });
+    }
+    try {
       await this.migrateLegacyPersistence(persisted);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn("[app-store] ignoring malformed legacy UI state", error);
+      startupDiagnostics.push({
+        scope: "application",
+        message: `Legacy UI state could not be fully migrated: ${message}`,
+      });
+    }
+
+    try {
       const initialWorkspacePaths = this.initialWorkspacePaths.map((path) => path.trim()).filter(Boolean);
       const knownWorkspaces = await this.driver.listWorkspaces();
       const workspacesToSync = new Map<string, string | undefined>();

--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -1117,9 +1117,9 @@ export class DesktopAppStore implements AppStoreInternals {
 
   private async initializeInternal(): Promise<void> {
     const persisted = await this.readUiState();
-    this.restorePersistedUiState(persisted);
     const startupDiagnostics: StartupDiagnostic[] = [];
     try {
+      this.restorePersistedUiState(persisted);
       await this.migrateLegacyPersistence(persisted);
       const initialWorkspacePaths = this.initialWorkspacePaths.map((path) => path.trim()).filter(Boolean);
       const knownWorkspaces = await this.driver.listWorkspaces();

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -599,6 +599,7 @@ export default function App() {
     sidePanelMode ? "main--with-diff" : "",
     isTerminalVisibleForSelectedThread ? "main--with-terminal" : "",
     showTerminalTakeover ? "main--terminal-takeover" : "",
+    snapshot.startupDiagnostics.length > 0 ? "main--with-startup-diagnostics" : "",
   ].filter(Boolean).join(" ");
   const terminalPanel = isTerminalVisibleForSelectedThread && selectedWorkspace ? (
     <TerminalPanel
@@ -807,6 +808,20 @@ export default function App() {
           promptRailVisible={promptRailVisible}
           onTogglePromptRail={togglePromptRail}
         />
+
+        {snapshot.startupDiagnostics.length > 0 ? (
+          <div className="startup-diagnostics" role="status" data-testid="startup-diagnostics">
+            <strong>Some saved workspaces could not be refreshed.</strong>
+            <span>
+              {snapshot.startupDiagnostics
+                .map((diagnostic) => {
+                  const workspaceName = diagnostic.workspacePath?.split(/[\\/]/).filter(Boolean).at(-1);
+                  return workspaceName ? `${workspaceName} is unavailable.` : diagnostic.message;
+                })
+                .join(" ")}
+            </span>
+          </div>
+        ) : null}
 
         {showTerminalTakeover ? (
           terminalPanel

--- a/apps/desktop/src/desktop-state.ts
+++ b/apps/desktop/src/desktop-state.ts
@@ -288,6 +288,12 @@ export interface RemoveWorktreeInput {
   readonly worktreeId: string;
 }
 
+export interface StartupDiagnostic {
+  readonly scope: "application" | "workspace";
+  readonly message: string;
+  readonly workspacePath?: string;
+}
+
 export interface DesktopAppState {
   readonly workspaces: readonly WorkspaceRecord[];
   readonly worktreesByWorkspace: Readonly<Record<string, readonly WorktreeRecord[]>>;
@@ -317,6 +323,7 @@ export interface DesktopAppState {
   readonly themePresetId: ThemePresetId;
   readonly sidebarCollapsed: boolean;
   readonly enableTransparency: boolean;
+  readonly startupDiagnostics: readonly StartupDiagnostic[];
   readonly revision: number;
   readonly lastError?: string;
 }
@@ -366,6 +373,7 @@ export function createEmptyDesktopAppState(): DesktopAppState {
     themePresetId: "default",
     sidebarCollapsed: false,
     enableTransparency: false,
+    startupDiagnostics: [],
     revision: 0,
   };
 }

--- a/apps/desktop/src/styles/main.css
+++ b/apps/desktop/src/styles/main.css
@@ -35,12 +35,28 @@
   grid-template-rows: auto minmax(0, 1fr) auto auto;
 }
 
+.main--with-startup-diagnostics {
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+}
+
+.main--with-terminal.main--with-startup-diagnostics {
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+}
+
+.main--with-side-panel > .startup-diagnostics {
+  grid-column: 1 / -1;
+}
+
 .main--with-side-panel > .terminal-panel {
   grid-column: 1;
 }
 
 .main--with-side-panel.main--terminal-takeover {
   grid-template-rows: auto minmax(0, 1fr);
+}
+
+.main--with-side-panel.main--terminal-takeover.main--with-startup-diagnostics {
+  grid-template-rows: auto auto minmax(0, 1fr);
 }
 
 .canvas {
@@ -169,6 +185,14 @@
 
 .main--with-side-panel.main--with-terminal > .diff-panel {
   grid-row: 2 / span 3;
+}
+
+.main--with-side-panel.main--with-startup-diagnostics > .diff-panel {
+  grid-row: 3 / -1;
+}
+
+.main--with-side-panel.main--with-terminal.main--with-startup-diagnostics > .diff-panel {
+  grid-row: 3 / span 3;
 }
 
 .file-workbench__mode {
@@ -461,6 +485,10 @@
   height: auto;
   max-height: none;
   z-index: 20;
+}
+
+.main--with-startup-diagnostics > .terminal-panel--takeover {
+  grid-row: 3 / -1;
 }
 
 .terminal-panel__resize-handle {
@@ -780,6 +808,18 @@
   color: var(--text-strong);
   font-size: 13px;
   font-weight: 600;
+}
+
+.startup-diagnostics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--danger-tint-border);
+  background: var(--danger-tint-bg);
+  color: var(--error-ink);
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .composer__slash-intent-meta {

--- a/apps/desktop/tests/core/persistence.spec.ts
+++ b/apps/desktop/tests/core/persistence.spec.ts
@@ -196,6 +196,77 @@ test("recovers persisted ui state from the backup when ui-state.json is corrupt"
   }
 });
 
+test("recovers from parseable malformed nested state without overwriting valid fields", async () => {
+  test.setTimeout(90_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await makeWorkspace("malformed-nested-state-workspace");
+  const uiStatePath = join(userDataDir, "ui-state.json");
+
+  const firstRun = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+  let workspaceId = "";
+  let sessionId = "";
+  try {
+    const window = await firstRun.firstWindow();
+    await createNamedThread(window, "Malformed nested state session");
+    await window.getByTestId("composer").fill("valid draft survives malformed nested state");
+    const state = await getDesktopState(window);
+    workspaceId = state.selectedWorkspaceId;
+    sessionId = state.selectedSessionId;
+    await expect.poll(async () => readFile(uiStatePath, "utf8")).toContain(
+      "valid draft survives malformed nested state",
+    );
+  } finally {
+    await firstRun.close();
+  }
+
+  const persisted = JSON.parse(await readFile(uiStatePath, "utf8")) as Record<string, unknown>;
+  const malformedSnapshot = `${JSON.stringify(
+    {
+      ...persisted,
+      selectedWorkspaceId: workspaceId,
+      selectedSessionId: sessionId,
+      composerDraft: "valid draft survives malformed nested state",
+      composerDraftsBySession: {
+        [`${workspaceId}:${sessionId}`]: "valid draft survives malformed nested state",
+      },
+      extensionCommandCompatibilityByWorkspace: {
+        [workspaceId]: {
+          commandName: "not-an-array",
+        },
+      },
+    },
+    null,
+    2,
+  )}\n`;
+  await writeFile(uiStatePath, malformedSnapshot, "utf8");
+
+  const secondRun = await launchDesktop(userDataDir, { testMode: "background" });
+  try {
+    const window = await secondRun.firstWindow();
+    const state = await getDesktopState(window);
+    expect(state.lastError).toContain("records is not iterable");
+    expect(state.startupDiagnostics).toEqual([
+      expect.objectContaining({
+        scope: "application",
+      }),
+    ]);
+    await expect(window.getByTestId("startup-diagnostics")).toBeVisible();
+  } finally {
+    await secondRun.close();
+  }
+
+  const recovered = JSON.parse(await readFile(uiStatePath, "utf8")) as Record<string, unknown>;
+  expect(recovered.selectedWorkspaceId).toBe(workspaceId);
+  expect(recovered.selectedSessionId).toBe(sessionId);
+  expect(recovered.composerDraft).toBe("valid draft survives malformed nested state");
+  expect(recovered.composerDraftsBySession).toEqual({
+    [`${workspaceId}:${sessionId}`]: "valid draft survives malformed nested state",
+  });
+});
+
 test("preserves durable ui state when one startup workspace is unavailable", async () => {
   test.setTimeout(120_000);
   const userDataDir = await makeUserDataDir();

--- a/apps/desktop/tests/core/persistence.spec.ts
+++ b/apps/desktop/tests/core/persistence.spec.ts
@@ -1,4 +1,4 @@
-import { readFile, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
@@ -193,6 +193,197 @@ test("recovers persisted ui state from the backup when ui-state.json is corrupt"
     await expect(window.getByTestId("composer")).toHaveValue("recover me from backup", { timeout: 15_000 });
   } finally {
     await secondRun.close();
+  }
+});
+
+test("preserves durable ui state when one startup workspace is unavailable", async () => {
+  test.setTimeout(120_000);
+  const userDataDir = await makeUserDataDir();
+  const healthyWorkspacePath = await makeWorkspace("healthy-startup-workspace");
+  const unavailableWorkspacePath = await makeWorkspace("unavailable-startup-workspace");
+  const uiStatePath = join(userDataDir, "ui-state.json");
+
+  const firstRun = await launchDesktop(userDataDir, {
+    initialWorkspaces: [healthyWorkspacePath, unavailableWorkspacePath],
+    testMode: "background",
+  });
+  let unavailableWorkspaceId = "";
+  let healthyWorkspaceId = "";
+  let unavailableSessionId = "";
+  try {
+    const window = await firstRun.firstWindow();
+    const seededState = await window.evaluate(async ({ healthyPath, unavailablePath }) => {
+      const app = window.piApp;
+      if (!app) {
+        throw new Error("piApp IPC bridge is unavailable");
+      }
+      let state = await app.getState();
+      const healthy = state.workspaces.find((entry) => entry.path === healthyPath);
+      const unavailable = state.workspaces.find((entry) => entry.path === unavailablePath);
+      if (!healthy || !unavailable) {
+        throw new Error("Expected both seeded workspaces");
+      }
+
+      await app.selectWorkspace(unavailable.id);
+      state = await app.createSession({ workspaceId: unavailable.id, title: "Unavailable workspace session" });
+      const session = state.workspaces
+        .find((entry) => entry.id === unavailable.id)
+        ?.sessions.find((entry) => entry.title === "Unavailable workspace session");
+      if (!session) {
+        throw new Error("Expected seeded unavailable-workspace session");
+      }
+
+      await app.selectSession({ workspaceId: unavailable.id, sessionId: session.id });
+      await app.updateComposerDraft("draft survives unavailable workspace");
+      await app.setSessionPinned({ workspaceId: unavailable.id, sessionId: session.id }, true);
+      await app.reorderWorkspaces([unavailable.id, healthy.id]);
+      await app.setNotificationPreferences({
+        backgroundCompletion: false,
+        backgroundFailure: true,
+        attentionNeeded: false,
+      });
+      await app.setIntegratedTerminalShell("/bin/zsh");
+      await app.setThemePresetId("github");
+      await app.setSidebarCollapsed(true);
+      state = await app.getState();
+      return {
+        state,
+        healthyWorkspaceId: healthy.id,
+        unavailableWorkspaceId: unavailable.id,
+        unavailableSessionId: session.id,
+      };
+    }, { healthyPath: healthyWorkspacePath, unavailablePath: unavailableWorkspacePath });
+
+    healthyWorkspaceId = seededState.healthyWorkspaceId;
+    unavailableWorkspaceId = seededState.unavailableWorkspaceId;
+    unavailableSessionId = seededState.unavailableSessionId;
+    expect(seededState.state.selectedWorkspaceId).toBe(unavailableWorkspaceId);
+    expect(seededState.state.selectedSessionId).toBe(unavailableSessionId);
+    await expect.poll(async () => readFile(uiStatePath, "utf8")).toContain("draft survives unavailable workspace");
+  } finally {
+    await firstRun.close();
+  }
+
+  const sessionKey = `${unavailableWorkspaceId}:${unavailableSessionId}`;
+  const existingUiState = JSON.parse(await readFile(uiStatePath, "utf8")) as Record<string, unknown>;
+  const beforeFailure = {
+    ...existingUiState,
+    selectedWorkspaceId: unavailableWorkspaceId,
+    selectedSessionId: unavailableSessionId,
+    activeView: "threads",
+    composerDraft: "draft survives unavailable workspace",
+    composerDraftsBySession: {
+      [sessionKey]: "draft survives unavailable workspace",
+    },
+    notificationPreferences: {
+      backgroundCompletion: false,
+      backgroundFailure: true,
+      attentionNeeded: false,
+    },
+    integratedTerminalShell: "/bin/zsh",
+    pinnedAtBySession: {
+      [sessionKey]: "2026-07-27T00:00:00.000Z",
+    },
+    pinnedSessionOrder: [sessionKey],
+    workspaceOrder: [unavailableWorkspaceId, healthyWorkspaceId],
+    themePresetId: "github",
+    sidebarCollapsed: true,
+  } satisfies Record<string, unknown>;
+  await writeFile(uiStatePath, `${JSON.stringify(beforeFailure, null, 2)}\n`, "utf8");
+  const movedWorkspacePath = `${unavailableWorkspacePath}-offline`;
+  await rename(unavailableWorkspacePath, movedWorkspacePath);
+
+  const secondRun = await launchDesktop(userDataDir, { testMode: "background" });
+  try {
+    const window = await secondRun.firstWindow();
+    const state = await getDesktopState(window);
+    const diagnostics = state.startupDiagnostics;
+
+    expect(state.workspaces.some((entry) => entry.id === healthyWorkspaceId)).toBe(true);
+    expect(state.workspaces.some((entry) => entry.id === unavailableWorkspaceId)).toBe(true);
+    expect(state.selectedWorkspaceId).toBe(unavailableWorkspaceId);
+    expect(state.selectedSessionId).toBe(unavailableSessionId);
+    expect(state.composerDraft).toBe("draft survives unavailable workspace");
+    expect(state.workspaceOrder).toEqual([unavailableWorkspaceId, healthyWorkspaceId]);
+    expect(state.pinnedSessionOrder).toEqual([`${unavailableWorkspaceId}:${unavailableSessionId}`]);
+    expect(state.notificationPreferences).toEqual({
+      backgroundCompletion: false,
+      backgroundFailure: true,
+      attentionNeeded: false,
+    });
+    expect(state.integratedTerminalShell).toBe("/bin/zsh");
+    expect(state.themePresetId).toBe("github");
+    expect(state.sidebarCollapsed).toBe(true);
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        scope: "workspace",
+        workspacePath: unavailableWorkspacePath,
+      }),
+    ]);
+    await expect(window.getByTestId("startup-diagnostics")).toContainText("unavailable-startup-workspace");
+
+    const afterFailure = JSON.parse(await readFile(uiStatePath, "utf8")) as Record<string, unknown>;
+    for (const key of [
+      "selectedWorkspaceId",
+      "selectedSessionId",
+      "composerDraftsBySession",
+      "notificationPreferences",
+      "integratedTerminalShell",
+      "pinnedAtBySession",
+      "pinnedSessionOrder",
+      "workspaceOrder",
+      "themePresetId",
+      "sidebarCollapsed",
+    ]) {
+      expect(afterFailure[key], `persisted key ${key}`).toEqual(beforeFailure[key]);
+    }
+
+    const healthySelection = await window.evaluate(async (workspaceId) => {
+      const app = window.piApp;
+      if (!app) {
+        throw new Error("piApp IPC bridge is unavailable");
+      }
+      return app.selectWorkspace(workspaceId);
+    }, healthyWorkspaceId);
+    expect(healthySelection.selectedWorkspaceId).toBe(healthyWorkspaceId);
+    await window.evaluate(async ({ workspaceId, sessionId }) => {
+      const app = window.piApp;
+      if (!app) {
+        throw new Error("piApp IPC bridge is unavailable");
+      }
+      await app.selectSession({ workspaceId, sessionId });
+    }, { workspaceId: unavailableWorkspaceId, sessionId: unavailableSessionId });
+
+    const proofDir = process.env.PI_APP_PERSISTENCE_PROOF_DIR?.trim();
+    if (proofDir) {
+      await mkdir(proofDir, { recursive: true });
+      await window.screenshot({ path: join(proofDir, "unavailable-workspace-recovery.png"), fullPage: true });
+      await writeFile(
+        join(proofDir, "unavailable-workspace-second-launch.json"),
+        `${JSON.stringify({ diagnostics, state }, null, 2)}\n`,
+        "utf8",
+      );
+    }
+  } finally {
+    await secondRun.close();
+  }
+
+  const thirdRun = await launchDesktop(userDataDir, { testMode: "background" });
+  try {
+    const window = await thirdRun.firstWindow();
+    const state = await getDesktopState(window);
+    expect(state.selectedWorkspaceId).toBe(unavailableWorkspaceId);
+    expect(state.selectedSessionId).toBe(unavailableSessionId);
+    expect(state.composerDraft).toBe("draft survives unavailable workspace");
+    expect(state.workspaces.some((entry) => entry.id === healthyWorkspaceId)).toBe(true);
+    await expect(window.getByTestId("startup-diagnostics")).toContainText("unavailable-startup-workspace");
+
+    const proofDir = process.env.PI_APP_PERSISTENCE_PROOF_DIR?.trim();
+    if (proofDir) {
+      await window.screenshot({ path: join(proofDir, "unavailable-workspace-third-launch.png"), fullPage: true });
+    }
+  } finally {
+    await thirdRun.close();
   }
 });
 

--- a/apps/desktop/tests/core/persistence.spec.ts
+++ b/apps/desktop/tests/core/persistence.spec.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
   createNamedThread,
+  createSessionViaIpc,
   getDesktopState,
   getSelectedTranscript,
   launchDesktop,
@@ -10,9 +11,12 @@ import {
   makeWorkspace,
   pasteTinyPng,
   persistedSessionDataPaths,
+  selectSession,
   stubNextOpenDialog,
+  writeProjectExtension,
   writeTextFile,
 } from "../helpers/electron-app";
+import { appendMessagesToSessionFile, sessionFilePathFromCatalog } from "../helpers/session-file";
 
 test("clears mixed attachment chips on submit after paste and file attach", async () => {
   test.setTimeout(30_000);
@@ -201,6 +205,24 @@ test("recovers from parseable malformed nested state without overwriting valid f
   const userDataDir = await makeUserDataDir();
   const workspacePath = await makeWorkspace("malformed-nested-state-workspace");
   const uiStatePath = join(userDataDir, "ui-state.json");
+  const extensionPath = await writeProjectExtension(
+    workspacePath,
+    "persisted-compatibility.ts",
+    `export default function persistedCompatibility(pi) {
+      pi.registerCommand("persisted-safe", {
+        description: "Persisted compatibility fixture",
+        handler: async () => {},
+      });
+    }\n`,
+  );
+  const validCompatibility = {
+    commandName: "persisted-safe",
+    extensionPath,
+    status: "supported",
+    message: "GUI-compatible command",
+    capability: "host-ui",
+    updatedAt: "2026-07-27T00:00:00.000Z",
+  } as const;
 
   const firstRun = await launchDesktop(userDataDir, {
     initialWorkspaces: [workspacePath],
@@ -208,19 +230,32 @@ test("recovers from parseable malformed nested state without overwriting valid f
   });
   let workspaceId = "";
   let sessionId = "";
+  let childSessionId = "";
   try {
     const window = await firstRun.firstWindow();
     await createNamedThread(window, "Malformed nested state session");
-    await window.getByTestId("composer").fill("valid draft survives malformed nested state");
     const state = await getDesktopState(window);
     workspaceId = state.selectedWorkspaceId;
     sessionId = state.selectedSessionId;
+    await createSessionViaIpc(window, workspaceId, "Supervised child session");
+    childSessionId = (await getDesktopState(window)).workspaces
+      .find((entry) => entry.id === workspaceId)
+      ?.sessions.find((entry) => entry.title === "Supervised child session")
+      ?.id ?? "";
+    expect(childSessionId).toBeTruthy();
+    await selectSession(window, "Malformed nested state session");
+    await window.getByTestId("composer").fill("valid draft survives malformed nested state");
     await expect.poll(async () => readFile(uiStatePath, "utf8")).toContain(
       "valid draft survives malformed nested state",
     );
   } finally {
     await firstRun.close();
   }
+
+  const sessionFilePath = await sessionFilePathFromCatalog(userDataDir, { workspaceId, sessionId });
+  await appendMessagesToSessionFile(sessionFilePath, [
+    { role: "user", text: "valid catalog transcript survives malformed nested state" },
+  ]);
 
   const persisted = JSON.parse(await readFile(uiStatePath, "utf8")) as Record<string, unknown>;
   const malformedSnapshot = `${JSON.stringify(
@@ -233,38 +268,110 @@ test("recovers from parseable malformed nested state without overwriting valid f
         [`${workspaceId}:${sessionId}`]: "valid draft survives malformed nested state",
       },
       extensionCommandCompatibilityByWorkspace: {
-        [workspaceId]: {
+        [workspaceId]: [
+          validCompatibility,
+          {
+            commandName: "missing-required-fields",
+          },
+        ],
+        "malformed-workspace": {
           commandName: "not-an-array",
         },
       },
+      composerAttachmentsBySession: {
+        [`${workspaceId}:${sessionId}`]: {
+          kind: "image",
+        },
+      },
+      orchestrationChildren: [
+        {
+          id: "persisted-supervised-child",
+          parentWorkspaceId: workspaceId,
+          parentSessionId: sessionId,
+          childWorkspaceId: workspaceId,
+          childSessionId,
+          title: "Supervised child session",
+          goal: "Prove startup supervision continues after malformed persistence.",
+          status: "queued",
+          latestTranscript: "Waiting for supervision.",
+          transcript: [],
+          evidence: [],
+          supervisionLoop: {
+            id: "persisted-supervision-loop",
+            status: "monitoring",
+            gate: "continue",
+            intervalMs: 250,
+            iterationCount: 7,
+            lastCheckedAt: "2000-01-01T00:00:00.000Z",
+            nextRunAt: "2000-01-01T00:00:00.000Z",
+            reason: "Waiting for the child to start.",
+            lastChildStatus: "queued",
+          },
+          createdAt: "2026-07-27T00:00:00.000Z",
+          updatedAt: "2026-07-27T00:00:00.000Z",
+        },
+      ],
     },
     null,
     2,
   )}\n`;
   await writeFile(uiStatePath, malformedSnapshot, "utf8");
 
-  const secondRun = await launchDesktop(userDataDir, { testMode: "background" });
+  const secondRun = await launchDesktop(userDataDir, {
+    testMode: "background",
+    envOverrides: {
+      PI_APP_ORCHESTRATION_SUPERVISION_INTERVAL_MS: "250",
+    },
+  });
   try {
     const window = await secondRun.firstWindow();
+    await expect(window.getByTestId("workspace-list")).toContainText("malformed-nested-state-workspace");
+    await expect(window.locator(".session-row--active")).toContainText("Malformed nested state session");
+    await expect(window.getByTestId("composer")).toHaveValue("valid draft survives malformed nested state");
+    await expect(window.getByTestId("transcript")).toContainText(
+      "valid catalog transcript survives malformed nested state",
+    );
+
     const state = await getDesktopState(window);
-    expect(state.lastError).toContain("records is not iterable");
-    expect(state.startupDiagnostics).toEqual([
-      expect.objectContaining({
-        scope: "application",
-      }),
-    ]);
-    await expect(window.getByTestId("startup-diagnostics")).toBeVisible();
+    const workspace = state.workspaces.find((entry) => entry.id === workspaceId);
+    expect(workspace?.sessions.some((entry) => entry.id === sessionId)).toBe(true);
+    expect(state.selectedWorkspaceId).toBe(workspaceId);
+    expect(state.selectedSessionId).toBe(sessionId);
+    expect(state.lastError).toBeUndefined();
+    expect(state.startupDiagnostics).toEqual([]);
+    expect(state.extensionCommandCompatibilityByWorkspace[workspaceId]).toEqual([validCompatibility]);
+    await expect
+      .poll(async () => {
+        const child = (await getDesktopState(window)).orchestrationChildren.find(
+          (entry) => entry.id === "persisted-supervised-child",
+        );
+        return child?.supervisionLoop?.iterationCount ?? 0;
+      }, { timeout: 10_000 })
+      .toBeGreaterThan(7);
+
+    const recovered = JSON.parse(await readFile(uiStatePath, "utf8")) as Record<string, unknown>;
+    expect(recovered.selectedWorkspaceId).toBe(workspaceId);
+    expect(recovered.selectedSessionId).toBe(sessionId);
+    expect(recovered.composerDraft).toBe("valid draft survives malformed nested state");
+    expect(recovered.composerDraftsBySession).toEqual({
+      [`${workspaceId}:${sessionId}`]: "valid draft survives malformed nested state",
+    });
+    expect(recovered.extensionCommandCompatibilityByWorkspace).toEqual({
+      [workspaceId]: [validCompatibility],
+    });
+    expect(recovered.composerAttachmentsBySession).toBeUndefined();
+
+    const transcriptBefore = await getSelectedTranscript(window);
+    const transcriptLengthBefore = transcriptBefore?.transcript.length ?? 0;
+    const composer = window.getByTestId("composer");
+    await composer.fill("/status");
+    await composer.press("Enter");
+    await expect
+      .poll(async () => (await getSelectedTranscript(window))?.transcript.length ?? 0)
+      .toBeGreaterThan(transcriptLengthBefore);
   } finally {
     await secondRun.close();
   }
-
-  const recovered = JSON.parse(await readFile(uiStatePath, "utf8")) as Record<string, unknown>;
-  expect(recovered.selectedWorkspaceId).toBe(workspaceId);
-  expect(recovered.selectedSessionId).toBe(sessionId);
-  expect(recovered.composerDraft).toBe("valid draft survives malformed nested state");
-  expect(recovered.composerDraftsBySession).toEqual({
-    [`${workspaceId}:${sessionId}`]: "valid draft survives malformed nested state",
-  });
 });
 
 test("preserves durable ui state when one startup workspace is unavailable", async () => {

--- a/packages/pi-sdk-driver/src/index.ts
+++ b/packages/pi-sdk-driver/src/index.ts
@@ -1,4 +1,5 @@
 export { JsonCatalogStore } from "./json-catalog-store.js";
+export type { SessionFileCatalogStorage } from "./json-catalog-store.js";
 export {
   applyHostUiRequestToExtensionUiState,
   createEmptyExtensionUiState,

--- a/packages/pi-sdk-driver/src/json-catalog-store.ts
+++ b/packages/pi-sdk-driver/src/json-catalog-store.ts
@@ -28,6 +28,14 @@ type ParsedCatalogFileState = Partial<Omit<CatalogFileState, "version">> & {
   version?: 1 | 2;
 };
 
+interface CatalogFileCoordinator {
+  state: CatalogFileState | undefined;
+  loadPromise: Promise<CatalogFileState> | undefined;
+  mutationQueue: Promise<void>;
+}
+
+const coordinatorsByPath = new Map<string, CatalogFileCoordinator>();
+
 export interface JsonCatalogStoreOptions {
   readonly catalogFilePath?: string;
 }
@@ -45,12 +53,11 @@ export interface SessionFileCatalogStorage extends CatalogStorage {
 
 export class JsonCatalogStore implements SessionFileCatalogStorage {
   private readonly filePath: string;
-  private state: CatalogFileState | undefined;
-  private loadPromise: Promise<void> | undefined;
-  private writeQueue: Promise<void> = Promise.resolve();
+  private readonly coordinator: CatalogFileCoordinator;
 
   constructor(options: JsonCatalogStoreOptions = {}) {
     this.filePath = options.catalogFilePath ? resolve(options.catalogFilePath) : defaultCatalogFilePath();
+    this.coordinator = coordinatorForPath(this.filePath);
   }
 
   readonly workspaces = {
@@ -219,52 +226,68 @@ export class JsonCatalogStore implements SessionFileCatalogStorage {
   }
 
   private async getState(): Promise<CatalogFileState> {
-    if (this.state) {
-      return this.state;
+    if (this.coordinator.state) {
+      return this.coordinator.state;
     }
-    if (!this.loadPromise) {
-      this.loadPromise = this.loadState();
+    if (!this.coordinator.loadPromise) {
+      this.coordinator.loadPromise = this.loadState();
     }
-    await this.loadPromise;
-    if (!this.state) {
-      this.state = createEmptyState();
+    const loadPromise = this.coordinator.loadPromise;
+    try {
+      const state = await loadPromise;
+      this.coordinator.state = state;
+      return state;
+    } catch (error) {
+      if (this.coordinator.loadPromise === loadPromise) {
+        this.coordinator.loadPromise = undefined;
+      }
+      throw error;
     }
-    return this.state;
   }
 
-  private async loadState(): Promise<void> {
+  private async loadState(): Promise<CatalogFileState> {
     try {
       const raw = await readFile(this.filePath, "utf8");
-      this.state = parseState(raw, this.filePath);
+      return parseState(raw, this.filePath);
     } catch (error) {
       if (isMissingFileError(error)) {
-        this.state = createEmptyState();
-        return;
+        return createEmptyState();
       }
       throw error;
     }
   }
 
   private async mutateState(mutator: (state: CatalogFileState) => void | false): Promise<void> {
-    const state = await this.getState();
-    if (mutator(state) === false) {
-      return;
-    }
-    await this.persistState(state);
-  }
-
-  private async persistState(state: CatalogFileState): Promise<void> {
-    const operation = this.writeQueue.then(async () => {
-      await writeJsonFileAtomic(this.filePath, state);
+    const operation = this.coordinator.mutationQueue.then(async () => {
+      const nextState = cloneCatalogState(await this.getState());
+      if (mutator(nextState) === false) {
+        return;
+      }
+      await writeJsonFileAtomic(this.filePath, nextState);
+      this.coordinator.state = nextState;
     });
 
-    this.writeQueue = operation.then(
+    this.coordinator.mutationQueue = operation.then(
       () => undefined,
       () => undefined,
     );
 
     await operation;
   }
+}
+
+function coordinatorForPath(filePath: string): CatalogFileCoordinator {
+  const existing = coordinatorsByPath.get(filePath);
+  if (existing) {
+    return existing;
+  }
+  const coordinator: CatalogFileCoordinator = {
+    state: undefined,
+    loadPromise: undefined,
+    mutationQueue: Promise.resolve(),
+  };
+  coordinatorsByPath.set(filePath, coordinator);
+  return coordinator;
 }
 
 function defaultCatalogFilePath(): string {
@@ -278,6 +301,16 @@ function createEmptyState(): CatalogFileState {
     sessions: [],
     worktrees: [],
     sessionFiles: {},
+  };
+}
+
+function cloneCatalogState(state: CatalogFileState): CatalogFileState {
+  return {
+    version: 2,
+    workspaces: state.workspaces.map(cloneWorkspaceEntry),
+    sessions: state.sessions.map(cloneSessionEntry),
+    worktrees: state.worktrees.map(cloneWorktreeEntry),
+    sessionFiles: { ...state.sessionFiles },
   };
 }
 

--- a/packages/pi-sdk-driver/src/json-catalog-store.ts
+++ b/packages/pi-sdk-driver/src/json-catalog-store.ts
@@ -29,9 +29,8 @@ type ParsedCatalogFileState = Partial<Omit<CatalogFileState, "version">> & {
 };
 
 interface CatalogFileCoordinator {
-  state: CatalogFileState | undefined;
-  loadPromise: Promise<CatalogFileState> | undefined;
   mutationQueue: Promise<void>;
+  generation: number;
 }
 
 const coordinatorsByPath = new Map<string, CatalogFileCoordinator>();
@@ -54,6 +53,10 @@ export interface SessionFileCatalogStorage extends CatalogStorage {
 export class JsonCatalogStore implements SessionFileCatalogStorage {
   private readonly filePath: string;
   private readonly coordinator: CatalogFileCoordinator;
+  private state: CatalogFileState | undefined;
+  private stateGeneration = -1;
+  private loadPromise: Promise<CatalogFileState> | undefined;
+  private loadGeneration = -1;
 
   constructor(options: JsonCatalogStoreOptions = {}) {
     this.filePath = options.catalogFilePath ? resolve(options.catalogFilePath) : defaultCatalogFilePath();
@@ -226,20 +229,24 @@ export class JsonCatalogStore implements SessionFileCatalogStorage {
   }
 
   private async getState(): Promise<CatalogFileState> {
-    if (this.coordinator.state) {
-      return this.coordinator.state;
+    const generation = this.coordinator.generation;
+    if (this.state && this.stateGeneration === generation) {
+      return this.state;
     }
-    if (!this.coordinator.loadPromise) {
-      this.coordinator.loadPromise = this.loadState();
+    if (!this.loadPromise || this.loadGeneration !== generation) {
+      this.loadPromise = this.loadState();
+      this.loadGeneration = generation;
     }
-    const loadPromise = this.coordinator.loadPromise;
+    const loadPromise = this.loadPromise;
     try {
       const state = await loadPromise;
-      this.coordinator.state = state;
+      if (this.loadPromise === loadPromise && this.coordinator.generation === generation) {
+        this.cacheState(state, generation);
+      }
       return state;
     } catch (error) {
-      if (this.coordinator.loadPromise === loadPromise) {
-        this.coordinator.loadPromise = undefined;
+      if (this.loadPromise === loadPromise) {
+        this.clearStateCache();
       }
       throw error;
     }
@@ -259,12 +266,15 @@ export class JsonCatalogStore implements SessionFileCatalogStorage {
 
   private async mutateState(mutator: (state: CatalogFileState) => void | false): Promise<void> {
     const operation = this.coordinator.mutationQueue.then(async () => {
-      const nextState = cloneCatalogState(await this.getState());
+      this.clearStateCache();
+      const nextState = await this.loadState();
       if (mutator(nextState) === false) {
+        this.cacheState(nextState, this.coordinator.generation);
         return;
       }
       await writeJsonFileAtomic(this.filePath, nextState);
-      this.coordinator.state = nextState;
+      this.coordinator.generation += 1;
+      this.cacheState(nextState, this.coordinator.generation);
     });
 
     this.coordinator.mutationQueue = operation.then(
@@ -274,6 +284,20 @@ export class JsonCatalogStore implements SessionFileCatalogStorage {
 
     await operation;
   }
+
+  private cacheState(state: CatalogFileState, generation: number): void {
+    this.state = state;
+    this.stateGeneration = generation;
+    this.loadPromise = undefined;
+    this.loadGeneration = -1;
+  }
+
+  private clearStateCache(): void {
+    this.state = undefined;
+    this.stateGeneration = -1;
+    this.loadPromise = undefined;
+    this.loadGeneration = -1;
+  }
 }
 
 function coordinatorForPath(filePath: string): CatalogFileCoordinator {
@@ -282,9 +306,8 @@ function coordinatorForPath(filePath: string): CatalogFileCoordinator {
     return existing;
   }
   const coordinator: CatalogFileCoordinator = {
-    state: undefined,
-    loadPromise: undefined,
     mutationQueue: Promise.resolve(),
+    generation: 0,
   };
   coordinatorsByPath.set(filePath, coordinator);
   return coordinator;
@@ -301,16 +324,6 @@ function createEmptyState(): CatalogFileState {
     sessions: [],
     worktrees: [],
     sessionFiles: {},
-  };
-}
-
-function cloneCatalogState(state: CatalogFileState): CatalogFileState {
-  return {
-    version: 2,
-    workspaces: state.workspaces.map(cloneWorkspaceEntry),
-    sessions: state.sessions.map(cloneSessionEntry),
-    worktrees: state.worktrees.map(cloneWorktreeEntry),
-    sessionFiles: { ...state.sessionFiles },
   };
 }
 

--- a/packages/pi-sdk-driver/src/session-supervisor.ts
+++ b/packages/pi-sdk-driver/src/session-supervisor.ts
@@ -101,6 +101,8 @@ import {
 
 export interface PiSdkDriverOptions {
   readonly catalogFilePath?: string;
+  /** Existing owner for catalog state. Takes precedence over catalogFilePath when provided. */
+  readonly catalogStorage?: SessionFileCatalogStorage;
   readonly createAgentSessionRuntimeImpl?: (options?: CreateAgentSessionOptions) => Promise<AgentSessionRuntime>;
   readonly modelRegistry?: ModelRegistry;
   readonly extensionFactories?: readonly ExtensionFactory[];
@@ -185,9 +187,11 @@ export class SessionSupervisor {
   private readonly isPidAlive = defaultIsPidAlive;
 
   constructor(options: PiSdkDriverOptions = {}) {
-    this.catalogs = options.catalogFilePath
-      ? new JsonCatalogStore({ catalogFilePath: options.catalogFilePath })
-      : new JsonCatalogStore();
+    this.catalogs =
+      options.catalogStorage ??
+      (options.catalogFilePath
+        ? new JsonCatalogStore({ catalogFilePath: options.catalogFilePath })
+        : new JsonCatalogStore());
     this.createAgentSessionRuntimeImpl =
       options.createAgentSessionRuntimeImpl ??
       ((createOptions) =>

--- a/packages/pi-sdk-driver/test/json-catalog-store.test.mts
+++ b/packages/pi-sdk-driver/test/json-catalog-store.test.mts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -107,6 +107,72 @@ test("same-path stores serialize concurrent workspace, session, and worktree mut
     assert.equal((await reopened.workspaces.listWorkspaces()).workspaces.length, 12);
     assert.equal((await reopened.sessions.listSessions()).sessions.length, 12);
     assert.equal((await reopened.worktrees.listWorktrees()).worktrees.length, 12);
+  });
+});
+
+test("new stores reload an externally replaced catalog and preserve it on mutation", async () => {
+  await withTempDir(async (dir) => {
+    const catalogFilePath = join(dir, "catalogs.json");
+    const firstStore = new JsonCatalogStore({ catalogFilePath });
+    await firstStore.workspaces.upsertWorkspace({
+      workspaceId: "stale-workspace",
+      path: join(dir, "stale-workspace"),
+      displayName: "Stale workspace",
+      lastOpenedAt: timestamp,
+      sortOrder: 0,
+    });
+
+    const replacementPath = `${catalogFilePath}.external-replacement`;
+    await writeFile(
+      replacementPath,
+      `${JSON.stringify(
+        {
+          version: 2,
+          workspaces: [
+            {
+              workspaceId: "repaired-workspace",
+              path: join(dir, "repaired-workspace"),
+              displayName: "Repaired workspace",
+              lastOpenedAt: timestamp,
+              sortOrder: 0,
+            },
+          ],
+          sessions: [],
+          worktrees: [],
+          sessionFiles: {},
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await rename(replacementPath, catalogFilePath);
+
+    const reopened = new JsonCatalogStore({ catalogFilePath });
+    assert.deepEqual(
+      (await reopened.workspaces.listWorkspaces()).workspaces.map((entry) => entry.workspaceId),
+      ["repaired-workspace"],
+    );
+
+    await reopened.workspaces.upsertWorkspace({
+      workspaceId: "new-workspace",
+      path: join(dir, "new-workspace"),
+      displayName: "New workspace",
+      lastOpenedAt: timestamp,
+      sortOrder: 1,
+    });
+
+    const persisted = JSON.parse(await readFile(catalogFilePath, "utf8")) as {
+      workspaces: Array<{ workspaceId: string }>;
+    };
+    assert.deepEqual(
+      persisted.workspaces.map((entry) => entry.workspaceId).sort(),
+      ["new-workspace", "repaired-workspace"],
+    );
+    assert.deepEqual(
+      (await firstStore.workspaces.listWorkspaces()).workspaces.map((entry) => entry.workspaceId).sort(),
+      ["new-workspace", "repaired-workspace"],
+    );
   });
 });
 

--- a/packages/pi-sdk-driver/test/json-catalog-store.test.mts
+++ b/packages/pi-sdk-driver/test/json-catalog-store.test.mts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { JsonCatalogStore, SessionSupervisor } from "../dist/index.js";
+
+const timestamp = "2026-07-27T00:00:00.000Z";
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-catalog-store-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("desktop and driver catalog owners preserve each other's records", async () => {
+  await withTempDir(async (dir) => {
+    const catalogFilePath = join(dir, "catalogs.json");
+    const workspacePath = join(dir, "workspace");
+    await mkdir(workspacePath);
+
+    const desktopCatalog = new JsonCatalogStore({ catalogFilePath });
+    await desktopCatalog.worktrees.listWorktrees();
+
+    const supervisor = new SessionSupervisor({
+      catalogFilePath,
+      catalogStorage: desktopCatalog,
+    });
+    const workspace = await supervisor.registerWorkspace(workspacePath, "Workspace");
+    await desktopCatalog.worktrees.upsertWorktree({
+      worktreeId: join(dir, "worktree"),
+      workspaceId: workspace.workspaceId,
+      path: join(dir, "worktree"),
+      displayName: "Worktree",
+      kind: "linked",
+      status: "ready",
+      branchName: "pi/worktree",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const persisted = JSON.parse(await readFile(catalogFilePath, "utf8")) as {
+      workspaces: Array<{ workspaceId: string }>;
+      worktrees: Array<{ worktreeId: string }>;
+    };
+    assert.deepEqual(persisted.workspaces.map((entry) => entry.workspaceId), [workspace.workspaceId]);
+    assert.deepEqual(persisted.worktrees.map((entry) => entry.worktreeId), [join(dir, "worktree")]);
+  });
+});
+
+test("same-path stores serialize concurrent workspace, session, and worktree mutations", async () => {
+  await withTempDir(async (dir) => {
+    const catalogFilePath = join(dir, "catalogs.json");
+    const workspaceWriter = new JsonCatalogStore({ catalogFilePath });
+    const sessionWriter = new JsonCatalogStore({ catalogFilePath });
+    const worktreeWriter = new JsonCatalogStore({ catalogFilePath });
+    await Promise.all([
+      workspaceWriter.workspaces.listWorkspaces(),
+      sessionWriter.sessions.listSessions(),
+      worktreeWriter.worktrees.listWorktrees(),
+    ]);
+
+    const writes = Array.from({ length: 12 }, (_, index) => {
+      const workspaceId = `workspace-${index}`;
+      return Promise.all([
+        workspaceWriter.workspaces.upsertWorkspace({
+          workspaceId,
+          path: join(dir, workspaceId),
+          displayName: `Workspace ${index}`,
+          lastOpenedAt: timestamp,
+          sortOrder: index,
+        }),
+        sessionWriter.sessions.upsertSession({
+          sessionRef: { workspaceId, sessionId: `session-${index}` },
+          workspaceId,
+          title: `Session ${index}`,
+          updatedAt: timestamp,
+          status: "idle",
+        }),
+        worktreeWriter.worktrees.upsertWorktree({
+          worktreeId: join(dir, `worktree-${index}`),
+          workspaceId,
+          path: join(dir, `worktree-${index}`),
+          displayName: `Worktree ${index}`,
+          kind: "linked",
+          status: "ready",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        }),
+      ]);
+    });
+    await Promise.all(writes);
+
+    const persisted = JSON.parse(await readFile(catalogFilePath, "utf8")) as {
+      workspaces: unknown[];
+      sessions: unknown[];
+      worktrees: unknown[];
+    };
+    assert.equal(persisted.workspaces.length, 12);
+    assert.equal(persisted.sessions.length, 12);
+    assert.equal(persisted.worktrees.length, 12);
+
+    const reopened = new JsonCatalogStore({ catalogFilePath });
+    assert.equal((await reopened.workspaces.listWorkspaces()).workspaces.length, 12);
+    assert.equal((await reopened.sessions.listSessions()).sessions.length, 12);
+    assert.equal((await reopened.worktrees.listWorktrees()).worktrees.length, 12);
+  });
+});
+
+test("an interrupted temp write leaves the last committed catalog readable", async () => {
+  await withTempDir(async (dir) => {
+    const catalogFilePath = join(dir, "catalogs.json");
+    const catalog = new JsonCatalogStore({ catalogFilePath });
+    await catalog.workspaces.upsertWorkspace({
+      workspaceId: "workspace",
+      path: join(dir, "workspace"),
+      displayName: "Workspace",
+      lastOpenedAt: timestamp,
+      sortOrder: 0,
+    });
+
+    await writeFile(`${catalogFilePath}.interrupted.tmp`, "{\"version\":2,\"workspaces\":[", "utf8");
+
+    const reopened = new JsonCatalogStore({ catalogFilePath });
+    assert.deepEqual(
+      (await reopened.workspaces.listWorkspaces()).workspaces.map((entry) => entry.workspaceId),
+      ["workspace"],
+    );
+    const persisted = JSON.parse(await readFile(catalogFilePath, "utf8")) as { workspaces: unknown[] };
+    assert.equal(persisted.workspaces.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve valid UI/session state when one startup workspace fails
- recover parseable malformed nested persisted fields without aborting catalog/session hydration
- serialize same-process catalog writers while reloading disk state before each mutation
- preserve externally repaired catalog data across reopened stores
- keep atomic backup/write recovery and add focused regressions

## Verification

- git diff --check origin/main..HEAD
- pi-sdk-driver tests: 31/31
- desktop typecheck
- persistence Electron spec: 6/6
- full desktop core: 118/118
- independent P1 autoreview: clean

Inter-process exclusive session/file ownership remains tracked separately in #55.

Closes #56
Closes #57
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/minghinmatthewlam/pi-gui/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->