### PR TITLE
perf: keep the renderer responsive while long threads stream

### DIFF
--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -90,7 +90,6 @@ import {
   buildWorkspaceRecords,
   cloneComposerAttachment,
   cloneComposerAttachments,
-  cloneTranscriptMessage,
   latestSessionActivityAt,
   mergeQueuedComposerMessages,
   mapToRecord,
@@ -2689,10 +2688,13 @@ export class DesktopAppStore implements AppStoreInternals {
   private buildSelectedTranscriptRecord(sessionRef: SessionRef): SelectedTranscriptRecord {
     this.ensureSessionSchemaInfo(sessionRef);
     const schemaInfo = this.sessionSchemaInfoCache.get(sessionKey(sessionRef));
+    // No defensive clone here: every consumer ships this record over IPC, which
+    // structured-clones the payload anyway. Cloning 400+ messages per publish
+    // just doubled main-process allocations during streaming.
     return {
       workspaceId: sessionRef.workspaceId,
       sessionId: sessionRef.sessionId,
-      transcript: (this.sessionState.transcriptCache.get(sessionKey(sessionRef)) ?? []).map(cloneTranscriptMessage),
+      transcript: this.sessionState.transcriptCache.get(sessionKey(sessionRef)) ?? [],
       ...(schemaInfo ? { schemaInfo } : {}),
     };
   }
@@ -3165,7 +3167,10 @@ export class DesktopAppStore implements AppStoreInternals {
     runtimeByWorkspace?: Record<string, RuntimeSnapshot>,
   ): DesktopAppState {
     const key = sessionKey(sessionRef);
-    const transcript = (this.sessionState.transcriptCache.get(key) ?? []).map(cloneTranscriptMessage);
+    // No clone: the cache follows immutable-write discipline (every mutation
+    // replaces the array), so this reference is a stable snapshot. Cloning the
+    // whole transcript here cost O(thread) allocations per session state sync.
+    const transcript = this.sessionState.transcriptCache.get(key) ?? [];
     const preview = previewFromTranscript(transcript);
     const lastViewedAt = this.sessionState.lastViewedAtBySession.get(key);
     const nextState = {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -440,6 +440,19 @@ function publishStateToWindow(window: BrowserWindow, state: DesktopAppState = st
   window.webContents.send(desktopIpc.stateChanged, projected);
 }
 
+// Transcript arrays in the store follow an immutable-write discipline (every
+// mutation path copies the array before writing), so array identity is an exact
+// change detector. Remember what each window last received and skip the send —
+// and its full-payload serialization — when nothing it displays has changed
+// (e.g. events from other sessions ticking the store).
+interface PublishedTranscriptFingerprint {
+  readonly workspaceId: string;
+  readonly sessionId: string;
+  readonly transcript: unknown;
+  readonly schemaInfo: unknown;
+}
+const lastPublishedTranscriptByWebContentsId = new Map<number, PublishedTranscriptFingerprint | null>();
+
 async function publishSelectedTranscriptToWindow(window: BrowserWindow): Promise<void> {
   if (!canPublishToWindow(window)) {
     return;
@@ -454,6 +467,29 @@ async function publishSelectedTranscriptToWindow(window: BrowserWindow): Promise
       }
     } else if (projected.selectedSessionId) {
       return;
+    }
+    const previous = lastPublishedTranscriptByWebContentsId.get(webContentsId);
+    if (payload) {
+      if (
+        previous &&
+        previous.workspaceId === payload.workspaceId &&
+        previous.sessionId === payload.sessionId &&
+        previous.transcript === payload.transcript &&
+        previous.schemaInfo === payload.schemaInfo
+      ) {
+        return;
+      }
+      lastPublishedTranscriptByWebContentsId.set(webContentsId, {
+        workspaceId: payload.workspaceId,
+        sessionId: payload.sessionId,
+        transcript: payload.transcript,
+        schemaInfo: payload.schemaInfo,
+      });
+    } else {
+      if (previous === null) {
+        return;
+      }
+      lastPublishedTranscriptByWebContentsId.set(webContentsId, null);
     }
     window.webContents.send(desktopIpc.selectedTranscriptChanged, payload);
   }
@@ -706,6 +742,7 @@ function createAppWindow(sourceView?: DesktopAppViewState): BrowserWindow {
   window.once("closed", () => {
     appWindows.delete(window);
     windowViews.delete(webContentsId);
+    lastPublishedTranscriptByWebContentsId.delete(webContentsId);
     terminalFocusedWebContentsIds.delete(webContentsId);
     terminalService?.disposeWebContents(webContentsId);
     void store.cancelPendingDialogsWithoutVisibleWindow((sessionRef) => isSessionVisibleInAnotherWindow(sessionRef));

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -725,17 +725,57 @@ function createAppWindow(sourceView?: DesktopAppViewState): BrowserWindow {
   return window;
 }
 
+// Store updates arrive per agent event — during streaming that is tens of times
+// per second, and each publish serializes the full app state plus the full
+// selected transcript over IPC. On long threads that firehose saturates the
+// renderer (deserialize + rebuild + render per token batch) and can OOM it.
+// Coalesce bursts to a trailing-edge cadence; the final flush always runs, so
+// the window never misses the settled state. Direct publishes on user-initiated
+// IPC requests are untouched and stay immediate.
+const PUBLISH_COALESCE_MS = 200;
+
+function throttleTrailing(fn: () => void, intervalMs: number): { run: () => void; cancel: () => void } {
+  let timer: NodeJS.Timeout | null = null;
+  let lastRun = 0;
+  return {
+    run: () => {
+      if (timer) {
+        return;
+      }
+      const wait = Math.max(0, intervalMs - (Date.now() - lastRun));
+      timer = setTimeout(() => {
+        timer = null;
+        lastRun = Date.now();
+        fn();
+      }, wait);
+    },
+    cancel: () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
 function attachStatePublisher(window: BrowserWindow): void {
   const webContentsId = window.webContents.id;
   const startPublishing = () => {
     stopPublishingStateByWebContentsId.get(webContentsId)?.();
     stopPublishingSelectedTranscriptByWebContentsId.get(webContentsId)?.();
-    const stopPublishingState = store.subscribe((state) => {
-      publishStateToWindow(window, state);
+    const publishLatest = throttleTrailing(() => {
+      publishStateToWindow(window);
       void publishSelectedTranscriptToWindow(window);
+    }, PUBLISH_COALESCE_MS);
+    const stopPublishingStateSubscription = store.subscribe(() => {
+      publishLatest.run();
     });
+    const stopPublishingState = () => {
+      publishLatest.cancel();
+      stopPublishingStateSubscription();
+    };
     const stopPublishingSelectedTranscript = store.subscribeToSelectedTranscript(() => {
-      void publishSelectedTranscriptToWindow(window);
+      publishLatest.run();
     });
     stopPublishingStateByWebContentsId.set(webContentsId, stopPublishingState);
     stopPublishingSelectedTranscriptByWebContentsId.set(webContentsId, stopPublishingSelectedTranscript);

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -771,7 +771,11 @@ function createAppWindow(sourceView?: DesktopAppViewState): BrowserWindow {
 // IPC requests are untouched and stay immediate.
 const PUBLISH_COALESCE_MS = 200;
 
-function throttleTrailing(fn: () => void, intervalMs: number): { run: () => void; cancel: () => void } {
+// Leading + trailing throttle: an isolated update publishes synchronously —
+// several main-side protocols (e.g. the composer-draft persist echo) depend on
+// the publish happening inside the same tick that marked its origin — while
+// bursts coalesce onto a trailing edge whose final flush always runs.
+function throttleLeadingTrailing(fn: () => void, intervalMs: number): { run: () => void; cancel: () => void } {
   let timer: NodeJS.Timeout | null = null;
   let lastRun = 0;
   return {
@@ -779,12 +783,17 @@ function throttleTrailing(fn: () => void, intervalMs: number): { run: () => void
       if (timer) {
         return;
       }
-      const wait = Math.max(0, intervalMs - (Date.now() - lastRun));
+      const elapsed = Date.now() - lastRun;
+      if (elapsed >= intervalMs) {
+        lastRun = Date.now();
+        fn();
+        return;
+      }
       timer = setTimeout(() => {
         timer = null;
         lastRun = Date.now();
         fn();
-      }, wait);
+      }, intervalMs - elapsed);
     },
     cancel: () => {
       if (timer) {
@@ -800,7 +809,7 @@ function attachStatePublisher(window: BrowserWindow): void {
   const startPublishing = () => {
     stopPublishingStateByWebContentsId.get(webContentsId)?.();
     stopPublishingSelectedTranscriptByWebContentsId.get(webContentsId)?.();
-    const publishLatest = throttleTrailing(() => {
+    const publishLatest = throttleLeadingTrailing(() => {
       publishStateToWindow(window);
       void publishSelectedTranscriptToWindow(window);
     }, PUBLISH_COALESCE_MS);

--- a/apps/desktop/src/conversation-timeline.tsx
+++ b/apps/desktop/src/conversation-timeline.tsx
@@ -573,7 +573,23 @@ function isSameDisplayItem(a: DisplayTimelineItem, b: DisplayTimelineItem): bool
     return a.role === b.role && a.text === b.text && a.attachments === b.attachments;
   }
   if (a.kind === "tool" && b.kind === "tool") {
-    return a.status === b.status && a.input === b.input && a.output === b.output;
+    // input/output are rebuilt objects on every transcript update, so identity
+    // comparison would re-render every tool row per streaming tick. All visible
+    // transitions (result arrival, failure) flip status and/or the derived
+    // label/detail/metadata strings, so compare those instead.
+    return (
+      a.status === b.status &&
+      a.toolName === b.toolName &&
+      a.label === b.label &&
+      a.detail === b.detail &&
+      a.metadata === b.metadata
+    );
+  }
+  if (a.kind === "activity" && b.kind === "activity") {
+    return a.label === b.label && a.detail === b.detail && a.metadata === b.metadata && a.tone === b.tone;
+  }
+  if (a.kind === "summary" && b.kind === "summary") {
+    return a.label === b.label && a.metadata === b.metadata && a.presentation === b.presentation;
   }
   if (a.kind === "turn-marker" && b.kind === "turn-marker") {
     return a.durationMs === b.durationMs;

--- a/apps/desktop/src/conversation-timeline.tsx
+++ b/apps/desktop/src/conversation-timeline.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject, type RefCallback, type RefObject } from "react";
+import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject, type RefCallback, type RefObject } from "react";
 import type { TranscriptMessage } from "./desktop-state";
 import type { DisplayTimelineItem } from "./timeline-types";
 import { buildDisplayTimelineItems } from "./timeline-turns";
@@ -492,17 +492,7 @@ function VirtualizedTranscriptList({
   );
 }
 
-function MeasuredTimelineItem({
-  item,
-  className,
-  top,
-  onHeightChange,
-  expandedToolCallIds,
-  onToggleToolCall,
-  onViewFileInDiff,
-  sourceMessageIndex,
-  onForkFromMessage,
-}: {
+interface MeasuredTimelineItemProps {
   readonly item: DisplayTimelineItem;
   readonly className?: string;
   readonly top?: number;
@@ -512,7 +502,19 @@ function MeasuredTimelineItem({
   readonly onViewFileInDiff?: (path: string) => void;
   readonly sourceMessageIndex?: number;
   readonly onForkFromMessage?: (messageIndex: number, preview?: string) => void;
-}) {
+}
+
+function MeasuredTimelineItemBase({
+  item,
+  className,
+  top,
+  onHeightChange,
+  expandedToolCallIds,
+  onToggleToolCall,
+  onViewFileInDiff,
+  sourceMessageIndex,
+  onForkFromMessage,
+}: MeasuredTimelineItemProps) {
   const rowRef = useRef<HTMLDivElement | null>(null);
 
   useLayoutEffect(() => {
@@ -554,6 +556,49 @@ function MeasuredTimelineItem({
     </div>
   );
 }
+
+// The transcript array is rebuilt with fresh item objects on every session
+// update, so reference equality on `item` would re-render all rows each
+// streaming tick — on long threads (virtualization off) that means re-running
+// every row several times per second, which saturates the renderer. Compare
+// items structurally by the fields that actually affect their rendering.
+function isSameDisplayItem(a: DisplayTimelineItem, b: DisplayTimelineItem): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a.kind !== b.kind || a.id !== b.id) {
+    return false;
+  }
+  if (a.kind === "message" && b.kind === "message") {
+    return a.role === b.role && a.text === b.text && a.attachments === b.attachments;
+  }
+  if (a.kind === "tool" && b.kind === "tool") {
+    return a.status === b.status && a.input === b.input && a.output === b.output;
+  }
+  if (a.kind === "turn-marker" && b.kind === "turn-marker") {
+    return a.durationMs === b.durationMs;
+  }
+  return false;
+}
+
+function areMeasuredTimelineItemPropsEqual(
+  prev: MeasuredTimelineItemProps,
+  next: MeasuredTimelineItemProps,
+): boolean {
+  return (
+    isSameDisplayItem(prev.item, next.item) &&
+    prev.className === next.className &&
+    prev.top === next.top &&
+    prev.onHeightChange === next.onHeightChange &&
+    prev.expandedToolCallIds === next.expandedToolCallIds &&
+    prev.onToggleToolCall === next.onToggleToolCall &&
+    prev.onViewFileInDiff === next.onViewFileInDiff &&
+    prev.sourceMessageIndex === next.sourceMessageIndex &&
+    prev.onForkFromMessage === next.onForkFromMessage
+  );
+}
+
+const MeasuredTimelineItem = memo(MeasuredTimelineItemBase, areMeasuredTimelineItemPropsEqual);
 
 function findStartIndex(offsets: readonly number[], heights: readonly number[], targetOffset: number): number {
   let low = 0;

--- a/apps/desktop/src/message-markdown.tsx
+++ b/apps/desktop/src/message-markdown.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -15,7 +16,10 @@ const MARKDOWN_COMPONENTS = {
   ),
 } as const;
 
-export function MessageMarkdown({ text }: { readonly text: string }) {
+// Memoized: remark parsing is the dominant render cost on long threads, and the
+// timeline re-renders on every streaming tick. `text` is a string, so shallow
+// comparison skips the re-parse for every message except the one still growing.
+export const MessageMarkdown = memo(function MessageMarkdown({ text }: { readonly text: string }) {
   return (
     <div className="message__content">
       <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS}>
@@ -23,4 +27,4 @@ export function MessageMarkdown({ text }: { readonly text: string }) {
       </ReactMarkdown>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Symptom

On long threads (400+ items) with an agent streaming, the renderer saturates and degrades as the thread grows — in our case ending in a renderer crash (V8 fatal trap at ~1.7GB RSS, ~125% CPU sustained) and a white window while the agent kept running in the main process.

## Root causes and fixes (one commit each)

1. **Every store update published the full app state + the full selected transcript over IPC** — tens of times per second while streaming, each publish serializing ~1MB. → Coalesce subscription-driven publishes onto a 200ms trailing edge, with a leading edge so isolated updates keep their original synchronous timing (several main-side protocols, e.g. the composer-draft persist echo, rely on it). User-initiated direct publishes stay immediate.
2. **Every streaming tick re-rendered every row, including a full remark re-parse of every message body** (transcript arrays are rebuilt with fresh objects per update, so reference-based memoization never held). → Memoize `MessageMarkdown` (text is a string; shallow compare skips the re-parse) and `MeasuredTimelineItem` with a structural comparator; compare tool rows by their derived `status`/`label`/`detail` strings instead of `input`/`output` identity.
3. **Two full-transcript clones per publish/sync** — one redundant with IPC's own structured clone, one cloning 400+ messages just to derive a one-line preview. → Hand out the array reference; the cache follows an immutable-write discipline (every mutation path copies the array before writing).
4. **Unrelated sessions' activity re-sent the window's unchanged transcript.** → Array identity is an exact change detector under the immutable-write discipline; remember what each window last received and skip no-op sends.

## Measurements

M4 Mac mini, 460-item thread, active streaming, DevTools closed:

| | before | after |
|---|---|---|
| renderer CPU | 122–129% | 30–50% |
| allocation churn | ~20MB/s | ~5MB/s |

The remaining cost is the per-publish O(thread) work (full-payload deserialize + rebuild); an incremental append/patch IPC protocol would be the next step if long-thread streaming needs to get cheaper still.

## Verification

- `tests/core/timeline-pinning.spec.ts` 10/10, `tests/core/persistence.spec.ts` 5/6 — the one failure (`recovers from parseable malformed nested state`) also fails on unmodified `main` in this environment (pre-existing).
- `pnpm typecheck` clean.
- Live verification on a real streaming agent session: pinning, off-bottom reading, jump-to-latest, thread/view switches all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)