### PR TITLE
Show models registered by extensions in the runtime snapshot

### DIFF
--- a/apps/desktop/tests/core/extension-provider-models.spec.ts
+++ b/apps/desktop/tests/core/extension-provider-models.spec.ts
@@ -1,0 +1,67 @@
+import { join } from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+import { desktopShortcut, launchDesktop, makeUserDataDir, makeWorkspace, seedAgentDir } from "../helpers/electron-app";
+
+const PROVIDER_ID = "ext-e2e-provider";
+const MODEL_ID = "ext-e2e-model";
+
+const EXTENSION_SOURCE = `export default async function testProviderExtension(pi) {
+  pi.registerProvider(${JSON.stringify(PROVIDER_ID)}, {
+    baseUrl: "http://127.0.0.1:9/v1",
+    apiKey: "test-extension-key",
+    api: "openai-completions",
+    models: [
+      {
+        id: ${JSON.stringify(MODEL_ID)},
+        name: "Extension E2E Model",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 16384,
+      },
+    ],
+  });
+}
+`;
+
+test("models registered by an extension appear in settings", async () => {
+  test.setTimeout(90_000);
+
+  const userDataDir = await makeUserDataDir();
+  const agentDir = join(userDataDir, "agent");
+  const workspacePath = await makeWorkspace("extension-provider-models-workspace");
+  await seedAgentDir(agentDir);
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await writeFile(join(agentDir, "extensions", "test-provider.ts"), EXTENSION_SOURCE, "utf8");
+
+  const harness = await launchDesktop(userDataDir, {
+    agentDir,
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+
+  try {
+    const window = await harness.firstWindow();
+    await window.keyboard.press(desktopShortcut(","));
+    await expect(window.getByTestId("settings-surface")).toBeVisible();
+    await window.getByRole("button", { name: "Models", exact: true }).click();
+    await expect(window.locator(".view-header__title")).toHaveText("Models");
+
+    const allModels = window.locator(".settings-section", {
+      has: window.locator(".settings-section__title", { hasText: "All models" }),
+    });
+    await allModels.locator(".settings-disclosure__summary").click();
+    await allModels.getByLabel("Search models").fill(PROVIDER_ID);
+
+    const modelRow = allModels.locator(".settings-option", {
+      has: window.locator(".settings-option__meta", { hasText: `${PROVIDER_ID}:${MODEL_ID}` }),
+    });
+    await expect(modelRow).toHaveCount(1);
+    await expect(modelRow).toContainText("Extension E2E Model");
+    await expect(modelRow).not.toContainText("not logged in");
+  } finally {
+    await harness.close();
+  }
+});

--- a/apps/desktop/tests/core/extension-provider-models.spec.ts
+++ b/apps/desktop/tests/core/extension-provider-models.spec.ts
@@ -1,7 +1,16 @@
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
-import { expect, test } from "@playwright/test";
-import { desktopShortcut, launchDesktop, makeUserDataDir, makeWorkspace, seedAgentDir } from "../helpers/electron-app";
+import { expect, test, type Page } from "@playwright/test";
+import {
+  createNamedThread,
+  desktopShortcut,
+  launchDesktop,
+  makeUserDataDir,
+  makeWorkspace,
+  seedAgentDir,
+  waitForWorkspaceByPath,
+  writeProjectExtension,
+} from "../helpers/electron-app";
 
 const PROVIDER_ID = "ext-e2e-provider";
 const MODEL_ID = "ext-e2e-model";
@@ -25,6 +34,45 @@ const EXTENSION_SOURCE = `export default async function testProviderExtension(pi
   });
 }
 `;
+
+const SCOPED_PREFIX = "ext-e2e-scoped";
+
+function projectExtensionSource(providerId: string, modelId: string): string {
+  return `export default async function projectProviderExtension(pi) {
+  pi.registerProvider(${JSON.stringify(providerId)}, {
+    baseUrl: "http://127.0.0.1:9/v1",
+    apiKey: "test-extension-key",
+    api: "openai-completions",
+    models: [
+      {
+        id: ${JSON.stringify(modelId)},
+        name: ${JSON.stringify(`Model ${modelId}`)},
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 16384,
+      },
+    ],
+  });
+}
+`;
+}
+
+/** Open Settings → Models and filter the "All models" list, returning the matching rows. */
+async function searchAllModels(window: Page, query: string) {
+  await window.keyboard.press(desktopShortcut(","));
+  await expect(window.getByTestId("settings-surface")).toBeVisible();
+  await window.getByRole("button", { name: "Models", exact: true }).click();
+  await expect(window.locator(".view-header__title")).toHaveText("Models");
+
+  const allModels = window.locator(".settings-section", {
+    has: window.locator(".settings-section__title", { hasText: "All models" }),
+  });
+  await allModels.locator(".settings-disclosure__summary").click();
+  await allModels.getByLabel("Search models").fill(query);
+  return allModels.locator(".settings-option");
+}
 
 test("models registered by an extension appear in settings", async () => {
   test.setTimeout(90_000);
@@ -61,6 +109,51 @@ test("models registered by an extension appear in settings", async () => {
     await expect(modelRow).toHaveCount(1);
     await expect(modelRow).toContainText("Extension E2E Model");
     await expect(modelRow).not.toContainText("not logged in");
+  } finally {
+    await harness.close();
+  }
+});
+
+test("project extension models stay scoped to the workspace that registers them", async () => {
+  test.setTimeout(120_000);
+
+  const userDataDir = await makeUserDataDir();
+  const agentDir = join(userDataDir, "agent");
+  await seedAgentDir(agentDir);
+
+  const alphaPath = await makeWorkspace("extension-provider-alpha");
+  const betaPath = await makeWorkspace("extension-provider-beta");
+  await writeProjectExtension(alphaPath, "provider.ts", projectExtensionSource(`${SCOPED_PREFIX}-alpha`, "alpha-model"));
+  await writeProjectExtension(betaPath, "provider.ts", projectExtensionSource(`${SCOPED_PREFIX}-beta`, "beta-model"));
+
+  const harness = await launchDesktop(userDataDir, {
+    agentDir,
+    initialWorkspaces: [alphaPath, betaPath],
+    testMode: "background",
+  });
+
+  try {
+    const window = await harness.firstWindow();
+    await waitForWorkspaceByPath(window, alphaPath);
+    await waitForWorkspaceByPath(window, betaPath);
+
+    await createNamedThread(window, "Alpha thread", { workspaceName: basename(alphaPath) });
+    let rows = await searchAllModels(window, SCOPED_PREFIX);
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText(`${SCOPED_PREFIX}-alpha:alpha-model`);
+    await window.keyboard.press("Escape");
+
+    await createNamedThread(window, "Beta thread", { workspaceName: basename(betaPath) });
+    rows = await searchAllModels(window, SCOPED_PREFIX);
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText(`${SCOPED_PREFIX}-beta:beta-model`);
+    await window.keyboard.press("Escape");
+
+    // Back to alpha: opening beta must not have leaked its provider into alpha.
+    await createNamedThread(window, "Alpha thread two", { workspaceName: basename(alphaPath) });
+    rows = await searchAllModels(window, SCOPED_PREFIX);
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText(`${SCOPED_PREFIX}-alpha:alpha-model`);
   } finally {
     await harness.close();
   }

--- a/packages/pi-sdk-driver/src/npm-package-fallback.ts
+++ b/packages/pi-sdk-driver/src/npm-package-fallback.ts
@@ -9,14 +9,28 @@ import {
   type CreateAgentSessionOptions,
   type CreateAgentSessionRuntimeResult,
   type ExtensionFactory,
+  type ModelRegistry,
 } from "@earendil-works/pi-coding-agent";
 
 export interface PiResourceLoaderOptions {
   readonly extensionFactories?: ExtensionFactory[];
 }
 
+/** `ModelInfo` is not exported from the package, so derive it from the session options. */
+export type PiModelInfo = NonNullable<CreateAgentSessionOptions["model"]>;
+
 export interface PiCreateAgentSessionOptions extends CreateAgentSessionOptions {
   readonly resourceLoaderOptions?: PiResourceLoaderOptions;
+  /**
+   * Pick the initial model against the cwd-bound registry the services just built.
+   *
+   * `createAgentSessionServices` flushes the extension providers registered for
+   * *this* cwd into *this* registry, so a model that only exists because of a
+   * workspace's extension can only be resolved here — after the services load and
+   * before the session is constructed, which is exactly the seam `pi` exposes
+   * `createAgentSessionFromServices` for. Ignored when `model` is set.
+   */
+  readonly resolveInitialModel?: (modelRegistry: ModelRegistry) => PiModelInfo | undefined;
 }
 
 export function isGlobalNpmLookupError(error: unknown): boolean {
@@ -98,12 +112,13 @@ async function createAgentSessionResultWithNpmFallback(
   options?: PiCreateAgentSessionOptions,
 ): Promise<CreateAgentSessionRuntimeResult> {
   const services = await createAgentSessionServicesWithNpmFallback(cwd, agentDir, options);
+  const model = options?.model ?? options?.resolveInitialModel?.(services.modelRegistry);
   return {
     ...(await createAgentSessionFromServices({
       services,
       sessionManager,
       ...(options?.sessionStartEvent ? { sessionStartEvent: options.sessionStartEvent } : {}),
-      ...(options?.model ? { model: options.model } : {}),
+      ...(model ? { model } : {}),
       ...(options?.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
       ...(options?.scopedModels ? { scopedModels: options.scopedModels } : {}),
       ...(options?.tools ? { tools: options.tools } : {}),
@@ -134,6 +149,7 @@ export async function createAgentSessionRuntimeWithNpmFallback(
     sessionStartEvent: _optionSessionStartEvent,
     resourceLoaderOptions: stableResourceLoaderOptions,
     model: initialModel,
+    resolveInitialModel: initialModelResolver,
     thinkingLevel: initialThinkingLevel,
     ...stableOptions
   } = options ?? {};
@@ -150,6 +166,9 @@ export async function createAgentSessionRuntimeWithNpmFallback(
         sessionManager,
         ...(sessionStartEvent ? { sessionStartEvent } : {}),
         ...(includeInitialSessionOptions && initialModel ? { model: initialModel } : {}),
+        ...(includeInitialSessionOptions && initialModelResolver
+          ? { resolveInitialModel: initialModelResolver }
+          : {}),
         ...(includeInitialSessionOptions && initialThinkingLevel ? { thinkingLevel: initialThinkingLevel } : {}),
       });
     },

--- a/packages/pi-sdk-driver/src/pi-sdk-driver.ts
+++ b/packages/pi-sdk-driver/src/pi-sdk-driver.ts
@@ -48,7 +48,11 @@ export class PiSdkDriver implements SessionDriver {
     this.modelRegistry = deps.modelRegistry;
     this.generateThreadTitleOverride = options.generateThreadTitleOverride;
 
-    this.supervisor = new SessionSupervisor({ ...options, modelRegistry: deps.modelRegistry });
+    this.supervisor = new SessionSupervisor({
+      ...options,
+      agentDir: deps.agentDir,
+      authStorage: deps.authStorage,
+    });
     this.runtimeSupervisor = new RuntimeSupervisor({ ...options, ...deps });
   }
 
@@ -160,8 +164,9 @@ export class PiSdkDriver implements SessionDriver {
     return this.supervisor.renameWorkspace(workspaceId, displayName);
   }
 
-  removeWorkspace(workspaceId: WorkspaceId): Promise<void> {
-    return this.supervisor.removeWorkspace(workspaceId);
+  async removeWorkspace(workspaceId: WorkspaceId): Promise<void> {
+    await this.supervisor.removeWorkspace(workspaceId);
+    this.runtimeSupervisor.removeWorkspace(workspaceId);
   }
 
   getTranscript(sessionRef: SessionRef) {

--- a/packages/pi-sdk-driver/src/runtime-deps.ts
+++ b/packages/pi-sdk-driver/src/runtime-deps.ts
@@ -5,6 +5,7 @@ import type { RuntimeSupervisorOptions } from "./runtime-supervisor.js";
 
 export interface RuntimeDependencies {
   readonly agentDir: string;
+  readonly modelsJsonPath: string;
   readonly authStorage: AuthStorage;
   readonly modelRegistry: ModelRegistry;
   readonly customProviderStore: CustomProviderStore;
@@ -18,6 +19,7 @@ export function createRuntimeDependencies(options: RuntimeSupervisorOptions = {}
   const customProviderStore = options.customProviderStore ?? new CustomProviderStore(modelsJsonPath);
   return {
     agentDir,
+    modelsJsonPath,
     authStorage,
     modelRegistry,
     customProviderStore,

--- a/packages/pi-sdk-driver/src/runtime-supervisor.ts
+++ b/packages/pi-sdk-driver/src/runtime-supervisor.ts
@@ -56,6 +56,8 @@ interface RuntimeContext {
   readonly settingsManager: SettingsManager;
   readonly packageManager: DefaultPackageManager;
   readonly resourceLoader: DefaultResourceLoader;
+  /** Provider ids this context last registered from extensions, so stale ones can be dropped. */
+  readonly extensionProviderIds: Set<string>;
 }
 
 export interface RuntimeInlineExtensionMetadata {
@@ -114,7 +116,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     context.settingsManager.reload();
     this.authStorage.reload();
     this.modelRegistry.refresh();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context);
     return this.buildSnapshot(context);
   }
@@ -123,7 +125,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     const context = await this.ensureContext(workspace);
     await this.authStorage.login(providerId, toPiOAuthLoginCallbacks(callbacks));
     this.modelRegistry.refresh();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [providerId]);
     return this.buildSnapshot(context);
   }
@@ -132,7 +134,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     const context = await this.ensureContext(workspace);
     this.authStorage.logout(providerId);
     this.modelRegistry.refresh();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
 
@@ -147,7 +149,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     }
     this.authStorage.set(providerId, { type: "api_key", key: normalized });
     this.modelRegistry.refresh();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [providerId]);
     return this.buildSnapshot(context);
   }
@@ -166,7 +168,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     const context = await this.ensureContext(workspace);
     await this.customProviderStore.set(input);
     this.modelRegistry.refresh();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [input.providerId]);
     return this.buildSnapshot(context);
   }
@@ -175,7 +177,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     const context = await this.ensureContext(workspace);
     await this.customProviderStore.delete(providerId);
     this.modelRegistry.refresh();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
 
@@ -247,7 +249,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     const context = await this.ensureContext(workspace);
     context.settingsManager.setEnableSkillCommands(enabled);
     await context.settingsManager.flush();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
 
@@ -328,7 +330,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
 
     this.toggleResource(context, resource, enabled, "skill");
     await context.settingsManager.flush();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
 
@@ -342,7 +344,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
 
     this.toggleResource(context, resource, enabled, "extension");
     await context.settingsManager.flush();
-    await context.resourceLoader.reload();
+    await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
 
@@ -402,9 +404,67 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
       settingsManager,
       packageManager,
       resourceLoader,
+      extensionProviderIds: new Set<string>(),
     };
+    this.syncExtensionProviders(context);
     this.contexts.set(workspace.workspaceId, context);
     return context;
+  }
+
+  private async reloadResources(context: RuntimeContext): Promise<void> {
+    await context.resourceLoader.reload();
+    this.syncExtensionProviders(context);
+  }
+
+  /**
+   * Apply providers that extensions registered while loading.
+   *
+   * `pi` queues `pi.registerProvider()` calls made during extension load on the
+   * shared extension runtime and flushes them when session services are created
+   * (`createAgentSessionServices`). The runtime snapshot never goes through that
+   * path, so without this the model list only ever shows built-ins, `models.json`
+   * providers, and custom providers — extension-provided models are invisible in
+   * settings and pickers even though sessions can use them.
+   */
+  private syncExtensionProviders(context: RuntimeContext): void {
+    const { runtime } = context.resourceLoader.getExtensions();
+    const registered = new Set<string>();
+    for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations) {
+      try {
+        this.modelRegistry.registerProvider(name, config);
+        registered.add(name);
+      } catch (error) {
+        console.warn(
+          `[pi-gui] Extension "${extensionPath}" failed to register provider "${name}": ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    runtime.pendingProviderRegistrations = [];
+
+    // Drop providers this context registered before but no longer does (extension
+    // disabled or removed), unless another workspace still provides them.
+    for (const providerId of context.extensionProviderIds) {
+      if (registered.has(providerId) || this.isExtensionProviderClaimedElsewhere(providerId, context)) {
+        continue;
+      }
+      this.modelRegistry.unregisterProvider(providerId);
+    }
+
+    context.extensionProviderIds.clear();
+    for (const providerId of registered) {
+      context.extensionProviderIds.add(providerId);
+    }
+  }
+
+  private isExtensionProviderClaimedElsewhere(providerId: string, context: RuntimeContext): boolean {
+    for (const other of this.contexts.values()) {
+      if (other !== context && other.extensionProviderIds.has(providerId)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private async buildSnapshot(context: RuntimeContext): Promise<RuntimeSnapshot> {

--- a/packages/pi-sdk-driver/src/runtime-supervisor.ts
+++ b/packages/pi-sdk-driver/src/runtime-supervisor.ts
@@ -52,19 +52,17 @@ interface ModelSettingsSnapshot {
   readonly enabledModelPatterns: readonly string[];
 }
 
-/** `ProviderConfigInput` is not exported from the package, so derive it from the extension runtime. */
-type ExtensionProviderConfig =
-  ReturnType<DefaultResourceLoader["getExtensions"]>["runtime"]["pendingProviderRegistrations"][number]["config"];
-
-type ExtensionProviders = Map<string, { config: ExtensionProviderConfig; extensionPath: string }>;
+/** A queued `pi.registerProvider()` call, as the extension runtime records it. */
+type ExtensionProviderRegistration =
+  ReturnType<DefaultResourceLoader["getExtensions"]>["runtime"]["pendingProviderRegistrations"][number];
 
 interface RuntimeContext {
   readonly workspace: WorkspaceRef;
   readonly settingsManager: SettingsManager;
   readonly packageManager: DefaultPackageManager;
   readonly resourceLoader: DefaultResourceLoader;
-  /** Providers this workspace's extensions registered, keyed by provider id. */
-  extensionProviders: ExtensionProviders;
+  /** `registerProvider()` calls this workspace's extensions made, in call order. */
+  extensionProviders: readonly ExtensionProviderRegistration[];
   /** Registry the snapshot is built from, owned by this workspace. */
   modelRegistry: ModelRegistry;
 }
@@ -100,21 +98,24 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
   private readonly agentDir: string;
   private readonly modelsJsonPath: string;
   private readonly authStorage: AuthStorage;
-  /** Registry shared with the session supervisor; kept in sync with auth and models.json. */
-  private readonly sessionModelRegistry: ModelRegistry;
+  /**
+   * The driver's process-wide registry, kept in sync with auth and models.json.
+   *
+   * Not what snapshots or sessions read: those own workspace- and cwd-scoped
+   * registries. It still backs the driver's own model lookups (thread titles).
+   */
+  private readonly sharedModelRegistry: ModelRegistry;
   private readonly extensionFactories: readonly ExtensionFactory[];
   private readonly inlineExtensionMetadata: readonly RuntimeInlineExtensionMetadata[];
   private readonly customProviderStore: CustomProviderStore;
   private readonly contexts = new Map<string, RuntimeContext>();
-  /** Extension provider ids currently mirrored into the session registry. */
-  private sessionExtensionProviderIds = new Set<string>();
 
   constructor(options: RuntimeSupervisorOptions = {}) {
     const deps = createRuntimeDependencies(options);
     this.agentDir = deps.agentDir;
     this.modelsJsonPath = deps.modelsJsonPath;
     this.authStorage = deps.authStorage;
-    this.sessionModelRegistry = deps.modelRegistry;
+    this.sharedModelRegistry = deps.modelRegistry;
     this.extensionFactories = options.extensionFactories ?? [];
     this.inlineExtensionMetadata = options.inlineExtensionMetadata ?? [];
     this.customProviderStore = deps.customProviderStore;
@@ -129,7 +130,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     const context = await this.ensureContext(workspace);
     context.settingsManager.reload();
     this.authStorage.reload();
-    this.sessionModelRegistry.refresh();
+    this.sharedModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context);
     return this.buildSnapshot(context);
@@ -138,7 +139,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
   async login(workspace: WorkspaceRef, providerId: string, callbacks: RuntimeLoginCallbacks): Promise<RuntimeSnapshot> {
     const context = await this.ensureContext(workspace);
     await this.authStorage.login(providerId, toPiOAuthLoginCallbacks(callbacks));
-    this.sessionModelRegistry.refresh();
+    this.sharedModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [providerId]);
     return this.buildSnapshot(context);
@@ -147,7 +148,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
   async logout(workspace: WorkspaceRef, providerId: string): Promise<RuntimeSnapshot> {
     const context = await this.ensureContext(workspace);
     this.authStorage.logout(providerId);
-    this.sessionModelRegistry.refresh();
+    this.sharedModelRegistry.refresh();
     await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
@@ -162,7 +163,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
       throw new Error(`API key setup is not supported for ${providerId}.`);
     }
     this.authStorage.set(providerId, { type: "api_key", key: normalized });
-    this.sessionModelRegistry.refresh();
+    this.sharedModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [providerId]);
     return this.buildSnapshot(context);
@@ -181,7 +182,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     }
     const context = await this.ensureContext(workspace);
     await this.customProviderStore.set(input);
-    this.sessionModelRegistry.refresh();
+    this.sharedModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [input.providerId]);
     return this.buildSnapshot(context);
@@ -190,7 +191,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
   async deleteCustomProvider(workspace: WorkspaceRef, providerId: string): Promise<RuntimeSnapshot> {
     const context = await this.ensureContext(workspace);
     await this.customProviderStore.delete(providerId);
-    this.sessionModelRegistry.refresh();
+    this.sharedModelRegistry.refresh();
     await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
@@ -413,25 +414,35 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
       await resourceLoader.reload();
     }
 
-    const extensionProviders = this.drainExtensionProviders(resourceLoader);
+    const { registry, accepted } = this.buildModelRegistry(this.drainExtensionProviders(resourceLoader));
     const context: RuntimeContext = {
       workspace,
       settingsManager,
       packageManager,
       resourceLoader,
-      extensionProviders,
-      modelRegistry: this.buildModelRegistry(extensionProviders),
+      extensionProviders: accepted,
+      modelRegistry: registry,
     };
     this.contexts.set(workspace.workspaceId, context);
-    this.syncSessionModelRegistry();
     return context;
+  }
+
+  /**
+   * Drop a workspace's cached context.
+   *
+   * Contexts hold that workspace's resource loader, settings manager, and model
+   * registry, so a removed workspace has to give them up — otherwise its
+   * extensions keep their providers alive for the rest of the process.
+   */
+  removeWorkspace(workspaceId: WorkspaceRef["workspaceId"]): void {
+    this.contexts.delete(workspaceId);
   }
 
   private async reloadResources(context: RuntimeContext): Promise<void> {
     await context.resourceLoader.reload();
-    context.extensionProviders = this.drainExtensionProviders(context.resourceLoader);
-    context.modelRegistry = this.buildModelRegistry(context.extensionProviders);
-    this.syncSessionModelRegistry();
+    const { registry, accepted } = this.buildModelRegistry(this.drainExtensionProviders(context.resourceLoader));
+    context.extensionProviders = accepted;
+    context.modelRegistry = registry;
   }
 
   /**
@@ -447,15 +458,17 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
    * Each reload replays every enabled extension, so the drained queue is the
    * workspace's complete current set: providers whose extension was disabled or
    * removed simply do not come back.
+   *
+   * The queue is kept in call order rather than collapsed per provider id.
+   * `registerProvider()` is a merge, not an assignment — a full registration
+   * followed by a `baseUrl`-only one keeps the models and re-points them — so
+   * only replaying every call reproduces what `pi` itself would build.
    */
-  private drainExtensionProviders(resourceLoader: DefaultResourceLoader): ExtensionProviders {
+  private drainExtensionProviders(resourceLoader: DefaultResourceLoader): ExtensionProviderRegistration[] {
     const { runtime } = resourceLoader.getExtensions();
-    const providers: ExtensionProviders = new Map();
-    for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations) {
-      providers.set(name, { config, extensionPath });
-    }
+    const registrations = [...runtime.pendingProviderRegistrations];
     runtime.pendingProviderRegistrations = [];
-    return providers;
+    return registrations;
   }
 
   /**
@@ -463,19 +476,26 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
    *
    * A fresh instance rather than `refresh()`: refreshing resets the process-wide
    * API and OAuth provider registrations and reapplies only the refreshed
-   * registry's providers, which would strip registrations owned by the session
-   * registry. Constructing a registry has the same cost and no global effect.
+   * registry's providers, which would strip registrations owned by session
+   * registries. Constructing a registry has the same cost and no global effect.
+   *
+   * Returns the registrations that were accepted, so a config `pi` rejects is
+   * dropped from the workspace's set instead of warning on every rebuild.
    */
-  private buildModelRegistry(providers: ExtensionProviders): ModelRegistry {
+  private buildModelRegistry(registrations: readonly ExtensionProviderRegistration[]): {
+    readonly registry: ModelRegistry;
+    readonly accepted: ExtensionProviderRegistration[];
+  } {
     const registry = ModelRegistry.create(this.authStorage, this.modelsJsonPath);
-    for (const [name, { config, extensionPath }] of providers) {
+    const accepted: ExtensionProviderRegistration[] = [];
+    for (const registration of registrations) {
+      const { name, config, extensionPath } = registration;
       try {
         // Copy: registering merges into the stored config object in place, which
-        // would let one registry's later registration rewrite our captured config.
+        // would let a later registration rewrite our captured config.
         registry.registerProvider(name, { ...config });
+        accepted.push(registration);
       } catch (error) {
-        // Rejected configs stay rejected, so drop it instead of warning on every rebuild.
-        providers.delete(name);
         console.warn(
           `[pi-gui] Extension "${extensionPath}" failed to register provider "${name}": ${
             error instanceof Error ? error.message : String(error)
@@ -483,41 +503,17 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
         );
       }
     }
-    return registry;
-  }
-
-  /**
-   * Mirror every open workspace's extension providers into the session registry.
-   *
-   * `createAgentSessionServices` only flushes them once a session exists, but the
-   * supervisor resolves a session's initial model against this registry before
-   * creating it — so without this, picking a model the snapshot advertises fails
-   * with "Unknown model". Cross-workspace collisions on a provider id resolve to
-   * whichever workspace synced last, matching how `pi` treats its own registry;
-   * snapshots stay workspace-scoped either way.
-   */
-  private syncSessionModelRegistry(): void {
-    const claimed = new Set<string>();
-    for (const context of this.contexts.values()) {
-      for (const [name, { config }] of context.extensionProviders) {
-        claimed.add(name);
-        this.sessionModelRegistry.registerProvider(name, { ...config });
-      }
-    }
-    for (const name of this.sessionExtensionProviderIds) {
-      if (!claimed.has(name)) {
-        this.sessionModelRegistry.unregisterProvider(name);
-      }
-    }
-    this.sessionExtensionProviderIds = claimed;
+    return { registry, accepted };
   }
 
   private async buildSnapshot(context: RuntimeContext): Promise<RuntimeSnapshot> {
-    // Pick up auth and models.json edits made since the last load. The session
+    // Pick up auth and models.json edits made since the last load. The shared
     // registry is refreshed first so it, not a workspace registry, ends up owning
     // the process-wide API and OAuth registrations.
-    this.sessionModelRegistry.refresh();
-    context.modelRegistry = this.buildModelRegistry(context.extensionProviders);
+    this.sharedModelRegistry.refresh();
+    const { registry, accepted } = this.buildModelRegistry(context.extensionProviders);
+    context.extensionProviders = accepted;
+    context.modelRegistry = registry;
     const resolvedPaths = await this.resolveRuntimePaths(context);
     const [skills, extensions, providers, models] = await Promise.all([
       this.buildSkillRecords(context, resolvedPaths.skills),

--- a/packages/pi-sdk-driver/src/runtime-supervisor.ts
+++ b/packages/pi-sdk-driver/src/runtime-supervisor.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join, relative, resolve } from "node:path";
 import {
   DefaultPackageManager,
   DefaultResourceLoader,
+  ModelRegistry,
   type PackageSource,
   SettingsManager,
   parseFrontmatter,
@@ -28,7 +29,7 @@ import type { WorkspaceRef } from "@pi-gui/session-driver";
 import { createRuntimeDependencies } from "./runtime-deps.js";
 import { createSettingsManagerWithoutNpmPackages, isGlobalNpmLookupError } from "./npm-package-fallback.js";
 import { skillSlashCommand } from "./runtime-command-utils.js";
-import type { AuthStatus, AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { AuthStatus, AuthStorage } from "@earendil-works/pi-coding-agent";
 import {
   BUILT_IN_PROVIDER_IDS,
   CustomProviderStore,
@@ -51,13 +52,21 @@ interface ModelSettingsSnapshot {
   readonly enabledModelPatterns: readonly string[];
 }
 
+/** `ProviderConfigInput` is not exported from the package, so derive it from the extension runtime. */
+type ExtensionProviderConfig =
+  ReturnType<DefaultResourceLoader["getExtensions"]>["runtime"]["pendingProviderRegistrations"][number]["config"];
+
+type ExtensionProviders = Map<string, { config: ExtensionProviderConfig; extensionPath: string }>;
+
 interface RuntimeContext {
   readonly workspace: WorkspaceRef;
   readonly settingsManager: SettingsManager;
   readonly packageManager: DefaultPackageManager;
   readonly resourceLoader: DefaultResourceLoader;
-  /** Provider ids this context last registered from extensions, so stale ones can be dropped. */
-  readonly extensionProviderIds: Set<string>;
+  /** Providers this workspace's extensions registered, keyed by provider id. */
+  extensionProviders: ExtensionProviders;
+  /** Registry the snapshot is built from, owned by this workspace. */
+  modelRegistry: ModelRegistry;
 }
 
 export interface RuntimeInlineExtensionMetadata {
@@ -89,18 +98,23 @@ interface PackageMetadata {
 
 export class RuntimeSupervisor implements RuntimeResourceDriver {
   private readonly agentDir: string;
+  private readonly modelsJsonPath: string;
   private readonly authStorage: AuthStorage;
-  private readonly modelRegistry: ModelRegistry;
+  /** Registry shared with the session supervisor; kept in sync with auth and models.json. */
+  private readonly sessionModelRegistry: ModelRegistry;
   private readonly extensionFactories: readonly ExtensionFactory[];
   private readonly inlineExtensionMetadata: readonly RuntimeInlineExtensionMetadata[];
   private readonly customProviderStore: CustomProviderStore;
   private readonly contexts = new Map<string, RuntimeContext>();
+  /** Extension provider ids currently mirrored into the session registry. */
+  private sessionExtensionProviderIds = new Set<string>();
 
   constructor(options: RuntimeSupervisorOptions = {}) {
     const deps = createRuntimeDependencies(options);
     this.agentDir = deps.agentDir;
+    this.modelsJsonPath = deps.modelsJsonPath;
     this.authStorage = deps.authStorage;
-    this.modelRegistry = deps.modelRegistry;
+    this.sessionModelRegistry = deps.modelRegistry;
     this.extensionFactories = options.extensionFactories ?? [];
     this.inlineExtensionMetadata = options.inlineExtensionMetadata ?? [];
     this.customProviderStore = deps.customProviderStore;
@@ -115,7 +129,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     const context = await this.ensureContext(workspace);
     context.settingsManager.reload();
     this.authStorage.reload();
-    this.modelRegistry.refresh();
+    this.sessionModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context);
     return this.buildSnapshot(context);
@@ -124,7 +138,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
   async login(workspace: WorkspaceRef, providerId: string, callbacks: RuntimeLoginCallbacks): Promise<RuntimeSnapshot> {
     const context = await this.ensureContext(workspace);
     await this.authStorage.login(providerId, toPiOAuthLoginCallbacks(callbacks));
-    this.modelRegistry.refresh();
+    this.sessionModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [providerId]);
     return this.buildSnapshot(context);
@@ -133,7 +147,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
   async logout(workspace: WorkspaceRef, providerId: string): Promise<RuntimeSnapshot> {
     const context = await this.ensureContext(workspace);
     this.authStorage.logout(providerId);
-    this.modelRegistry.refresh();
+    this.sessionModelRegistry.refresh();
     await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
@@ -148,7 +162,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
       throw new Error(`API key setup is not supported for ${providerId}.`);
     }
     this.authStorage.set(providerId, { type: "api_key", key: normalized });
-    this.modelRegistry.refresh();
+    this.sessionModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [providerId]);
     return this.buildSnapshot(context);
@@ -167,7 +181,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     }
     const context = await this.ensureContext(workspace);
     await this.customProviderStore.set(input);
-    this.modelRegistry.refresh();
+    this.sessionModelRegistry.refresh();
     await this.reloadResources(context);
     await this.autoEnableModelsForAuthenticatedProviders(context, [input.providerId]);
     return this.buildSnapshot(context);
@@ -176,7 +190,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
   async deleteCustomProvider(workspace: WorkspaceRef, providerId: string): Promise<RuntimeSnapshot> {
     const context = await this.ensureContext(workspace);
     await this.customProviderStore.delete(providerId);
-    this.modelRegistry.refresh();
+    this.sessionModelRegistry.refresh();
     await this.reloadResources(context);
     return this.buildSnapshot(context);
   }
@@ -399,41 +413,69 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
       await resourceLoader.reload();
     }
 
+    const extensionProviders = this.drainExtensionProviders(resourceLoader);
     const context: RuntimeContext = {
       workspace,
       settingsManager,
       packageManager,
       resourceLoader,
-      extensionProviderIds: new Set<string>(),
+      extensionProviders,
+      modelRegistry: this.buildModelRegistry(extensionProviders),
     };
-    this.syncExtensionProviders(context);
     this.contexts.set(workspace.workspaceId, context);
+    this.syncSessionModelRegistry();
     return context;
   }
 
   private async reloadResources(context: RuntimeContext): Promise<void> {
     await context.resourceLoader.reload();
-    this.syncExtensionProviders(context);
+    context.extensionProviders = this.drainExtensionProviders(context.resourceLoader);
+    context.modelRegistry = this.buildModelRegistry(context.extensionProviders);
+    this.syncSessionModelRegistry();
   }
 
   /**
-   * Apply providers that extensions registered while loading.
+   * Drain the providers this workspace's extensions registered while loading.
    *
    * `pi` queues `pi.registerProvider()` calls made during extension load on the
-   * shared extension runtime and flushes them when session services are created
-   * (`createAgentSessionServices`). The runtime snapshot never goes through that
-   * path, so without this the model list only ever shows built-ins, `models.json`
-   * providers, and custom providers — extension-provided models are invisible in
-   * settings and pickers even though sessions can use them.
+   * resource loader's extension runtime and flushes them when session services are
+   * created (`createAgentSessionServices`). The runtime snapshot never goes through
+   * that path, so without this the model list only ever shows built-ins,
+   * `models.json` providers, and custom providers — extension-provided models are
+   * invisible in settings and pickers even though sessions can use them.
+   *
+   * Each reload replays every enabled extension, so the drained queue is the
+   * workspace's complete current set: providers whose extension was disabled or
+   * removed simply do not come back.
    */
-  private syncExtensionProviders(context: RuntimeContext): void {
-    const { runtime } = context.resourceLoader.getExtensions();
-    const registered = new Set<string>();
+  private drainExtensionProviders(resourceLoader: DefaultResourceLoader): ExtensionProviders {
+    const { runtime } = resourceLoader.getExtensions();
+    const providers: ExtensionProviders = new Map();
     for (const { name, config, extensionPath } of runtime.pendingProviderRegistrations) {
+      providers.set(name, { config, extensionPath });
+    }
+    runtime.pendingProviderRegistrations = [];
+    return providers;
+  }
+
+  /**
+   * Build a registry from disk plus the given workspace's extension providers.
+   *
+   * A fresh instance rather than `refresh()`: refreshing resets the process-wide
+   * API and OAuth provider registrations and reapplies only the refreshed
+   * registry's providers, which would strip registrations owned by the session
+   * registry. Constructing a registry has the same cost and no global effect.
+   */
+  private buildModelRegistry(providers: ExtensionProviders): ModelRegistry {
+    const registry = ModelRegistry.create(this.authStorage, this.modelsJsonPath);
+    for (const [name, { config, extensionPath }] of providers) {
       try {
-        this.modelRegistry.registerProvider(name, config);
-        registered.add(name);
+        // Copy: registering merges into the stored config object in place, which
+        // would let one registry's later registration rewrite our captured config.
+        registry.registerProvider(name, { ...config });
       } catch (error) {
+        // Rejected configs stay rejected, so drop it instead of warning on every rebuild.
+        providers.delete(name);
         console.warn(
           `[pi-gui] Extension "${extensionPath}" failed to register provider "${name}": ${
             error instanceof Error ? error.message : String(error)
@@ -441,39 +483,47 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
         );
       }
     }
-    runtime.pendingProviderRegistrations = [];
-
-    // Drop providers this context registered before but no longer does (extension
-    // disabled or removed), unless another workspace still provides them.
-    for (const providerId of context.extensionProviderIds) {
-      if (registered.has(providerId) || this.isExtensionProviderClaimedElsewhere(providerId, context)) {
-        continue;
-      }
-      this.modelRegistry.unregisterProvider(providerId);
-    }
-
-    context.extensionProviderIds.clear();
-    for (const providerId of registered) {
-      context.extensionProviderIds.add(providerId);
-    }
+    return registry;
   }
 
-  private isExtensionProviderClaimedElsewhere(providerId: string, context: RuntimeContext): boolean {
-    for (const other of this.contexts.values()) {
-      if (other !== context && other.extensionProviderIds.has(providerId)) {
-        return true;
+  /**
+   * Mirror every open workspace's extension providers into the session registry.
+   *
+   * `createAgentSessionServices` only flushes them once a session exists, but the
+   * supervisor resolves a session's initial model against this registry before
+   * creating it — so without this, picking a model the snapshot advertises fails
+   * with "Unknown model". Cross-workspace collisions on a provider id resolve to
+   * whichever workspace synced last, matching how `pi` treats its own registry;
+   * snapshots stay workspace-scoped either way.
+   */
+  private syncSessionModelRegistry(): void {
+    const claimed = new Set<string>();
+    for (const context of this.contexts.values()) {
+      for (const [name, { config }] of context.extensionProviders) {
+        claimed.add(name);
+        this.sessionModelRegistry.registerProvider(name, { ...config });
       }
     }
-    return false;
+    for (const name of this.sessionExtensionProviderIds) {
+      if (!claimed.has(name)) {
+        this.sessionModelRegistry.unregisterProvider(name);
+      }
+    }
+    this.sessionExtensionProviderIds = claimed;
   }
 
   private async buildSnapshot(context: RuntimeContext): Promise<RuntimeSnapshot> {
+    // Pick up auth and models.json edits made since the last load. The session
+    // registry is refreshed first so it, not a workspace registry, ends up owning
+    // the process-wide API and OAuth registrations.
+    this.sessionModelRegistry.refresh();
+    context.modelRegistry = this.buildModelRegistry(context.extensionProviders);
     const resolvedPaths = await this.resolveRuntimePaths(context);
     const [skills, extensions, providers, models] = await Promise.all([
       this.buildSkillRecords(context, resolvedPaths.skills),
       this.buildExtensionRecords(context, resolvedPaths.extensions),
-      this.buildProviderRecords(),
-      this.buildModelRecords(),
+      this.buildProviderRecords(context),
+      this.buildModelRecords(context),
     ]);
 
     const defaultProvider = context.settingsManager.getDefaultProvider();
@@ -525,10 +575,10 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
     }
   }
 
-  private async buildProviderRecords(): Promise<readonly RuntimeProviderRecord[]> {
+  private async buildProviderRecords(context: RuntimeContext): Promise<readonly RuntimeProviderRecord[]> {
     const oauthProviders = new Map(this.authStorage.getOAuthProviders().map((provider) => [provider.id, provider]));
     const providerIds = new Set<string>([
-      ...this.modelRegistry.getAll().map((model) => model.provider),
+      ...context.modelRegistry.getAll().map((model) => model.provider),
       ...oauthProviders.keys(),
       ...this.authStorage.list(),
     ]);
@@ -539,7 +589,7 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
         const auth = this.authStorage.get(providerId);
         const oauthProvider = oauthProviders.get(providerId);
         const apiKeySetupSupported = providerSupportsDesktopApiKeySetup(providerId);
-        const providerAuthStatus = this.modelRegistry.getProviderAuthStatus(providerId);
+        const providerAuthStatus = context.modelRegistry.getProviderAuthStatus(providerId);
         const hasAuth = providerAuthStatus.configured || this.authStorage.hasAuth(providerId);
         return {
           id: providerId,
@@ -553,14 +603,13 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
       });
   }
 
-  private async buildModelRecords(): Promise<readonly RuntimeModelRecord[]> {
-    this.modelRegistry.refresh();
+  private async buildModelRecords(context: RuntimeContext): Promise<readonly RuntimeModelRecord[]> {
     const availableKeys = new Set(
-      (await this.modelRegistry.getAvailable()).map((model) => `${model.provider}:${model.id}`),
+      (await context.modelRegistry.getAvailable()).map((model) => `${model.provider}:${model.id}`),
     );
-    const providers = new Map((await this.buildProviderRecords()).map((provider) => [provider.id, provider]));
+    const providers = new Map((await this.buildProviderRecords(context)).map((provider) => [provider.id, provider]));
 
-    return this.modelRegistry
+    return context.modelRegistry
       .getAll()
       .map<RuntimeModelRecord>((model) => {
         const provider = providers.get(model.provider);
@@ -591,8 +640,8 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
       return;
     }
 
-    const providers = await this.buildProviderRecords();
-    const models = await this.buildModelRecords();
+    const providers = await this.buildProviderRecords(context);
+    const models = await this.buildModelRecords(context);
     const hasSelectableModels = models.some((model) =>
       model.available && currentPatterns.includes(`${model.providerId}/${model.modelId}`),
     );

--- a/packages/pi-sdk-driver/src/session-supervisor.ts
+++ b/packages/pi-sdk-driver/src/session-supervisor.ts
@@ -1,8 +1,9 @@
 import { access, realpath, stat, unlink } from "node:fs/promises";
 import { resolve } from "node:path";
 import {
-  ModelRegistry,
   SessionManager,
+  type AuthStorage,
+  type ModelRegistry,
   type AgentSessionRuntime,
   type AgentSession,
   type AgentSessionEvent,
@@ -97,12 +98,40 @@ import type { SessionTranscriptItem, SessionTranscriptMessage } from "./transcri
 import {
   createAgentSessionRuntimeWithNpmFallback,
   type PiCreateAgentSessionOptions,
+  type PiModelInfo,
 } from "./npm-package-fallback.js";
+
+function requireModel(modelRegistry: ModelRegistry, provider: string, modelId: string): PiModelInfo {
+  const model = modelRegistry.find(provider, modelId);
+  if (!model) {
+    throw new Error(`Unknown model ${provider}:${modelId}`);
+  }
+  return model;
+}
+
+/**
+ * Resolve a model against a live session's registry.
+ *
+ * The registry was built when the session was created, so a provider added since
+ * then — a custom provider set up in Settings, say — is not in it yet. Refreshing
+ * on a miss reloads `models.json` and reapplies the session's own extension
+ * registrations, which is what makes a freshly added model selectable without
+ * reopening the session.
+ */
+function requireSessionModel(modelRegistry: ModelRegistry, provider: string, modelId: string): PiModelInfo {
+  const model = modelRegistry.find(provider, modelId);
+  if (model) {
+    return model;
+  }
+  modelRegistry.refresh();
+  return requireModel(modelRegistry, provider, modelId);
+}
 
 export interface PiSdkDriverOptions {
   readonly catalogFilePath?: string;
-  readonly createAgentSessionRuntimeImpl?: (options?: CreateAgentSessionOptions) => Promise<AgentSessionRuntime>;
-  readonly modelRegistry?: ModelRegistry;
+  readonly createAgentSessionRuntimeImpl?: (options?: PiCreateAgentSessionOptions) => Promise<AgentSessionRuntime>;
+  readonly agentDir?: string;
+  readonly authStorage?: AuthStorage;
   readonly extensionFactories?: readonly ExtensionFactory[];
   readonly generateThreadTitleOverride?: (
     workspace: WorkspaceRef,
@@ -176,8 +205,9 @@ interface SkillAdapter {
 
 export class SessionSupervisor {
   private readonly catalogs: SessionFileCatalogStorage;
-  private readonly createAgentSessionRuntimeImpl: (options?: CreateAgentSessionOptions) => Promise<AgentSessionRuntime>;
-  private readonly modelRegistry: ModelRegistry | undefined;
+  private readonly createAgentSessionRuntimeImpl: (options?: PiCreateAgentSessionOptions) => Promise<AgentSessionRuntime>;
+  private readonly agentDir: string | undefined;
+  private readonly authStorage: AuthStorage | undefined;
   private readonly records = new Map<string, ManagedSessionRecord>();
   private readonly ensureRecordInFlight = new Map<string, Promise<ManagedSessionRecord>>();
   private readonly leaseIdentity: LeaseIdentity = currentLeaseIdentity();
@@ -198,7 +228,26 @@ export class SessionSupervisor {
             ...(options.extensionFactories ? { extensionFactories: [...options.extensionFactories] } : {}),
           },
         }));
-    this.modelRegistry = options.modelRegistry;
+    this.agentDir = options.agentDir;
+    this.authStorage = options.authStorage;
+  }
+
+  /**
+   * Options every session creation shares.
+   *
+   * Deliberately no `modelRegistry`: letting `createAgentSessionServices` build
+   * one per session keeps it cwd-bound, so it holds exactly the extension
+   * providers registered for this workspace and cannot pick up another open
+   * workspace's endpoint or credentials for the same provider id. `authStorage`
+   * is shared so a login made in Settings reaches sessions that are already open.
+   */
+  private baseCreateOptions(cwd: string, sessionManager: SessionManager): PiCreateAgentSessionOptions {
+    return {
+      cwd,
+      sessionManager,
+      ...(this.agentDir ? { agentDir: this.agentDir } : {}),
+      ...(this.authStorage ? { authStorage: this.authStorage } : {}),
+    };
   }
 
   listWorkspaces(): Promise<WorkspaceCatalogSnapshot> {
@@ -448,20 +497,21 @@ export class SessionSupervisor {
   async createSession(workspace: WorkspaceRef, options?: CreateSessionOptions): Promise<SessionSnapshot> {
     await this.touchWorkspace(workspace);
 
-    const initialModel = options?.initialModel
-      ? this.resolveModel(options.initialModel.provider, options.initialModel.modelId)
-      : undefined;
-    const createOptions: CreateAgentSessionOptions = {
-      cwd: workspace.path,
-      sessionManager: SessionManager.create(workspace.path),
-      ...(this.modelRegistry ? { modelRegistry: this.modelRegistry } : {}),
+    const initialModel = options?.initialModel;
+    const createOptions: PiCreateAgentSessionOptions = {
+      ...this.baseCreateOptions(workspace.path, SessionManager.create(workspace.path)),
+      ...(initialModel
+        ? {
+            resolveInitialModel: (modelRegistry: ModelRegistry) =>
+              requireModel(modelRegistry, initialModel.provider, initialModel.modelId),
+          }
+        : {}),
+      ...(options?.initialThinkingLevel
+        ? {
+            thinkingLevel: options.initialThinkingLevel as NonNullable<CreateAgentSessionOptions["thinkingLevel"]>,
+          }
+        : {}),
     };
-    if (initialModel) {
-      createOptions.model = initialModel;
-    }
-    if (options?.initialThinkingLevel) {
-      createOptions.thinkingLevel = options.initialThinkingLevel as NonNullable<CreateAgentSessionOptions["thinkingLevel"]>;
-    }
 
     const runtime = await this.createAgentSessionRuntimeImpl(createOptions);
     const session = runtime.session;
@@ -565,24 +615,24 @@ export class SessionSupervisor {
       branchedManager = forked;
     }
 
-    const createOptions: CreateAgentSessionOptions = {
-      cwd: targetWorkspace.path,
-      sessionManager: branchedManager,
-      ...(this.modelRegistry ? { modelRegistry: this.modelRegistry } : {}),
-    };
     const forkConfig = deriveSessionConfig(branchedManager);
-    if (forkConfig?.provider && forkConfig?.modelId) {
-      try {
-        createOptions.model = this.resolveModel(forkConfig.provider, forkConfig.modelId);
-      } catch {
-        // Forked model is no longer available; fall back to the runtime default.
-      }
-    }
-    if (forkConfig?.thinkingLevel) {
-      createOptions.thinkingLevel = forkConfig.thinkingLevel as NonNullable<
-        CreateAgentSessionOptions["thinkingLevel"]
-      >;
-    }
+    const forkProvider = forkConfig?.provider;
+    const forkModelId = forkConfig?.modelId;
+    const createOptions: PiCreateAgentSessionOptions = {
+      ...this.baseCreateOptions(targetWorkspace.path, branchedManager),
+      ...(forkProvider && forkModelId
+        ? {
+            // A model the source session used may not exist in the target
+            // workspace; fall back to the runtime default rather than failing.
+            resolveInitialModel: (modelRegistry: ModelRegistry) => modelRegistry.find(forkProvider, forkModelId),
+          }
+        : {}),
+      ...(forkConfig?.thinkingLevel
+        ? {
+            thinkingLevel: forkConfig.thinkingLevel as NonNullable<CreateAgentSessionOptions["thinkingLevel"]>,
+          }
+        : {}),
+    };
 
     const runtime = await this.createAgentSessionRuntimeImpl(createOptions);
     const session = runtime.session;
@@ -801,7 +851,10 @@ export class SessionSupervisor {
       throw new Error(`Session ${sessionKey(record.ref)} is not active.`);
     }
 
-    const model = this.resolveModel(selection.provider, selection.modelId);
+    // The session's own registry, not a shared one: it holds this workspace's
+    // extension providers, so the endpoint and credentials resolved here are the
+    // ones this workspace registered even if another workspace claims the id.
+    const model = requireSessionModel(session.modelRegistry, selection.provider, selection.modelId);
     const auth = await session.modelRegistry.getApiKeyAndHeaders(model);
     if (!auth.ok) {
       throw new Error(auth.error);
@@ -997,11 +1050,9 @@ export class SessionSupervisor {
     // conversation. Absent/dead/own leases never block (fully advisory).
     await this.assertSessionNotForeignLeased(sessionFile);
 
-    const runtime = await this.createAgentSessionRuntimeImpl({
-      cwd: workspace.path,
-      sessionManager: SessionManager.open(sessionFile),
-      ...(this.modelRegistry ? { modelRegistry: this.modelRegistry } : {}),
-    });
+    const runtime = await this.createAgentSessionRuntimeImpl(
+      this.baseCreateOptions(workspace.path, SessionManager.open(sessionFile)),
+    );
     const session = runtime.session;
 
     const record = existing ?? this.createRecord(workspaceToRef(workspace), runtime, sessionEntry.title);
@@ -1505,14 +1556,6 @@ export class SessionSupervisor {
     await session.followUp(text, images ? [...images] : undefined);
   }
 
-  private resolveModel(provider: string, modelId: string) {
-    const model = this.modelRegistry?.find(provider, modelId);
-    if (!model) {
-      throw new Error(`Unknown model ${provider}:${modelId}`);
-    }
-    return model;
-  }
-
   private applySessionThinkingLevel(session: AgentSession, thinkingLevel: string): void {
     const availableLevels = session.getAvailableThinkingLevels();
     const effectiveLevel = clampThinkingLevel(thinkingLevel, availableLevels) as AgentSession["thinkingLevel"];
@@ -1526,7 +1569,7 @@ export class SessionSupervisor {
 
   private async emitModelSelection(
     session: AgentSession,
-    model: ReturnType<SessionSupervisor["resolveModel"]>,
+    model: PiModelInfo,
     previousModel: AgentSession["model"],
   ): Promise<void> {
     const emitModelSelect = (session as unknown as {

--- a/packages/pi-sdk-driver/test/runtime-supervisor-extension-providers.test.mts
+++ b/packages/pi-sdk-driver/test/runtime-supervisor-extension-providers.test.mts
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { RuntimeSupervisor } from "../dist/runtime-supervisor.js";
+
+const EXTENSION_PROVIDER = "ext-test-provider";
+const EXTENSION_MODEL = "ext-test-model";
+const JSON_PROVIDER = "json-test-provider";
+const JSON_MODEL = "json-test-model";
+const FILE_PROVIDER = "file-test-provider";
+const FILE_MODEL = "file-test-model";
+
+async function createAgentDir(): Promise<{ agentDir: string; workspacePath: string }> {
+  const root = await mkdtemp(join(tmpdir(), "pi-gui-ext-providers-"));
+  const agentDir = join(root, "agent");
+  const workspacePath = join(root, "workspace");
+  await mkdir(agentDir, { recursive: true });
+  await mkdir(workspacePath, { recursive: true });
+  await writeFile(join(agentDir, "auth.json"), "{}");
+  await writeFile(join(agentDir, "settings.json"), JSON.stringify({ packages: [] }));
+  await writeFile(
+    join(agentDir, "models.json"),
+    JSON.stringify({
+      providers: {
+        [JSON_PROVIDER]: {
+          baseUrl: "http://localhost:9/v1",
+          api: "openai-completions",
+          apiKey: "test-key",
+          models: [{ id: JSON_MODEL, input: ["text"] }],
+        },
+      },
+    }),
+  );
+  return { agentDir, workspacePath };
+}
+
+function createSupervisor(agentDir: string) {
+  return new RuntimeSupervisor({
+    agentDir,
+    extensionFactories: [
+      (pi) => {
+        pi.registerProvider(EXTENSION_PROVIDER, {
+          baseUrl: "http://localhost:9/v1",
+          apiKey: "test-key",
+          api: "openai-completions",
+          models: [
+            {
+              id: EXTENSION_MODEL,
+              name: "Extension Test Model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 16384,
+            },
+          ],
+        });
+      },
+    ],
+  });
+}
+
+test("runtime snapshot includes providers registered by extensions", async () => {
+  const { agentDir, workspacePath } = await createAgentDir();
+  const supervisor = createSupervisor(agentDir);
+  const workspace = { workspaceId: "workspace-1", path: workspacePath };
+
+  const snapshot = await supervisor.getRuntimeSnapshot(workspace);
+
+  assert.ok(
+    snapshot.models.some((model) => model.providerId === JSON_PROVIDER && model.modelId === JSON_MODEL),
+    "models.json provider should be listed",
+  );
+  assert.ok(
+    snapshot.models.some((model) => model.providerId === EXTENSION_PROVIDER && model.modelId === EXTENSION_MODEL),
+    "extension-registered provider should be listed",
+  );
+  assert.ok(
+    snapshot.providers.some((provider) => provider.id === EXTENSION_PROVIDER),
+    "extension-registered provider should appear in the provider list",
+  );
+});
+
+test("disabling an extension drops the providers it registered", async () => {
+  const { agentDir, workspacePath } = await createAgentDir();
+  const extensionPath = join(agentDir, "extensions", "file-provider.ts");
+  await mkdir(join(agentDir, "extensions"), { recursive: true });
+  await writeFile(
+    extensionPath,
+    `export default async function fileProviderExtension(pi) {
+  pi.registerProvider(${JSON.stringify(FILE_PROVIDER)}, {
+    baseUrl: "http://localhost:9/v1",
+    apiKey: "test-key",
+    api: "openai-completions",
+    models: [
+      {
+        id: ${JSON.stringify(FILE_MODEL)},
+        name: "File Extension Model",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 16384,
+      },
+    ],
+  });
+}
+`,
+  );
+
+  const supervisor = new RuntimeSupervisor({ agentDir });
+  const workspace = { workspaceId: "workspace-1", path: workspacePath };
+
+  const enabled = await supervisor.getRuntimeSnapshot(workspace);
+  assert.ok(
+    enabled.models.some((model) => model.providerId === FILE_PROVIDER && model.modelId === FILE_MODEL),
+    "file-based extension provider should be listed while enabled",
+  );
+
+  const disabled = await supervisor.setExtensionEnabled(workspace, extensionPath, false);
+  assert.ok(
+    !disabled.models.some((model) => model.providerId === FILE_PROVIDER),
+    "provider should be dropped once its extension is disabled",
+  );
+});
+
+test("extension providers survive a runtime refresh", async () => {
+  const { agentDir, workspacePath } = await createAgentDir();
+  const supervisor = createSupervisor(agentDir);
+  const workspace = { workspaceId: "workspace-1", path: workspacePath };
+
+  await supervisor.getRuntimeSnapshot(workspace);
+  const refreshed = await supervisor.refreshRuntime(workspace);
+
+  assert.ok(
+    refreshed.models.some((model) => model.providerId === EXTENSION_PROVIDER && model.modelId === EXTENSION_MODEL),
+    "extension-registered provider should still be listed after refreshRuntime",
+  );
+});

--- a/packages/pi-sdk-driver/test/runtime-supervisor-extension-providers.test.mts
+++ b/packages/pi-sdk-driver/test/runtime-supervisor-extension-providers.test.mts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { RuntimeSupervisor } from "../dist/runtime-supervisor.js";
 
 const EXTENSION_PROVIDER = "ext-test-provider";
@@ -11,6 +12,53 @@ const JSON_PROVIDER = "json-test-provider";
 const JSON_MODEL = "json-test-model";
 const FILE_PROVIDER = "file-test-provider";
 const FILE_MODEL = "file-test-model";
+
+function extensionSource(providerId: string, modelId: string, baseUrl = "http://localhost:9/v1"): string {
+  return `export default async function providerExtension(pi) {
+  pi.registerProvider(${JSON.stringify(providerId)}, {
+    baseUrl: ${JSON.stringify(baseUrl)},
+    apiKey: "test-key",
+    api: "openai-completions",
+    models: [
+      {
+        id: ${JSON.stringify(modelId)},
+        name: ${JSON.stringify(`Model ${modelId}`)},
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 16384,
+      },
+    ],
+  });
+}
+`;
+}
+
+/** Create a workspace with a project-scoped extension under `<workspace>/.pi/extensions`. */
+async function createProjectWorkspace(
+  root: string,
+  workspaceId: string,
+  providerId: string,
+  modelId: string,
+  baseUrl?: string,
+): Promise<{ workspace: { workspaceId: string; path: string }; extensionPath: string }> {
+  const path = join(root, workspaceId);
+  const extensionPath = join(path, ".pi", "extensions", "provider.ts");
+  await mkdir(join(path, ".pi", "extensions"), { recursive: true });
+  await writeFile(extensionPath, extensionSource(providerId, modelId, baseUrl));
+  return { workspace: { workspaceId, path }, extensionPath };
+}
+
+function providerIds(snapshot: { providers: readonly { id: string }[] }, prefix: string): string[] {
+  return snapshot.providers.map((provider) => provider.id).filter((id) => id.startsWith(prefix));
+}
+
+function modelKeys(snapshot: { models: readonly { providerId: string; modelId: string }[] }, prefix: string): string[] {
+  return snapshot.models
+    .filter((model) => model.providerId.startsWith(prefix))
+    .map((model) => `${model.providerId}:${model.modelId}`);
+}
 
 async function createAgentDir(): Promise<{ agentDir: string; workspacePath: string }> {
   const root = await mkdtemp(join(tmpdir(), "pi-gui-ext-providers-"));
@@ -34,6 +82,16 @@ async function createAgentDir(): Promise<{ agentDir: string; workspacePath: stri
     }),
   );
   return { agentDir, workspacePath };
+}
+
+/** An agent dir with no models.json providers, for multi-workspace isolation tests. */
+async function createSharedAgentDir(): Promise<{ root: string; agentDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), "pi-gui-ext-providers-"));
+  const agentDir = join(root, "agent");
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(join(agentDir, "auth.json"), "{}");
+  await writeFile(join(agentDir, "settings.json"), JSON.stringify({ packages: [] }));
+  return { root, agentDir };
 }
 
 function createSupervisor(agentDir: string) {
@@ -123,6 +181,104 @@ test("disabling an extension drops the providers it registered", async () => {
   assert.ok(
     !disabled.models.some((model) => model.providerId === FILE_PROVIDER),
     "provider should be dropped once its extension is disabled",
+  );
+});
+
+test("each workspace only sees providers its own project extensions register", async () => {
+  const { root, agentDir } = await createSharedAgentDir();
+  const a = await createProjectWorkspace(root, "workspace-a", "scoped-a", "model-a");
+  const b = await createProjectWorkspace(root, "workspace-b", "scoped-b", "model-b");
+  const supervisor = new RuntimeSupervisor({ agentDir });
+
+  const firstA = await supervisor.getRuntimeSnapshot(a.workspace);
+  assert.deepEqual(providerIds(firstA, "scoped-"), ["scoped-a"]);
+
+  const snapshotB = await supervisor.getRuntimeSnapshot(b.workspace);
+  assert.deepEqual(providerIds(snapshotB, "scoped-"), ["scoped-b"], "workspace B must not see workspace A's provider");
+  assert.deepEqual(modelKeys(snapshotB, "scoped-"), ["scoped-b:model-b"]);
+
+  const secondA = await supervisor.getRuntimeSnapshot(a.workspace);
+  assert.deepEqual(
+    providerIds(secondA, "scoped-"),
+    ["scoped-a"],
+    "workspace A must not pick up workspace B's provider after B was opened",
+  );
+  assert.deepEqual(modelKeys(secondA, "scoped-"), ["scoped-a:model-a"]);
+});
+
+test("the same provider id resolves to each workspace's own configuration", async () => {
+  const { root, agentDir } = await createSharedAgentDir();
+  const a = await createProjectWorkspace(root, "workspace-a", "shared-id", "model-a", "http://localhost:9/a");
+  const b = await createProjectWorkspace(root, "workspace-b", "shared-id", "model-b", "http://localhost:9/b");
+  const supervisor = new RuntimeSupervisor({ agentDir });
+
+  await supervisor.getRuntimeSnapshot(a.workspace);
+  const snapshotB = await supervisor.getRuntimeSnapshot(b.workspace);
+  assert.deepEqual(modelKeys(snapshotB, "shared-id"), ["shared-id:model-b"]);
+
+  const secondA = await supervisor.getRuntimeSnapshot(a.workspace);
+  assert.deepEqual(
+    modelKeys(secondA, "shared-id"),
+    ["shared-id:model-a"],
+    "workspace A must keep its own configuration for a provider id workspace B also registers",
+  );
+});
+
+test("disabling an extension only drops the registrations of that workspace", async () => {
+  const { root, agentDir } = await createSharedAgentDir();
+  const a = await createProjectWorkspace(root, "workspace-a", "scoped-a", "model-a");
+  const b = await createProjectWorkspace(root, "workspace-b", "scoped-b", "model-b");
+  const supervisor = new RuntimeSupervisor({ agentDir });
+
+  await supervisor.getRuntimeSnapshot(a.workspace);
+  await supervisor.getRuntimeSnapshot(b.workspace);
+
+  const disabledA = await supervisor.setExtensionEnabled(a.workspace, a.extensionPath, false);
+  assert.deepEqual(providerIds(disabledA, "scoped-"), [], "workspace A should lose its own provider");
+
+  const snapshotB = await supervisor.getRuntimeSnapshot(b.workspace);
+  assert.deepEqual(
+    providerIds(snapshotB, "scoped-"),
+    ["scoped-b"],
+    "workspace B should keep its provider when workspace A disables its extension",
+  );
+});
+
+/**
+ * Sessions resolve models against the registry the driver shares with the session
+ * supervisor, so every provider a snapshot advertises has to be registered there
+ * too — otherwise picking an extension model fails with "Unknown model".
+ */
+test("the session registry resolves extension models from every open workspace", async () => {
+  const { root, agentDir } = await createSharedAgentDir();
+  const a = await createProjectWorkspace(root, "workspace-a", "scoped-a", "model-a");
+  const b = await createProjectWorkspace(root, "workspace-b", "scoped-b", "model-b");
+  const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+  const sessionRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+  const supervisor = new RuntimeSupervisor({ agentDir, authStorage, modelRegistry: sessionRegistry });
+
+  await supervisor.getRuntimeSnapshot(a.workspace);
+  await supervisor.getRuntimeSnapshot(b.workspace);
+
+  assert.ok(sessionRegistry.find("scoped-a", "model-a"), "workspace A's extension model must be resolvable");
+  assert.ok(sessionRegistry.find("scoped-b", "model-b"), "workspace B's extension model must be resolvable");
+});
+
+test("disabling an extension removes its provider from the session registry", async () => {
+  const { root, agentDir } = await createSharedAgentDir();
+  const a = await createProjectWorkspace(root, "workspace-a", "scoped-a", "model-a");
+  const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+  const sessionRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+  const supervisor = new RuntimeSupervisor({ agentDir, authStorage, modelRegistry: sessionRegistry });
+
+  await supervisor.getRuntimeSnapshot(a.workspace);
+  assert.ok(sessionRegistry.find("scoped-a", "model-a"));
+
+  await supervisor.setExtensionEnabled(a.workspace, a.extensionPath, false);
+  assert.equal(
+    sessionRegistry.find("scoped-a", "model-a"),
+    undefined,
+    "a disabled extension's provider must not linger in the session registry",
   );
 });
 

--- a/packages/pi-sdk-driver/test/runtime-supervisor-extension-providers.test.mts
+++ b/packages/pi-sdk-driver/test/runtime-supervisor-extension-providers.test.mts
@@ -244,44 +244,6 @@ test("disabling an extension only drops the registrations of that workspace", as
   );
 });
 
-/**
- * Sessions resolve models against the registry the driver shares with the session
- * supervisor, so every provider a snapshot advertises has to be registered there
- * too — otherwise picking an extension model fails with "Unknown model".
- */
-test("the session registry resolves extension models from every open workspace", async () => {
-  const { root, agentDir } = await createSharedAgentDir();
-  const a = await createProjectWorkspace(root, "workspace-a", "scoped-a", "model-a");
-  const b = await createProjectWorkspace(root, "workspace-b", "scoped-b", "model-b");
-  const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
-  const sessionRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
-  const supervisor = new RuntimeSupervisor({ agentDir, authStorage, modelRegistry: sessionRegistry });
-
-  await supervisor.getRuntimeSnapshot(a.workspace);
-  await supervisor.getRuntimeSnapshot(b.workspace);
-
-  assert.ok(sessionRegistry.find("scoped-a", "model-a"), "workspace A's extension model must be resolvable");
-  assert.ok(sessionRegistry.find("scoped-b", "model-b"), "workspace B's extension model must be resolvable");
-});
-
-test("disabling an extension removes its provider from the session registry", async () => {
-  const { root, agentDir } = await createSharedAgentDir();
-  const a = await createProjectWorkspace(root, "workspace-a", "scoped-a", "model-a");
-  const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
-  const sessionRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
-  const supervisor = new RuntimeSupervisor({ agentDir, authStorage, modelRegistry: sessionRegistry });
-
-  await supervisor.getRuntimeSnapshot(a.workspace);
-  assert.ok(sessionRegistry.find("scoped-a", "model-a"));
-
-  await supervisor.setExtensionEnabled(a.workspace, a.extensionPath, false);
-  assert.equal(
-    sessionRegistry.find("scoped-a", "model-a"),
-    undefined,
-    "a disabled extension's provider must not linger in the session registry",
-  );
-});
-
 test("extension providers survive a runtime refresh", async () => {
   const { agentDir, workspacePath } = await createAgentDir();
   const supervisor = createSupervisor(agentDir);

--- a/packages/pi-sdk-driver/test/session-extension-provider-scope.test.mts
+++ b/packages/pi-sdk-driver/test/session-extension-provider-scope.test.mts
@@ -1,0 +1,250 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PiSdkDriver } from "../dist/pi-sdk-driver.js";
+import { createAgentSessionRuntimeWithNpmFallback } from "../dist/npm-package-fallback.js";
+
+/**
+ * Sessions must resolve models against the registry `createAgentSessionServices`
+ * builds for their own cwd. These cover what a shared, cross-workspace registry
+ * got wrong: two workspaces claiming one provider id would resolve to whichever
+ * synced last, mixing one workspace's endpoint with another's credentials.
+ *
+ * Endpoints are discard ports and every key is a canary; nothing here sends a
+ * request.
+ */
+
+const ENDPOINT_A = "http://127.0.0.1:9/workspace-a";
+const ENDPOINT_B = "http://127.0.0.1:9/workspace-b";
+const KEY_A = "CANARY_A_DO_NOT_USE";
+const KEY_B = "CANARY_B_DO_NOT_USE";
+
+function modelDefinition(modelId: string): string {
+  return `{
+        id: ${JSON.stringify(modelId)},
+        name: ${JSON.stringify(`Model ${modelId}`)},
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 16384,
+      }`;
+}
+
+function providerExtensionSource(
+  providerId: string,
+  modelId: string,
+  baseUrl: string,
+  apiKey: string,
+): string {
+  return `export default async function providerExtension(pi) {
+  pi.registerProvider(${JSON.stringify(providerId)}, {
+    baseUrl: ${JSON.stringify(baseUrl)},
+    apiKey: ${JSON.stringify(apiKey)},
+    api: "openai-completions",
+    models: [${modelDefinition(modelId)}],
+  });
+}
+`;
+}
+
+async function makeAgentDir(): Promise<{ root: string; agentDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), "pi-gui-session-ext-scope-"));
+  const agentDir = join(root, "agent");
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(join(agentDir, "auth.json"), "{}");
+  await writeFile(join(agentDir, "settings.json"), JSON.stringify({ packages: [] }));
+  return { root, agentDir };
+}
+
+/** Write a workspace whose project extension registers `providerId`. */
+async function makeWorkspaceDir(root: string, name: string, source: string): Promise<string> {
+  const path = join(root, name);
+  await mkdir(join(path, ".pi", "extensions"), { recursive: true });
+  await writeFile(join(path, ".pi", "extensions", "provider.ts"), source);
+  return path;
+}
+
+/**
+ * A driver whose session runtimes are the real ones, wrapped only to keep the
+ * `AgentSessionRuntime` around so a test can inspect the registry the session
+ * actually resolves against.
+ */
+function makeDriver(root: string, agentDir: string) {
+  const created: { cwd: string | undefined; runtime: { session: { modelRegistry: any } } }[] = [];
+  const driver = new PiSdkDriver({
+    agentDir,
+    catalogFilePath: join(root, "catalogs.json"),
+    createAgentSessionRuntimeImpl: async (options: any) => {
+      const runtime = await createAgentSessionRuntimeWithNpmFallback(options);
+      created.push({ cwd: options?.cwd, runtime: runtime as never });
+      return runtime;
+    },
+  });
+  const registryFor = (cwd: string) => {
+    const entry = created.findLast((candidate) => candidate.cwd === cwd);
+    assert.ok(entry, `no session runtime was created for ${cwd}`);
+    return entry.runtime.session.modelRegistry;
+  };
+  return { driver, registryFor };
+}
+
+test("a workspace resolves its own models for a provider id another workspace also registers", async () => {
+  const { root, agentDir } = await makeAgentDir();
+  const pathA = await makeWorkspaceDir(
+    root,
+    "workspace-a",
+    providerExtensionSource("shared-id", "model-a", ENDPOINT_A, KEY_A),
+  );
+  const pathB = await makeWorkspaceDir(
+    root,
+    "workspace-b",
+    providerExtensionSource("shared-id", "model-b", ENDPOINT_B, KEY_B),
+  );
+  const { driver } = makeDriver(root, agentDir);
+
+  const { workspace: workspaceA } = await driver.syncWorkspace(pathA);
+  const { workspace: workspaceB } = await driver.syncWorkspace(pathB);
+  await driver.runtimeSupervisor.getRuntimeSnapshot(workspaceA);
+  await driver.runtimeSupervisor.getRuntimeSnapshot(workspaceB);
+
+  // B registered `shared-id` last. A must still resolve the model A advertises.
+  const snapshot = await driver.createSession(workspaceA, {
+    initialModel: { provider: "shared-id", modelId: "model-a" },
+  });
+  assert.equal(snapshot.config?.provider, "shared-id");
+  assert.equal(snapshot.config?.modelId, "model-a");
+  await driver.closeSession(snapshot.ref);
+});
+
+test("a session keeps its own workspace's endpoint and key for a shared provider and model id", async () => {
+  const { root, agentDir } = await makeAgentDir();
+  const pathA = await makeWorkspaceDir(
+    root,
+    "workspace-a",
+    providerExtensionSource("shared-id", "model-x", ENDPOINT_A, KEY_A),
+  );
+  const pathB = await makeWorkspaceDir(
+    root,
+    "workspace-b",
+    providerExtensionSource("shared-id", "model-x", ENDPOINT_B, KEY_B),
+  );
+  const { driver, registryFor } = makeDriver(root, agentDir);
+
+  const { workspace: workspaceA } = await driver.syncWorkspace(pathA);
+  const { workspace: workspaceB } = await driver.syncWorkspace(pathB);
+  await driver.runtimeSupervisor.getRuntimeSnapshot(workspaceA);
+
+  const snapshot = await driver.createSession(workspaceA, {
+    initialModel: { provider: "shared-id", modelId: "model-x" },
+  });
+
+  // Opening workspace B while A has a live session must not re-point that
+  // session — the mixing a registry shared across workspaces produced.
+  await driver.runtimeSupervisor.getRuntimeSnapshot(workspaceB);
+
+  const registry = registryFor(workspaceA.path);
+  const model = registry.find("shared-id", "model-x");
+  assert.ok(model, "workspace A's session must resolve the shared model id");
+  assert.equal(model.baseUrl, ENDPOINT_A, "workspace A's session must keep workspace A's endpoint");
+
+  const auth = await registry.getApiKeyAndHeaders(model);
+  assert.equal(auth.ok, true);
+  assert.equal(auth.apiKey, KEY_A, "workspace A's session must use workspace A's credential");
+  await driver.closeSession(snapshot.ref);
+});
+
+test("removing a workspace leaves another workspace's session resolution intact", async () => {
+  const { root, agentDir } = await makeAgentDir();
+  const pathA = await makeWorkspaceDir(
+    root,
+    "workspace-a",
+    providerExtensionSource("shared-id", "model-a", ENDPOINT_A, KEY_A),
+  );
+  const pathB = await makeWorkspaceDir(
+    root,
+    "workspace-b",
+    providerExtensionSource("shared-id", "model-b", ENDPOINT_B, KEY_B),
+  );
+  const { driver, registryFor } = makeDriver(root, agentDir);
+
+  const { workspace: workspaceA } = await driver.syncWorkspace(pathA);
+  const { workspace: workspaceB } = await driver.syncWorkspace(pathB);
+  await driver.runtimeSupervisor.getRuntimeSnapshot(workspaceA);
+  await driver.runtimeSupervisor.getRuntimeSnapshot(workspaceB);
+
+  await driver.removeWorkspace(workspaceA.workspaceId);
+
+  const snapshot = await driver.createSession(workspaceB, {
+    initialModel: { provider: "shared-id", modelId: "model-b" },
+  });
+  const registry = registryFor(workspaceB.path);
+  const model = registry.find("shared-id", "model-b");
+  assert.ok(model, "workspace B must still resolve its own model after workspace A is removed");
+  assert.equal(model.baseUrl, ENDPOINT_B);
+  await driver.closeSession(snapshot.ref);
+});
+
+test("removing a workspace evicts its runtime context", async () => {
+  const { root, agentDir } = await makeAgentDir();
+  const path = await makeWorkspaceDir(
+    root,
+    "workspace-a",
+    providerExtensionSource("before-removal", "model-a", ENDPOINT_A, KEY_A),
+  );
+  const { driver } = makeDriver(root, agentDir);
+
+  const { workspace } = await driver.syncWorkspace(path);
+  const before = await driver.runtimeSupervisor.getRuntimeSnapshot(workspace);
+  assert.ok(before.providers.some((provider) => provider.id === "before-removal"));
+
+  await driver.removeWorkspace(workspace.workspaceId);
+
+  // A cached context is served without reloading resources, so an extension
+  // added after the removal only shows up if the context was actually dropped.
+  await writeFile(
+    join(path, ".pi", "extensions", "added-after-removal.ts"),
+    providerExtensionSource("after-removal", "model-b", ENDPOINT_B, KEY_B),
+  );
+  const after = await driver.runtimeSupervisor.getRuntimeSnapshot(workspace);
+  assert.ok(
+    after.providers.some((provider) => provider.id === "after-removal"),
+    "reopening a removed workspace must build a fresh context that reloads its extensions",
+  );
+});
+
+test("an override-only registration keeps the models the first registration defined", async () => {
+  const { root, agentDir } = await makeAgentDir();
+  const path = await makeWorkspaceDir(
+    root,
+    "workspace-a",
+    `export default async function providerExtension(pi) {
+  pi.registerProvider("merge-id", {
+    baseUrl: ${JSON.stringify(ENDPOINT_A)},
+    apiKey: ${JSON.stringify(KEY_A)},
+    api: "openai-completions",
+    models: [${modelDefinition("model-a")}],
+  });
+  pi.registerProvider("merge-id", { baseUrl: ${JSON.stringify(ENDPOINT_B)} });
+}
+`,
+  );
+  const { driver, registryFor } = makeDriver(root, agentDir);
+
+  const { workspace } = await driver.syncWorkspace(path);
+  const runtimeSnapshot = await driver.runtimeSupervisor.getRuntimeSnapshot(workspace);
+  assert.ok(
+    runtimeSnapshot.models.some((model) => model.providerId === "merge-id" && model.modelId === "model-a"),
+    "the override-only registration must not drop the model the first call defined",
+  );
+
+  const snapshot = await driver.createSession(workspace, {
+    initialModel: { provider: "merge-id", modelId: "model-a" },
+  });
+  const model = registryFor(workspace.path).find("merge-id", "model-a");
+  assert.ok(model, "the merged provider must stay resolvable for sessions");
+  assert.equal(model.baseUrl, ENDPOINT_B, "the override-only registration must re-point the model");
+  await driver.closeSession(snapshot.ref);
+});


### PR DESCRIPTION
Fixes #51.

## Problem

`pi` queues `pi.registerProvider()` calls made while extensions load onto the shared extension runtime (`core/extensions/loader.js` → `runtime.pendingProviderRegistrations`) and flushes that queue in exactly two places, both session paths: `createAgentSessionServices` and `ExtensionRunner.bindCore`.

`RuntimeSupervisor` builds its snapshot from the file-backed `ModelRegistry` (`runtime-deps.ts:17`) and calls `resourceLoader.reload()` without ever flushing that queue, so `buildModelRecords()` can't see extension providers. Result: extension-registered models are invisible in Settings → Models and in every picker. The provider itself still shows up (because `buildProviderRecords()` unions `authStorage.list()`), just with zero models — and if the user's default model came from such a provider (e.g. set via the `pi` CLI), Settings renders "Your default model (x:y) is not enabled".

## Change

`packages/pi-sdk-driver/src/runtime-supervisor.ts`:

- New `reloadResources()` wraps every `resourceLoader.reload()` call site, so the flush happens on context creation and on every reload (refresh, login/logout, API-key set, custom-provider add/delete, skill/extension toggle).
- `syncExtensionProviders()` drains `runtime.pendingProviderRegistrations` into the registry, logging and skipping providers that fail to register rather than failing the whole snapshot.
- Each context remembers the provider ids it last registered, so a provider that disappears (extension disabled or removed) gets unregistered — unless another open workspace still registers it.

## Tests

- `packages/pi-sdk-driver/test/runtime-supervisor-extension-providers.test.mts` — driver-level load / refresh / disable coverage.
- `apps/desktop/tests/core/extension-provider-models.spec.ts` — Electron spec that seeds a real extension calling `pi.registerProvider()` and asserts the model shows up in Settings.

Both verified red without the driver change.

## Workspace scoping

Each `RuntimeContext` owns the registry its snapshot is built from, holding only that workspace's registrations, so nothing one workspace registers reaches another's model list. The registry shared with the session supervisor still receives every open workspace's providers, because session model resolution runs before pi's own flush — see the review comment for why both halves are needed.

## Note for a future `pi` bump

The driver pins `pi-coding-agent@^0.80.6`. `ModelRegistry.create` is gone in 0.80.10 in favour of `ModelRuntime`, so this area will need adapting on the next bump.
