### PR TITLE
feat(composer): show context occupancy next to the model selector

### DIFF
--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -2241,6 +2241,12 @@ export class DesktopAppStore implements AppStoreInternals {
           this.updateSessionConfig(event.sessionRef, event.snapshot.config);
           this.updateQueuedComposerMessages(event.sessionRef, event.snapshot.queuedMessages);
           await this.refreshSessionCommands(event.sessionRef);
+          if (event.type === "runCompleted") {
+            // Live-event assistant messages are built without usage metadata;
+            // re-read the settled transcript from the session file so fields
+            // only present there (e.g. contextTokens) reach the UI.
+            await this.reloadTranscriptFromDriver(event.sessionRef);
+          }
           break;
         case "sessionUpdated":
           this.updateSessionConfig(event.sessionRef, event.snapshot.config);

--- a/apps/desktop/electron/app-store.ts
+++ b/apps/desktop/electron/app-store.ts
@@ -1538,6 +1538,34 @@ export class DesktopAppStore implements AppStoreInternals {
     await this.recordSelectedTranscriptFileStat(sessionRef);
   }
 
+  /**
+   * Post-run reload of the settled transcript from the session file. The file
+   * is canonical after a run, but a lagging or partial read (or a driver that
+   * doesn't persist transcripts, as in tests) must never wipe a richer live
+   * timeline — compare substantive rows (messages + tools; the live timeline
+   * also carries activity rows the file never has) and keep the live timeline
+   * when the parse comes up short.
+   */
+  private async reloadTranscriptFromDriverIfComplete(sessionRef: SessionRef): Promise<void> {
+    const key = sessionKey(sessionRef);
+    let parsed: TranscriptMessage[];
+    try {
+      parsed = timelineFromDriverTranscript(await this.driver.getTranscript(sessionRef));
+    } catch {
+      return;
+    }
+    const substantiveRows = (items: readonly TranscriptMessage[]): number =>
+      items.reduce((count, item) => (item.kind === "message" || item.kind === "tool" ? count + 1 : count), 0);
+    const current = this.sessionState.transcriptCache.get(key) ?? [];
+    if (substantiveRows(parsed) < substantiveRows(current)) {
+      return;
+    }
+    this.sessionState.loadedTranscriptKeys.add(key);
+    this.sessionState.transcriptCache.set(key, parsed);
+    await this.recordSelectedTranscriptFileStat(sessionRef);
+    this.publishSelectedTranscriptFor(sessionRef);
+  }
+
   async reloadTranscriptFromDriver(sessionRef: SessionRef): Promise<void> {
     const key = sessionKey(sessionRef);
     const transcript = timelineFromDriverTranscript(await this.driver.getTranscript(sessionRef));
@@ -2245,7 +2273,7 @@ export class DesktopAppStore implements AppStoreInternals {
             // Live-event assistant messages are built without usage metadata;
             // re-read the settled transcript from the session file so fields
             // only present there (e.g. contextTokens) reach the UI.
-            await this.reloadTranscriptFromDriver(event.sessionRef);
+            await this.reloadTranscriptFromDriverIfComplete(event.sessionRef);
           }
           break;
         case "sessionUpdated":

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -160,6 +160,15 @@ export default function App() {
       : null;
   const activeTranscript = selectedTranscriptForSession?.transcript ?? [];
   const isTranscriptLoading = Boolean(selectedSession) && !selectedTranscriptForSession;
+  const activeContextTokens = useMemo(() => {
+    for (let index = activeTranscript.length - 1; index >= 0; index -= 1) {
+      const item = activeTranscript[index];
+      if (item?.kind === "message" && item.role === "assistant" && item.contextTokens != null) {
+        return item.contextTokens;
+      }
+    }
+    return undefined;
+  }, [activeTranscript]);
   const {
     setTimelinePaneElement,
     disableTimelineVirtualization,
@@ -953,6 +962,7 @@ export default function App() {
               composerDraft={composerDraft}
               composerRef={composerRef}
               runtime={selectedModelRuntime}
+              contextTokens={activeContextTokens}
               provider={resolvedSessionProvider}
               modelId={resolvedSessionModelId}
               thinkingLevel={resolvedSessionThinkingLevel}

--- a/apps/desktop/src/composer-panel.tsx
+++ b/apps/desktop/src/composer-panel.tsx
@@ -19,6 +19,8 @@ interface ComposerPanelProps {
   readonly selectedSession: SessionRecord;
   readonly lastError?: string;
   readonly runtime?: RuntimeSnapshot;
+  /** Context occupancy (total tokens) reported by the last completed turn. */
+  readonly contextTokens?: number;
   readonly activeSlashCommand?: ComposerSlashCommand;
   readonly activeSlashCommandMeta?: string;
   readonly composerDraft: string;
@@ -69,6 +71,7 @@ export function ComposerPanel({
   selectedSession,
   lastError,
   runtime,
+  contextTokens,
   activeSlashCommand,
   activeSlashCommandMeta,
   composerDraft,
@@ -181,6 +184,20 @@ export function ComposerPanel({
                     onSetModel={onSetModel}
                     onSetThinking={onSetThinking}
                   />
+                  {contextTokens != null ? (
+                    <span title="Context used, from the last completed turn's reported usage">
+                      {" · "}
+                      {formatContextTokens(contextTokens)}
+                      {(() => {
+                        const window = runtime?.models.find(
+                          (model) => model.providerId === provider && model.modelId === modelId,
+                        )?.contextWindow;
+                        return window
+                          ? ` / ${formatContextTokens(window)} (${Math.round((contextTokens / window) * 100)}%)`
+                          : "";
+                      })()}
+                    </span>
+                  ) : null}
                 </div>
                 <div className="composer__actions">
                   <button
@@ -212,4 +229,15 @@ export function ComposerPanel({
       </div>
     </footer>
   );
+}
+
+function formatContextTokens(count: number): string {
+  if (count >= 1_000_000) {
+    const millions = count / 1_000_000;
+    return `${Number.isInteger(millions) ? millions : millions.toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${Math.round(count / 1000)}k`;
+  }
+  return String(count);
 }

--- a/packages/pi-sdk-driver/src/runtime-supervisor.ts
+++ b/packages/pi-sdk-driver/src/runtime-supervisor.ts
@@ -513,6 +513,9 @@ export class RuntimeSupervisor implements RuntimeResourceDriver {
           authType: provider?.authType ?? "none",
           reasoning: Boolean(model.reasoning),
           supportsImages: model.input.includes("image"),
+          ...(typeof model.contextWindow === "number" && model.contextWindow > 0
+            ? { contextWindow: model.contextWindow }
+            : {}),
         };
       })
       .sort((left, right) =>

--- a/packages/pi-sdk-driver/src/session-supervisor-utils.ts
+++ b/packages/pi-sdk-driver/src/session-supervisor-utils.ts
@@ -251,6 +251,7 @@ export function transcriptFromMessages(messages: readonly unknown[], fallbackTim
 
     const text = messageText(message);
     const attachments = messageAttachments(message);
+    const contextTokens = role === "assistant" ? messageContextTokens(message) : undefined;
     if (text || attachments.length > 0) {
       transcript.push({
         kind: "message",
@@ -258,6 +259,7 @@ export function transcriptFromMessages(messages: readonly unknown[], fallbackTim
         role,
         text,
         ...(attachments.length > 0 ? { attachments } : {}),
+        ...(contextTokens != null ? { contextTokens } : {}),
         createdAt,
       });
     }
@@ -268,6 +270,15 @@ export function transcriptFromMessages(messages: readonly unknown[], fallbackTim
   }
 
   return transcript;
+}
+
+function messageContextTokens(message: Record<string, unknown>): number | undefined {
+  const usage = message.usage;
+  if (!isRecord(usage)) {
+    return undefined;
+  }
+  const total = usage.totalTokens;
+  return typeof total === "number" && Number.isFinite(total) && total > 0 ? total : undefined;
 }
 
 function messageCreatedAt(message: Record<string, unknown>, fallback: string): string {

--- a/packages/pi-sdk-driver/src/transcript.ts
+++ b/packages/pi-sdk-driver/src/transcript.ts
@@ -24,6 +24,9 @@ export interface SessionTranscriptMessage {
   readonly attachments?: readonly SessionTranscriptAttachment[];
   readonly createdAt: string;
   readonly id: string;
+  /** Total tokens (prompt + completion) reported for the turn that produced this
+   * assistant message — i.e. the context occupancy after that turn. */
+  readonly contextTokens?: number;
 }
 
 export interface SessionTranscriptToolCall {

--- a/packages/session-driver/src/runtime-types.ts
+++ b/packages/session-driver/src/runtime-types.ts
@@ -33,6 +33,7 @@ export interface RuntimeModelRecord {
   readonly authType: RuntimeAuthType;
   readonly reasoning: boolean;
   readonly supportsImages: boolean;
+  readonly contextWindow?: number;
 }
 
 export interface RuntimeSkillRecord {


### PR DESCRIPTION
## What

Shows how full the model's context window is, right in the composer footer:

```
Enter to send · Shift+Enter for newline · provider:model · 201k / 1.0M (19%)
```

pi already reports per-turn usage (`usage.totalTokens` = prompt + completion, i.e. context occupancy after the turn) and the model catalog carries `contextWindow` — both were dropped on the way to the UI.

## How

- `SessionTranscriptMessage.contextTokens` (from the assistant record's `usage.totalTokens`) and `RuntimeModelRecord.contextWindow` plumb the two numbers through.
- The composer footer renders the last completed turn's occupancy against the active model's window; hidden until a turn has reported usage, falls back to the bare count when the model has no known window.
- Live-event assistant messages don't carry usage, so on `runCompleted` the settled transcript is re-read from the session file (one parse per turn, not per tick) — guarded to never replace a richer live timeline with a shorter parse (lagging file, or drivers that don't persist transcripts, as in the e2e harness).

## Verification

- `tests/core/timeline-pinning.spec.ts` 10/10, `pnpm typecheck` clean.
- Live: fresh threads show the indicator right as their first turn completes; long-standing threads show it on load; compaction is reflected on the next turn (the number is always the last turn's real usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)