### PR TITLE
fix(timeline): stop spurious pane ref re-attachments yanking scroll mid-stream

### DIFF
--- a/apps/desktop/src/conversation-timeline.tsx
+++ b/apps/desktop/src/conversation-timeline.tsx
@@ -155,8 +155,30 @@ export function ConversationTimeline({
     setMeasurementVersion((current) => current + 1);
   }, []);
 
+  // React re-runs ref callbacks (detach null + re-attach node) whenever the callback
+  // identity changes, even though the DOM node is unchanged — and timelinePaneElementRef's
+  // identity changes on every transcript append (its useCallback chain depends on
+  // activeTranscript.length). Each spurious re-attach re-runs the pane mount logic,
+  // whose saved-scroll restore yanks the viewport away from the live bottom mid-stream
+  // (the scroll-jump bug). Forward only real node changes; swallow same-node
+  // re-attachments and their paired null-detach.
+  const forwardedPaneNodeRef = useRef<HTMLDivElement | null>(null);
   const assignTimelinePaneRef = useCallback((node: HTMLDivElement | null) => {
+    if (node === null) {
+      timelinePaneRef.current = null;
+      queueMicrotask(() => {
+        if (timelinePaneRef.current === null && forwardedPaneNodeRef.current !== null) {
+          forwardedPaneNodeRef.current = null;
+          timelinePaneElementRef?.(null);
+        }
+      });
+      return;
+    }
     timelinePaneRef.current = node;
+    if (forwardedPaneNodeRef.current === node) {
+      return;
+    }
+    forwardedPaneNodeRef.current = node;
     timelinePaneElementRef?.(node);
   }, [timelinePaneElementRef, timelinePaneRef]);
 


### PR DESCRIPTION
## Symptom

On long threads (past `VIRTUALIZATION_THRESHOLD`) with an agent actively appending items, the timeline viewport oscillates on a ~2s beat between the live bottom and a fixed earlier position, and the **New activity below** button stops working mid-stream (the smooth scroll gets cancelled and yanked back).

## Root cause

`timelinePaneElementRef`'s identity changes on every transcript append: `requestPinnedBottomAlignment`'s `useCallback` depends on `activeTranscript.length`, and `setTimelinePaneElement` depends on it in turn. React re-runs ref callbacks (detach `null` + re-attach `node`) whenever the callback identity changes — even though the DOM node is unchanged. Each spurious re-attach re-runs the pane mount logic, whose saved-scroll restore snaps the viewport back to a stale reading position, while the pinned-bottom machinery pulls it back down: the visible oscillation.

Instrumented on a live 120+-item thread with tool calls appending every few seconds: three detach/attach pairs in a single burst, each re-applying the same saved `scrollTop` (14720) while `scrollHeight` grew from 18811 to 18935.

## Fix

Guard `assignTimelinePaneRef`: forward only real node changes; swallow same-node re-attachments and their paired null-detach (a microtask defers the null so genuine unmounts still propagate).

## Verification

- Same live scenario after the fix: 0 spurious mount/restore events across 40 transcript updates (previously 3 remount+restore cycles in a comparable window); jump-to-latest lands and sticks; off-bottom reading position survives thread switches, view switches, and streaming.
- `tests/core/timeline-pinning.spec.ts`: 10/10 pass.
- `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)