### PR TITLE
feat: add dashboard view with thread kanban and usage analytics

### DIFF
--- a/apps/desktop/electron/dashboard-usage.ts
+++ b/apps/desktop/electron/dashboard-usage.ts
@@ -1,0 +1,333 @@
+// Dashboard usage aggregation: scans pi session JSONL transcripts under
+// ~/.pi/agent/sessions and aggregates token/cost usage by day, ISO week, and
+// year, plus per-period model breakdowns.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type {
+  DashboardPeriodModels,
+  DashboardUsageByDay,
+  DashboardUsageByModel,
+  DashboardUsagePeriodKind,
+  DashboardUsageSnapshot,
+  DashboardUsageTotals,
+} from "../src/ipc";
+
+interface UsageFields {
+  readonly input: number;
+  readonly output: number;
+  readonly cacheRead: number;
+  readonly cacheWrite: number;
+  readonly totalTokens: number;
+  readonly cost?: {
+    readonly input?: number;
+    readonly output?: number;
+    readonly cacheRead?: number;
+    readonly cacheWrite?: number;
+    readonly total?: number;
+  };
+}
+
+interface SessionMessage {
+  readonly provider?: unknown;
+  readonly model?: unknown;
+  readonly usage?: unknown;
+}
+
+interface MessageEvent {
+  readonly type?: unknown;
+  readonly timestamp?: unknown;
+  readonly message?: SessionMessage;
+}
+
+interface ParsedUsageEvent {
+  readonly day: string;
+  readonly week: string;
+  readonly year: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly input: number;
+  readonly output: number;
+  readonly cacheRead: number;
+  readonly cost: number;
+}
+
+interface MutableBucket {
+  date: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
+interface MutableModel {
+  model: string;
+  provider: string;
+  messages: number;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function sessionsRoot(): string {
+  return join(homedir(), ".pi", "agent", "sessions");
+}
+
+function listSessionFiles(dir: string, out: string[] = []): string[] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, String(entry.name));
+    if (entry.isDirectory()) {
+      listSessionFiles(full, out);
+    } else if (entry.isFile() && String(entry.name).endsWith(".jsonl")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function dateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function mondayOf(date: Date): Date {
+  const d = new Date(date.getTime());
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function scanSignature(root: string): string {
+  const parts: string[] = [];
+  for (const file of listSessionFiles(root)) {
+    try {
+      const stat = statSync(file);
+      parts.push(`${file}:${stat.mtimeMs}:${stat.size}`);
+    } catch {
+      // File disappeared between listing and stat; ignore it.
+    }
+  }
+  return parts.join("|");
+}
+
+// Parsed events cache keyed on (path, mtimeMs, size) of every session file;
+// skips rescanning when nothing changed on disk.
+let eventsCache: { signature: string; events: ParsedUsageEvent[] } | undefined;
+
+function parseAllEvents(): ParsedUsageEvent[] {
+  const events: ParsedUsageEvent[] = [];
+  for (const file of listSessionFiles(sessionsRoot())) {
+    let content: string;
+    try {
+      content = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of content.split("\n")) {
+      if (!line.includes('"totalTokens"')) {
+        continue;
+      }
+      let event: MessageEvent;
+      try {
+        event = JSON.parse(line) as MessageEvent;
+      } catch {
+        continue;
+      }
+      if (event.type !== "message") {
+        continue;
+      }
+      const message = event.message;
+      if (!message || typeof message !== "object") {
+        continue;
+      }
+      const usage = message.usage as UsageFields | undefined;
+      if (!usage || typeof usage !== "object") {
+        continue;
+      }
+      const input = numberOrZero(usage.input);
+      const output = numberOrZero(usage.output);
+      const cacheRead = numberOrZero(usage.cacheRead);
+      const totalTokens = numberOrZero(usage.totalTokens);
+      const cost = numberOrZero(usage.cost?.total);
+      if (totalTokens === 0 && cost === 0) {
+        continue;
+      }
+      const timestamp = typeof event.timestamp === "string" ? event.timestamp : "";
+      const date = new Date(timestamp);
+      if (Number.isNaN(date.getTime())) {
+        continue;
+      }
+      events.push({
+        day: dateKey(date),
+        week: dateKey(mondayOf(date)),
+        year: String(date.getFullYear()),
+        provider: typeof message.provider === "string" ? message.provider : "unknown",
+        model: typeof message.model === "string" ? message.model : "unknown",
+        input,
+        output,
+        cacheRead,
+        cost,
+      });
+    }
+  }
+  return events;
+}
+
+function getEvents(): ParsedUsageEvent[] {
+  const root = sessionsRoot();
+  const signature = scanSignature(root);
+  if (eventsCache && eventsCache.signature === signature) {
+    return eventsCache.events;
+  }
+  const events = parseAllEvents();
+  eventsCache = { signature, events };
+  return events;
+}
+
+function bucketToSnapshot(bucket: MutableBucket): DashboardUsageByDay {
+  return {
+    date: bucket.date,
+    inputTokens: bucket.inputTokens,
+    outputTokens: bucket.outputTokens,
+    cacheReadTokens: bucket.cacheReadTokens,
+    cost: Math.round(bucket.cost * 10000) / 10000,
+  };
+}
+
+function collectBuckets(
+  events: readonly ParsedUsageEvent[],
+  select: (event: ParsedUsageEvent) => string,
+): DashboardUsageByDay[] {
+  const map = new Map<string, MutableBucket>();
+  for (const event of events) {
+    const key = select(event);
+    let bucket = map.get(key);
+    if (!bucket) {
+      bucket = { date: key, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cost: 0 };
+      map.set(key, bucket);
+    }
+    bucket.inputTokens += event.input;
+    bucket.outputTokens += event.output;
+    bucket.cacheReadTokens += event.cacheRead;
+    bucket.cost += event.cost;
+  }
+  return [...map.values()].sort((a, b) => a.date.localeCompare(b.date)).map(bucketToSnapshot);
+}
+
+export function readDashboardUsage(): DashboardUsageSnapshot {
+  const events = getEvents();
+
+  const days = collectBuckets(events, (event) => event.day);
+  const weeks = collectBuckets(events, (event) => event.week);
+  const years = collectBuckets(events, (event) => event.year);
+
+  const modelMap = new Map<string, MutableModel>();
+  const totals = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cost: 0 };
+  for (const event of events) {
+    totals.inputTokens += event.input;
+    totals.outputTokens += event.output;
+    totals.cacheReadTokens += event.cacheRead;
+    totals.cost += event.cost;
+    const modelKey = `${event.provider}/${event.model}`;
+    let entry = modelMap.get(modelKey);
+    if (!entry) {
+      entry = { model: event.model, provider: event.provider, messages: 0, inputTokens: 0, outputTokens: 0, cost: 0 };
+      modelMap.set(modelKey, entry);
+    }
+    entry.messages += 1;
+    entry.inputTokens += event.input;
+    entry.outputTokens += event.output;
+    entry.cost += event.cost;
+  }
+
+  const byModel = [...modelMap.values()]
+    .sort((a, b) => b.cost - a.cost || b.inputTokens + b.outputTokens - (a.inputTokens + a.outputTokens))
+    .slice(0, 10)
+    .map((entry) => ({
+      model: entry.model,
+      provider: entry.provider,
+      messages: entry.messages,
+      inputTokens: entry.inputTokens,
+      outputTokens: entry.outputTokens,
+      cost: Math.round(entry.cost * 10000) / 10000,
+    }));
+
+  return {
+    days,
+    weeks,
+    years,
+    totals: {
+      inputTokens: Math.round(totals.inputTokens),
+      outputTokens: Math.round(totals.outputTokens),
+      cacheReadTokens: Math.round(totals.cacheReadTokens),
+      cost: Math.round(totals.cost * 10000) / 10000,
+    },
+    byModel,
+  };
+}
+
+export function readDashboardUsageForPeriod(
+  kind: DashboardUsagePeriodKind,
+  key: string,
+): DashboardPeriodModels {
+  const events = getEvents();
+  const filtered = events.filter((event) =>
+    kind === "day" ? event.day === key : kind === "week" ? event.week === key : event.year === key,
+  );
+
+  const modelMap = new Map<string, MutableModel>();
+  const totals = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cost: 0 };
+  for (const event of filtered) {
+    totals.inputTokens += event.input;
+    totals.outputTokens += event.output;
+    totals.cacheReadTokens += event.cacheRead;
+    totals.cost += event.cost;
+    const modelKey = `${event.provider}/${event.model}`;
+    let entry = modelMap.get(modelKey);
+    if (!entry) {
+      entry = { model: event.model, provider: event.provider, messages: 0, inputTokens: 0, outputTokens: 0, cost: 0 };
+      modelMap.set(modelKey, entry);
+    }
+    entry.messages += 1;
+    entry.inputTokens += event.input;
+    entry.outputTokens += event.output;
+    entry.cost += event.cost;
+  }
+
+  return {
+    kind,
+    key,
+    models: [...modelMap.values()]
+      .sort((a, b) => b.cost - a.cost || b.inputTokens + b.outputTokens - (a.inputTokens + a.outputTokens))
+      .map((entry) => ({
+        model: entry.model,
+        provider: entry.provider,
+        messages: entry.messages,
+        inputTokens: entry.inputTokens,
+        outputTokens: entry.outputTokens,
+        cost: Math.round(entry.cost * 10000) / 10000,
+      })),
+    totals: {
+      inputTokens: Math.round(totals.inputTokens),
+      outputTokens: Math.round(totals.outputTokens),
+      cacheReadTokens: Math.round(totals.cacheReadTokens),
+      cost: Math.round(totals.cost * 10000) / 10000,
+    },
+  };
+}

--- a/apps/desktop/electron/dashboard-usage.ts
+++ b/apps/desktop/electron/dashboard-usage.ts
@@ -18,6 +18,7 @@ interface UsageFields {
   readonly output: number;
   readonly cacheRead: number;
   readonly cacheWrite: number;
+  readonly reasoning?: number;
   readonly totalTokens: number;
   readonly cost?: {
     readonly input?: number;
@@ -49,6 +50,7 @@ interface ParsedUsageEvent {
   readonly input: number;
   readonly output: number;
   readonly cacheRead: number;
+  readonly reasoning: number;
   readonly cost: number;
 }
 
@@ -57,6 +59,7 @@ interface MutableBucket {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
+  reasoningTokens: number;
   cost: number;
 }
 
@@ -66,6 +69,7 @@ interface MutableModel {
   messages: number;
   inputTokens: number;
   outputTokens: number;
+  reasoningTokens: number;
   cost: number;
 }
 
@@ -90,7 +94,7 @@ function listSessionFiles(dir: string, out: string[] = []): string[] {
       out.push(full);
     }
   }
-  return out;
+  return out.sort();
 }
 
 function dateKey(date: Date): string {
@@ -113,90 +117,98 @@ function numberOrZero(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-function scanSignature(root: string): string {
-  const parts: string[] = [];
-  for (const file of listSessionFiles(root)) {
-    try {
-      const stat = statSync(file);
-      parts.push(`${file}:${stat.mtimeMs}:${stat.size}`);
-    } catch {
-      // File disappeared between listing and stat; ignore it.
-    }
+// Per-file parsed-event cache. A session transcript is appended to while a
+// conversation streams, so the cache key is (mtimeMs, size) per file rather
+// than a whole-tree signature — only files that changed since the last read
+// get re-parsed, and deleted files are pruned.
+const fileCache = new Map<string, { mtimeMs: number; size: number; events: ParsedUsageEvent[] }>();
+
+function parseFileEvents(file: string): ParsedUsageEvent[] {
+  let content: string;
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    return [];
   }
-  return parts.join("|");
-}
-
-// Parsed events cache keyed on (path, mtimeMs, size) of every session file;
-// skips rescanning when nothing changed on disk.
-let eventsCache: { signature: string; events: ParsedUsageEvent[] } | undefined;
-
-function parseAllEvents(): ParsedUsageEvent[] {
   const events: ParsedUsageEvent[] = [];
-  for (const file of listSessionFiles(sessionsRoot())) {
-    let content: string;
+  for (const line of content.split("\n")) {
+    if (!line.includes('"totalTokens"')) {
+      continue;
+    }
+    let event: MessageEvent;
     try {
-      content = readFileSync(file, "utf8");
+      event = JSON.parse(line) as MessageEvent;
     } catch {
       continue;
     }
-    for (const line of content.split("\n")) {
-      if (!line.includes('"totalTokens"')) {
-        continue;
-      }
-      let event: MessageEvent;
-      try {
-        event = JSON.parse(line) as MessageEvent;
-      } catch {
-        continue;
-      }
-      if (event.type !== "message") {
-        continue;
-      }
-      const message = event.message;
-      if (!message || typeof message !== "object") {
-        continue;
-      }
-      const usage = message.usage as UsageFields | undefined;
-      if (!usage || typeof usage !== "object") {
-        continue;
-      }
-      const input = numberOrZero(usage.input);
-      const output = numberOrZero(usage.output);
-      const cacheRead = numberOrZero(usage.cacheRead);
-      const totalTokens = numberOrZero(usage.totalTokens);
-      const cost = numberOrZero(usage.cost?.total);
-      if (totalTokens === 0 && cost === 0) {
-        continue;
-      }
-      const timestamp = typeof event.timestamp === "string" ? event.timestamp : "";
-      const date = new Date(timestamp);
-      if (Number.isNaN(date.getTime())) {
-        continue;
-      }
-      events.push({
-        day: dateKey(date),
-        week: dateKey(mondayOf(date)),
-        year: String(date.getFullYear()),
-        provider: typeof message.provider === "string" ? message.provider : "unknown",
-        model: typeof message.model === "string" ? message.model : "unknown",
-        input,
-        output,
-        cacheRead,
-        cost,
-      });
+    if (event.type !== "message") {
+      continue;
     }
+    const message = event.message;
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const usage = message.usage as UsageFields | undefined;
+    if (!usage || typeof usage !== "object") {
+      continue;
+    }
+    const input = numberOrZero(usage.input);
+    const output = numberOrZero(usage.output);
+    const cacheRead = numberOrZero(usage.cacheRead);
+    const reasoning = numberOrZero(usage.reasoning);
+    const totalTokens = numberOrZero(usage.totalTokens);
+    const cost = numberOrZero(usage.cost?.total);
+    if (totalTokens === 0 && cost === 0) {
+      continue;
+    }
+    const timestamp = typeof event.timestamp === "string" ? event.timestamp : "";
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) {
+      continue;
+    }
+    events.push({
+      day: dateKey(date),
+      week: dateKey(mondayOf(date)),
+      year: String(date.getFullYear()),
+      provider: typeof message.provider === "string" ? message.provider : "unknown",
+      model: typeof message.model === "string" ? message.model : "unknown",
+      input,
+      output,
+      cacheRead,
+      reasoning,
+      cost,
+    });
   }
   return events;
 }
 
 function getEvents(): ParsedUsageEvent[] {
   const root = sessionsRoot();
-  const signature = scanSignature(root);
-  if (eventsCache && eventsCache.signature === signature) {
-    return eventsCache.events;
+  const files = listSessionFiles(root);
+  const seen = new Set<string>();
+  const events: ParsedUsageEvent[] = [];
+  for (const file of files) {
+    seen.add(file);
+    let stat;
+    try {
+      stat = statSync(file);
+    } catch {
+      continue;
+    }
+    const cached = fileCache.get(file);
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+      events.push(...cached.events);
+      continue;
+    }
+    const parsed = parseFileEvents(file);
+    fileCache.set(file, { mtimeMs: stat.mtimeMs, size: stat.size, events: parsed });
+    events.push(...parsed);
   }
-  const events = parseAllEvents();
-  eventsCache = { signature, events };
+  for (const key of fileCache.keys()) {
+    if (!seen.has(key)) {
+      fileCache.delete(key);
+    }
+  }
   return events;
 }
 
@@ -206,6 +218,7 @@ function bucketToSnapshot(bucket: MutableBucket): DashboardUsageByDay {
     inputTokens: bucket.inputTokens,
     outputTokens: bucket.outputTokens,
     cacheReadTokens: bucket.cacheReadTokens,
+    reasoningTokens: bucket.reasoningTokens,
     cost: Math.round(bucket.cost * 10000) / 10000,
   };
 }
@@ -219,12 +232,13 @@ function collectBuckets(
     const key = select(event);
     let bucket = map.get(key);
     if (!bucket) {
-      bucket = { date: key, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cost: 0 };
+      bucket = { date: key, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, reasoningTokens: 0, cost: 0 };
       map.set(key, bucket);
     }
     bucket.inputTokens += event.input;
     bucket.outputTokens += event.output;
     bucket.cacheReadTokens += event.cacheRead;
+    bucket.reasoningTokens += event.reasoning;
     bucket.cost += event.cost;
   }
   return [...map.values()].sort((a, b) => a.date.localeCompare(b.date)).map(bucketToSnapshot);
@@ -238,26 +252,28 @@ export function readDashboardUsage(): DashboardUsageSnapshot {
   const years = collectBuckets(events, (event) => event.year);
 
   const modelMap = new Map<string, MutableModel>();
-  const totals = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cost: 0 };
+  const totals = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, reasoningTokens: 0, cost: 0 };
   for (const event of events) {
     totals.inputTokens += event.input;
     totals.outputTokens += event.output;
     totals.cacheReadTokens += event.cacheRead;
+    totals.reasoningTokens += event.reasoning;
     totals.cost += event.cost;
     const modelKey = `${event.provider}/${event.model}`;
     let entry = modelMap.get(modelKey);
     if (!entry) {
-      entry = { model: event.model, provider: event.provider, messages: 0, inputTokens: 0, outputTokens: 0, cost: 0 };
+      entry = { model: event.model, provider: event.provider, messages: 0, inputTokens: 0, outputTokens: 0, reasoningTokens: 0, cost: 0 };
       modelMap.set(modelKey, entry);
     }
     entry.messages += 1;
     entry.inputTokens += event.input;
     entry.outputTokens += event.output;
+    entry.reasoningTokens += event.reasoning;
     entry.cost += event.cost;
   }
 
   const byModel = [...modelMap.values()]
-    .sort((a, b) => b.cost - a.cost || b.inputTokens + b.outputTokens - (a.inputTokens + a.outputTokens))
+    .sort((a, b) => b.cost - a.cost || b.inputTokens + b.outputTokens + b.reasoningTokens - (a.inputTokens + a.outputTokens + a.reasoningTokens))
     .slice(0, 10)
     .map((entry) => ({
       model: entry.model,
@@ -265,6 +281,7 @@ export function readDashboardUsage(): DashboardUsageSnapshot {
       messages: entry.messages,
       inputTokens: entry.inputTokens,
       outputTokens: entry.outputTokens,
+      reasoningTokens: entry.reasoningTokens,
       cost: Math.round(entry.cost * 10000) / 10000,
     }));
 
@@ -276,6 +293,7 @@ export function readDashboardUsage(): DashboardUsageSnapshot {
       inputTokens: Math.round(totals.inputTokens),
       outputTokens: Math.round(totals.outputTokens),
       cacheReadTokens: Math.round(totals.cacheReadTokens),
+      reasoningTokens: Math.round(totals.reasoningTokens),
       cost: Math.round(totals.cost * 10000) / 10000,
     },
     byModel,
@@ -292,21 +310,23 @@ export function readDashboardUsageForPeriod(
   );
 
   const modelMap = new Map<string, MutableModel>();
-  const totals = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cost: 0 };
+  const totals = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, reasoningTokens: 0, cost: 0 };
   for (const event of filtered) {
     totals.inputTokens += event.input;
     totals.outputTokens += event.output;
     totals.cacheReadTokens += event.cacheRead;
+    totals.reasoningTokens += event.reasoning;
     totals.cost += event.cost;
     const modelKey = `${event.provider}/${event.model}`;
     let entry = modelMap.get(modelKey);
     if (!entry) {
-      entry = { model: event.model, provider: event.provider, messages: 0, inputTokens: 0, outputTokens: 0, cost: 0 };
+      entry = { model: event.model, provider: event.provider, messages: 0, inputTokens: 0, outputTokens: 0, reasoningTokens: 0, cost: 0 };
       modelMap.set(modelKey, entry);
     }
     entry.messages += 1;
     entry.inputTokens += event.input;
     entry.outputTokens += event.output;
+    entry.reasoningTokens += event.reasoning;
     entry.cost += event.cost;
   }
 
@@ -314,19 +334,21 @@ export function readDashboardUsageForPeriod(
     kind,
     key,
     models: [...modelMap.values()]
-      .sort((a, b) => b.cost - a.cost || b.inputTokens + b.outputTokens - (a.inputTokens + a.outputTokens))
+      .sort((a, b) => b.cost - a.cost || b.inputTokens + b.outputTokens + b.reasoningTokens - (a.inputTokens + a.outputTokens + a.reasoningTokens))
       .map((entry) => ({
         model: entry.model,
         provider: entry.provider,
         messages: entry.messages,
         inputTokens: entry.inputTokens,
         outputTokens: entry.outputTokens,
+        reasoningTokens: entry.reasoningTokens,
         cost: Math.round(entry.cost * 10000) / 10000,
       })),
     totals: {
       inputTokens: Math.round(totals.inputTokens),
       outputTokens: Math.round(totals.outputTokens),
       cacheReadTokens: Math.round(totals.cacheReadTokens),
+      reasoningTokens: Math.round(totals.reasoningTokens),
       cost: Math.round(totals.cost * 10000) / 10000,
     },
   };

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -44,7 +44,9 @@ import {
   type CustomProviderConfig,
   type CustomProviderProbeInput,
   type CustomProviderProbeResult,
+  type DashboardUsageQuery,
 } from "../src/ipc";
+import { readDashboardUsage, readDashboardUsageForPeriod } from "./dashboard-usage";
 import { SUPPORTED_COMPOSER_IMAGE_TYPES } from "../src/composer-attachments";
 import type {
   ComposerAttachment,
@@ -1172,6 +1174,11 @@ app.whenReady().then(async () => {
     }
     await shell.openPath(workspacePath);
   });
+  ipcMain.handle(desktopIpc.dashboardUsage, (_event, query?: DashboardUsageQuery) =>
+    query && query.kind && query.key
+      ? readDashboardUsageForPeriod(query.kind, query.key)
+      : readDashboardUsage(),
+  );
   ipcMain.handle(desktopIpc.createWorktree, (event, input: CreateWorktreeInput) =>
     runWindowScopedForEvent(event, () => store.createWorktree(input)),
   );

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -6,6 +6,9 @@ import {
   type CustomProviderProbeInput,
   type CustomProviderProbeResult,
   type ChangedFilesResult,
+  type DashboardPeriodModels,
+  type DashboardUsageQuery,
+  type DashboardUsageSnapshot,
   type DesktopNotificationPermissionStatus,
   type WorkspaceFilePreview,
   type PiDesktopCommand,
@@ -121,6 +124,8 @@ contextBridge.exposeInMainWorld("piApp", {
     };
   },
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
+  getDashboardUsage: () =>
+    ipcRenderer.invoke(desktopIpc.dashboardUsage) as Promise<DashboardUsageSnapshot>,
   addWorkspacePath: (workspacePath: string) =>
     ipcRenderer.invoke(desktopIpc.addWorkspacePath, workspacePath) as Promise<DesktopAppState>,
   pickWorkspace: () => ipcRenderer.invoke(desktopIpc.pickWorkspace) as Promise<DesktopAppState>,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -126,6 +126,8 @@ contextBridge.exposeInMainWorld("piApp", {
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
   getDashboardUsage: () =>
     ipcRenderer.invoke(desktopIpc.dashboardUsage) as Promise<DashboardUsageSnapshot>,
+  getDashboardPeriodModels: (query: DashboardUsageQuery) =>
+    ipcRenderer.invoke(desktopIpc.dashboardUsage, query) as Promise<DashboardPeriodModels>,
   addWorkspacePath: (workspacePath: string) =>
     ipcRenderer.invoke(desktopIpc.addWorkspacePath, workspacePath) as Promise<DesktopAppState>,
   pickWorkspace: () => ipcRenderer.invoke(desktopIpc.pickWorkspace) as Promise<DesktopAppState>,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -26,6 +26,7 @@ import { deriveModelOnboardingState } from "./model-onboarding";
 import type { SettingsSection } from "./settings-view";
 import { SecondarySurfaces } from "./app/secondary-surfaces";
 import { NewThreadView } from "./new-thread-view";
+import { DashboardView } from "./dashboard-view";
 import { buildThreadGroups } from "./thread-groups";
 import { Sidebar } from "./sidebar";
 import { SidebarToggleButton } from "./sidebar-toggle-button";
@@ -831,7 +832,15 @@ export default function App() {
           terminalPanel
         ) : (
           <>
-        {snapshot.activeView === "new-thread" ? (
+        {snapshot.activeView === "dashboard" ? (
+          <DashboardView
+            workspaces={snapshot.workspaces}
+            onOpenSession={(workspaceId, sessionId) => {
+              void updateSnapshot(api, setSnapshot, () => api.selectSession({ workspaceId, sessionId }));
+              setActiveView("threads");
+            }}
+          />
+        ) : snapshot.activeView === "new-thread" ? (
           rootWorkspaceOptions.length > 0 ? (
             <NewThreadView
               workspaces={rootWorkspaceOptions}

--- a/apps/desktop/src/dashboard-view.tsx
+++ b/apps/desktop/src/dashboard-view.tsx
@@ -1,0 +1,543 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  DashboardPeriodModels,
+  DashboardUsageByDay,
+  DashboardUsageByModel,
+  DashboardUsagePeriodKind,
+  DashboardUsageSnapshot,
+} from "./ipc";
+import type { SessionRecord, WorkspaceRecord } from "./desktop-state";
+import { DashboardIcon, RefreshIcon } from "./icons";
+import { formatRelativeTime } from "./string-utils";
+
+interface DashboardViewProps {
+  readonly workspaces: readonly WorkspaceRecord[];
+  readonly onOpenSession: (workspaceId: string, sessionId: string) => void;
+}
+
+interface SessionWithWorkspace {
+  readonly workspace: WorkspaceRecord;
+  readonly session: SessionRecord;
+}
+
+interface WindowEntry {
+  readonly key: string;
+  readonly bucket: DashboardUsageByDay;
+}
+
+const COLUMNS = [
+  { kind: "running", label: "Running" },
+  { kind: "idle", label: "Idle" },
+  { kind: "archived", label: "Archived" },
+] as const;
+
+type ColumnKind = (typeof COLUMNS)[number]["kind"];
+
+const WINDOW_SIZES: Record<DashboardUsagePeriodKind, number> = { day: 14, week: 12, year: 6 };
+const GRANULARITY_LABELS: Record<DashboardUsagePeriodKind, string> = {
+  day: "Day",
+  week: "Week",
+  year: "Year",
+};
+
+export function DashboardView({ workspaces, onOpenSession }: DashboardViewProps) {
+  const [usage, setUsage] = useState<DashboardUsageSnapshot | null>(null);
+  const [usageError, setUsageError] = useState<string | null>(null);
+  const [workspaceFilter, setWorkspaceFilter] = useState("all");
+  const [granularity, setGranularity] = useState<DashboardUsagePeriodKind>("day");
+  const [anchor, setAnchor] = useState(() => todayKey());
+  const [selected, setSelected] = useState<{ kind: DashboardUsagePeriodKind; key: string } | null>(null);
+  const [periodDetail, setPeriodDetail] = useState<DashboardPeriodModels | null>(null);
+  const [periodError, setPeriodError] = useState<string | null>(null);
+
+  const loadUsage = useCallback(() => {
+    setUsageError(null);
+    const api = window.piApp;
+    if (!api) {
+      return;
+    }
+    void api.getDashboardUsage().then(
+      (snapshot) => setUsage(snapshot),
+      (error: unknown) => setUsageError(error instanceof Error ? error.message : String(error)),
+    );
+  }, []);
+
+  useEffect(() => {
+    loadUsage();
+  }, [loadUsage]);
+
+  const allSessions = useMemo<readonly SessionWithWorkspace[]>(
+    () =>
+      workspaces.flatMap((workspace) =>
+        workspace.sessions.map((session) => ({ workspace, session })),
+      ),
+    [workspaces],
+  );
+
+  const filteredSessions = useMemo(
+    () =>
+      workspaceFilter === "all"
+        ? allSessions
+        : allSessions.filter((entry) => entry.workspace.id === workspaceFilter),
+    [allSessions, workspaceFilter],
+  );
+
+  const columns = useMemo(() => {
+    const group: Record<ColumnKind, SessionWithWorkspace[]> = {
+      running: [],
+      idle: [],
+      archived: [],
+    };
+    for (const entry of filteredSessions) {
+      if (entry.session.archivedAt) {
+        group.archived.push(entry);
+      } else if (entry.session.status === "running") {
+        group.running.push(entry);
+      } else {
+        group.idle.push(entry);
+      }
+    }
+    return group;
+  }, [filteredSessions]);
+
+  const windowSize = WINDOW_SIZES[granularity];
+  const today = todayKey();
+
+  const anchorKey = useMemo(() => {
+    if (granularity === "day") {
+      return anchor;
+    }
+    if (granularity === "week") {
+      return mondayKeyOf(anchor);
+    }
+    return anchor.slice(0, 4);
+  }, [granularity, anchor]);
+
+  const buckets = useMemo(() => {
+    if (!usage) {
+      return [];
+    }
+    return granularity === "day" ? usage.days : granularity === "week" ? usage.weeks : usage.years;
+  }, [usage, granularity]);
+
+  const windowEntries = useMemo<readonly WindowEntry[]>(
+    () => buildWindow(buckets, granularity, anchorKey, windowSize),
+    [buckets, granularity, anchorKey, windowSize],
+  );
+
+  const windowTotals = useMemo(() => {
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheReadTokens = 0;
+    let cost = 0;
+    for (const entry of windowEntries) {
+      inputTokens += entry.bucket.inputTokens;
+      outputTokens += entry.bucket.outputTokens;
+      cacheReadTokens += entry.bucket.cacheReadTokens;
+      cost += entry.bucket.cost;
+    }
+    return { inputTokens, outputTokens, cacheReadTokens, cost };
+  }, [windowEntries]);
+
+  const maxTokens = useMemo(
+    () => Math.max(1, ...windowEntries.map((entry) => entry.bucket.inputTokens + entry.bucket.outputTokens)),
+    [windowEntries],
+  );
+
+  const cacheHitRate = useMemo(() => {
+    const total = windowTotals.cacheReadTokens + windowTotals.inputTokens;
+    return total > 0 ? windowTotals.cacheReadTokens / total : 0;
+  }, [windowTotals]);
+
+  const handleGranularityChange = (kind: DashboardUsagePeriodKind) => {
+    setGranularity(kind);
+    setSelected(null);
+    setPeriodDetail(null);
+    setPeriodError(null);
+  };
+
+  const shiftAnchor = (direction: -1 | 1) => {
+    if (granularity === "day") {
+      setAnchor(addDays(anchor, direction));
+    } else if (granularity === "week") {
+      setAnchor(addDays(anchor, direction * 7));
+    } else {
+      const date = parseKey(anchor);
+      date.setFullYear(date.getFullYear() + direction);
+      setAnchor(dateKeyOf(date));
+    }
+  };
+
+  const handleSelectPeriod = (entry: WindowEntry) => {
+    const kind = granularity;
+    const key = entry.key;
+    setSelected({ kind, key });
+    setPeriodDetail(null);
+    setPeriodError(null);
+    const api = window.piApp;
+    if (!api) {
+      return;
+    }
+    void api.getDashboardPeriodModels({ kind, key }).then(
+      (detail) => setPeriodDetail(detail),
+      (error: unknown) => setPeriodError(error instanceof Error ? error.message : String(error)),
+    );
+  };
+
+  const labelEvery = window.length > 15 ? 5 : 1;
+
+  return (
+    <section className="canvas canvas--dashboard">
+      <div className="dashboard">
+        <header className="dashboard__header">
+          <div className="dashboard__heading">
+            <h1>Dashboard</h1>
+            <span className="dashboard__subtitle">Threads and token usage across workspaces</span>
+          </div>
+          <div className="dashboard__controls">
+            <label className="dashboard__filter">
+              <span>Workspace</span>
+              <select value={workspaceFilter} onChange={(event) => setWorkspaceFilter(event.target.value)}>
+                <option value="all">All</option>
+                {workspaces.map((workspace) => (
+                  <option key={workspace.id} value={workspace.id}>
+                    {workspace.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button className="dashboard__refresh" type="button" onClick={loadUsage} disabled={!usage && !usageError}>
+              <RefreshIcon />
+              <span>Refresh</span>
+            </button>
+          </div>
+        </header>
+
+        <div className="dashboard__section">
+          <h2 className="dashboard__section-title">Usage</h2>
+          {usageError ? (
+            <div className="dashboard__notice dashboard__notice--error" role="status">
+              Failed to load usage: {usageError}
+            </div>
+          ) : !usage ? (
+            <div className="dashboard__notice">Loading usage…</div>
+          ) : (
+            <div className="dashboard__usage">
+              <div className="dashboard__kpis">
+                <div className="kpi-card">
+                  <span className="kpi-card__label">Window tokens</span>
+                  <span className="kpi-card__value">
+                    {formatTokens(windowTotals.inputTokens + windowTotals.outputTokens)}
+                  </span>
+                </div>
+                <div className="kpi-card">
+                  <span className="kpi-card__label">Window cost</span>
+                  <span className="kpi-card__value">{formatCost(windowTotals.cost)}</span>
+                </div>
+                <div className="kpi-card">
+                  <span className="kpi-card__label">Total cost</span>
+                  <span className="kpi-card__value">{formatCost(usage.totals.cost)}</span>
+                </div>
+                <div className="kpi-card">
+                  <span className="kpi-card__label">Cache hit rate</span>
+                  <span className="kpi-card__value">{(cacheHitRate * 100).toFixed(0)}%</span>
+                </div>
+              </div>
+
+              <div className="chart">
+                <div className="chart__toolbar">
+                  <div className="chart__tabs" role="tablist" aria-label="Granularity">
+                    {(["day", "week", "year"] as const).map((kind) => (
+                      <button
+                        key={kind}
+                        type="button"
+                        role="tab"
+                        aria-selected={granularity === kind}
+                        className={`chart__tab ${granularity === kind ? "chart__tab--active" : ""}`}
+                        onClick={() => handleGranularityChange(kind)}
+                      >
+                        {GRANULARITY_LABELS[kind]}
+                      </button>
+                    ))}
+                  </div>
+                  <div className="chart__nav">
+                    <button type="button" className="chart__nav-btn" onClick={() => shiftAnchor(-1)} aria-label="Earlier">
+                      ‹
+                    </button>
+                    <label className="chart__date">
+                      <span>{granularity === "day" ? "Ends" : granularity === "week" ? "Week of" : "Year"}</span>
+                      <input
+                        type="date"
+                        value={anchor}
+                        max={today}
+                        onChange={(event) => {
+                          if (event.target.value) {
+                            setAnchor(event.target.value);
+                          }
+                        }}
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      className="chart__nav-btn"
+                      onClick={() => shiftAnchor(1)}
+                      disabled={anchorKey >= todayAnchorKey(granularity)}
+                      aria-label="Later"
+                    >
+                      ›
+                    </button>
+                  </div>
+                </div>
+
+                <div className="bar-chart" role="img" aria-label={`Token usage per ${granularity}`}>
+                  {windowEntries.map((entry, index) => {
+                    const total = entry.bucket.inputTokens + entry.bucket.outputTokens;
+                    const height = Math.max(2, Math.round((total / maxTokens) * 100));
+                    const isSelected = selected?.kind === granularity && selected.key === entry.key;
+                    return (
+                      <div
+                        key={entry.key}
+                        className={`bar-chart__bar-wrap ${isSelected ? "bar-chart__bar-wrap--selected" : ""}`}
+                        title={`${periodTitle(granularity, entry.key)}: ${formatTokens(total)} tokens · ${formatCost(entry.bucket.cost)}`}
+                      >
+                        <button
+                          type="button"
+                          className="bar-chart__bar"
+                          style={{ height: `${height}%` }}
+                          onClick={() => handleSelectPeriod(entry)}
+                          aria-label={`Select ${periodTitle(granularity, entry.key)}`}
+                        />
+                        {index % labelEvery === 0 ? (
+                          <span className="bar-chart__label">{barLabel(granularity, entry.key)}</span>
+                        ) : (
+                          <span className="bar-chart__label bar-chart__label--empty" />
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {selected ? (
+                <div className="chart">
+                  <div className="chart__head">
+                    <h3>{periodTitle(selected.kind, selected.key)}</h3>
+                    <button
+                      type="button"
+                      className="chart__clear"
+                      onClick={() => {
+                        setSelected(null);
+                        setPeriodDetail(null);
+                        setPeriodError(null);
+                      }}
+                    >
+                      × Show all-time
+                    </button>
+                  </div>
+                  {periodError ? (
+                    <div className="dashboard__notice dashboard__notice--error">{periodError}</div>
+                  ) : !periodDetail ? (
+                    <div className="dashboard__notice">Loading period…</div>
+                  ) : (
+                    <>
+                      <div className="dashboard__kpis">
+                        <div className="kpi-card">
+                          <span className="kpi-card__label">Tokens</span>
+                          <span className="kpi-card__value">
+                            {formatTokens(periodDetail.totals.inputTokens + periodDetail.totals.outputTokens)}
+                          </span>
+                        </div>
+                        <div className="kpi-card">
+                          <span className="kpi-card__label">Cost</span>
+                          <span className="kpi-card__value">{formatCost(periodDetail.totals.cost)}</span>
+                        </div>
+                        <div className="kpi-card">
+                          <span className="kpi-card__label">Cache read</span>
+                          <span className="kpi-card__value">{formatTokens(periodDetail.totals.cacheReadTokens)}</span>
+                        </div>
+                      </div>
+                      {periodDetail.models.length === 0 ? (
+                        <div className="dashboard__notice">No usage in this period.</div>
+                      ) : (
+                        <ModelBars models={periodDetail.models} />
+                      )}
+                    </>
+                  )}
+                </div>
+              ) : (
+                <div className="chart">
+                  <h3>Top models (all time)</h3>
+                  {usage.byModel.length === 0 ? (
+                    <div className="dashboard__notice">No usage recorded yet.</div>
+                  ) : (
+                    <ModelBars models={usage.byModel} />
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="dashboard__section">
+          <h2 className="dashboard__section-title">Threads</h2>
+          <div className="kanban">
+            {COLUMNS.map((column) => {
+              const items = columns[column.kind];
+              return (
+                <div key={column.kind} className="kanban__column">
+                  <h3 className="kanban__column-head">
+                    {column.label}
+                    <span className="kanban__count">{items.length}</span>
+                  </h3>
+                  <div className="kanban__cards">
+                    {items.length === 0 ? (
+                      <p className="kanban__empty">Nothing here</p>
+                    ) : (
+                      items.map(({ workspace, session }) => (
+                        <button
+                          key={session.id}
+                          type="button"
+                          className="kanban__card"
+                          onClick={() => onOpenSession(workspace.id, session.id)}
+                        >
+                          <span className="kanban__card-title">{session.title || "Untitled"}</span>
+                          <span className="kanban__card-preview">{session.preview || "No preview yet"}</span>
+                          <span className="kanban__card-meta">
+                            <span>{workspace.name}</span>
+                            <span>{formatRelativeTime(session.updatedAt)}</span>
+                          </span>
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <footer className="dashboard__footer">
+          <DashboardIcon />
+          <span>Dashboard is read-only. Open a card to continue a thread.</span>
+        </footer>
+      </div>
+    </section>
+  );
+}
+
+function ModelBars({ models }: { readonly models: readonly DashboardUsageByModel[] }) {
+  const maxCost = Math.max(1, ...models.map((entry) => entry.cost));
+  return (
+    <ul className="model-bars">
+      {models.map((entry) => (
+        <li key={`${entry.provider}/${entry.model}`} className="model-bar">
+          <span className="model-bar__label">
+            {entry.model}
+            <span className="model-bar__meta">
+              {entry.provider} · {entry.messages} msgs · {formatTokens(entry.inputTokens + entry.outputTokens)} ·{" "}
+              {formatCost(entry.cost)}
+            </span>
+          </span>
+          <span className="model-bar__track">
+            <span
+              className="model-bar__fill"
+              style={{ width: `${Math.max(1, Math.round((entry.cost / maxCost) * 100))}%` }}
+            />
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function buildWindow(
+  buckets: readonly DashboardUsageByDay[],
+  kind: DashboardUsagePeriodKind,
+  anchorKey: string,
+  size: number,
+): WindowEntry[] {
+  const map = new Map(buckets.map((bucket) => [bucket.date, bucket]));
+  const todayAnchor = todayAnchorKey(kind);
+  const end = anchorKey > todayAnchor ? todayAnchor : anchorKey;
+  const out: WindowEntry[] = [];
+  const zero = (key: string): DashboardUsageByDay => ({
+    date: key,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cost: 0,
+  });
+  for (let i = size - 1; i >= 0; i -= 1) {
+    const key =
+      kind === "day"
+        ? addDays(end, -i)
+        : kind === "week"
+          ? addDays(end, -7 * i)
+          : String(Number(end) - i);
+    out.push({ key, bucket: map.get(key) ?? zero(key) });
+  }
+  return out;
+}
+
+function todayAnchorKey(kind: DashboardUsagePeriodKind): string {
+  const today = todayKey();
+  return kind === "day" ? today : kind === "week" ? mondayKeyOf(today) : today.slice(0, 4);
+}
+
+function todayKey(): string {
+  return dateKeyOf(new Date());
+}
+
+function dateKeyOf(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function parseKey(key: string): Date {
+  const [y = 0, m = 1, d = 1] = key.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function addDays(key: string, days: number): string {
+  const date = parseKey(key);
+  date.setDate(date.getDate() + days);
+  return dateKeyOf(date);
+}
+
+function mondayKeyOf(key: string): string {
+  const date = parseKey(key);
+  const day = date.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setDate(date.getDate() + diff);
+  return dateKeyOf(date);
+}
+
+function barLabel(kind: DashboardUsagePeriodKind, key: string): string {
+  return kind === "year" ? key : key.slice(5);
+}
+
+function periodTitle(kind: DashboardUsagePeriodKind, key: string): string {
+  if (kind === "day") {
+    return key;
+  }
+  if (kind === "week") {
+    return `Week of ${key}`;
+  }
+  return key;
+}
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  return String(Math.round(value));
+}
+
+function formatCost(value: number): string {
+  return `$${value.toFixed(4)}`;
+}

--- a/apps/desktop/src/dashboard-view.tsx
+++ b/apps/desktop/src/dashboard-view.tsx
@@ -129,14 +129,16 @@ export function DashboardView({ workspaces, onOpenSession }: DashboardViewProps)
     let inputTokens = 0;
     let outputTokens = 0;
     let cacheReadTokens = 0;
+    let reasoningTokens = 0;
     let cost = 0;
     for (const entry of windowEntries) {
       inputTokens += entry.bucket.inputTokens;
       outputTokens += entry.bucket.outputTokens;
       cacheReadTokens += entry.bucket.cacheReadTokens;
+      reasoningTokens += entry.bucket.reasoningTokens;
       cost += entry.bucket.cost;
     }
-    return { inputTokens, outputTokens, cacheReadTokens, cost };
+    return { inputTokens, outputTokens, cacheReadTokens, reasoningTokens, cost };
   }, [windowEntries]);
 
   const maxTokens = useMemo(
@@ -227,7 +229,7 @@ export function DashboardView({ workspaces, onOpenSession }: DashboardViewProps)
                 <div className="kpi-card">
                   <span className="kpi-card__label">Window tokens</span>
                   <span className="kpi-card__value">
-                    {formatTokens(windowTotals.inputTokens + windowTotals.outputTokens)}
+                    {formatTokens(windowTotals.inputTokens + windowTotals.outputTokens + windowTotals.reasoningTokens)}
                   </span>
                 </div>
                 <div className="kpi-card">
@@ -344,7 +346,7 @@ export function DashboardView({ workspaces, onOpenSession }: DashboardViewProps)
                         <div className="kpi-card">
                           <span className="kpi-card__label">Tokens</span>
                           <span className="kpi-card__value">
-                            {formatTokens(periodDetail.totals.inputTokens + periodDetail.totals.outputTokens)}
+                            {formatTokens(periodDetail.totals.inputTokens + periodDetail.totals.outputTokens + periodDetail.totals.reasoningTokens)}
                           </span>
                         </div>
                         <div className="kpi-card">
@@ -434,7 +436,7 @@ function ModelBars({ models }: { readonly models: readonly DashboardUsageByModel
           <span className="model-bar__label">
             {entry.model}
             <span className="model-bar__meta">
-              {entry.provider} · {entry.messages} msgs · {formatTokens(entry.inputTokens + entry.outputTokens)} ·{" "}
+              {entry.provider} · {entry.messages} msgs · {formatTokens(entry.inputTokens + entry.outputTokens + entry.reasoningTokens)} ·{" "}
               {formatCost(entry.cost)}
             </span>
           </span>
@@ -465,6 +467,7 @@ function buildWindow(
     inputTokens: 0,
     outputTokens: 0,
     cacheReadTokens: 0,
+    reasoningTokens: 0,
     cost: 0,
   });
   for (let i = size - 1; i >= 0; i -= 1) {

--- a/apps/desktop/src/desktop-state.ts
+++ b/apps/desktop/src/desktop-state.ts
@@ -6,7 +6,7 @@ export type SessionStatus = "idle" | "running" | "failed";
 export type { SessionRole, TimelineToolCall, TranscriptMessage } from "./timeline-types";
 import type { TranscriptMessage } from "./timeline-types";
 
-export type AppView = "threads" | "new-thread" | "skills" | "extensions" | "settings";
+export type AppView = "threads" | "new-thread" | "skills" | "extensions" | "settings" | "dashboard";
 export type WorkspaceKind = "primary" | "worktree";
 export type WorktreeStatus = "ready" | "missing" | "error";
 export type NewThreadEnvironment = "local" | "worktree";

--- a/apps/desktop/src/icons.tsx
+++ b/apps/desktop/src/icons.tsx
@@ -280,6 +280,17 @@ export function StatusIcon() {
   );
 }
 
+export function DashboardIcon() {
+  return (
+    <Icon>
+      <rect x="3.5" y="3.5" width="5.4" height="5.4" rx="1.2" stroke="currentColor" strokeWidth="1.3" />
+      <rect x="11.1" y="3.5" width="5.4" height="5.4" rx="1.2" stroke="currentColor" strokeWidth="1.3" />
+      <rect x="3.5" y="11.1" width="5.4" height="5.4" rx="1.2" stroke="currentColor" strokeWidth="1.3" />
+      <rect x="11.1" y="11.1" width="5.4" height="5.4" rx="1.2" stroke="currentColor" strokeWidth="1.3" />
+    </Icon>
+  );
+}
+
 export function SkillIcon() {
   return (
     <Icon>

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -52,6 +52,52 @@ export type CustomProviderProbeResult =
   | { readonly ok: true; readonly models: readonly string[] }
   | { readonly ok: false; readonly error: string };
 
+export type DashboardUsagePeriodKind = "day" | "week" | "year";
+
+export interface DashboardUsageByDay {
+  readonly date: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cost: number;
+}
+
+export interface DashboardUsageByModel {
+  readonly model: string;
+  readonly provider: string;
+  readonly messages: number;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cost: number;
+}
+
+export interface DashboardUsageTotals {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cost: number;
+}
+
+export interface DashboardUsageSnapshot {
+  readonly days: readonly DashboardUsageByDay[];
+  readonly weeks: readonly DashboardUsageByDay[];
+  readonly years: readonly DashboardUsageByDay[];
+  readonly totals: DashboardUsageTotals;
+  readonly byModel: readonly DashboardUsageByModel[];
+}
+
+export interface DashboardUsageQuery {
+  readonly kind: DashboardUsagePeriodKind;
+  readonly key: string;
+}
+
+export interface DashboardPeriodModels {
+  readonly kind: DashboardUsagePeriodKind;
+  readonly key: string;
+  readonly models: readonly DashboardUsageByModel[];
+  readonly totals: DashboardUsageTotals;
+}
+
 export const desktopIpc = {
   stateRequest: "pi-gui:state-request",
   stateChanged: "pi-gui:state-changed",
@@ -86,6 +132,7 @@ export const desktopIpc = {
   setChildSupervisionLoop: "pi-gui:set-child-supervision-loop",
   cancelCurrentRun: "pi-gui:cancel-current-run",
   setActiveView: "pi-gui:set-active-view",
+  dashboardUsage: "pi-gui:dashboard-usage",
   setSidebarCollapsed: "pi-gui:set-sidebar-collapsed",
   refreshRuntime: "pi-gui:refresh-runtime",
   setModelSettingsScopeMode: "pi-gui:set-model-settings-scope-mode",
@@ -319,6 +366,8 @@ export interface PiDesktopApi {
   setChildSupervisionLoop(input: SetChildSupervisionLoopInput): Promise<DesktopAppState>;
   cancelCurrentRun(): Promise<DesktopAppState>;
   setActiveView(view: AppView): Promise<DesktopAppState>;
+  getDashboardUsage(): Promise<DashboardUsageSnapshot>;
+  getDashboardPeriodModels(query: DashboardUsageQuery): Promise<DashboardPeriodModels>;
   setSidebarCollapsed(collapsed: boolean): Promise<DesktopAppState>;
   refreshRuntime(workspaceId?: string): Promise<DesktopAppState>;
   setModelSettingsScopeMode(mode: ModelSettingsScopeMode): Promise<DesktopAppState>;

--- a/apps/desktop/src/ipc.ts
+++ b/apps/desktop/src/ipc.ts
@@ -59,6 +59,7 @@ export interface DashboardUsageByDay {
   readonly inputTokens: number;
   readonly outputTokens: number;
   readonly cacheReadTokens: number;
+  readonly reasoningTokens: number;
   readonly cost: number;
 }
 
@@ -68,6 +69,7 @@ export interface DashboardUsageByModel {
   readonly messages: number;
   readonly inputTokens: number;
   readonly outputTokens: number;
+  readonly reasoningTokens: number;
   readonly cost: number;
 }
 
@@ -75,6 +77,7 @@ export interface DashboardUsageTotals {
   readonly inputTokens: number;
   readonly outputTokens: number;
   readonly cacheReadTokens: number;
+  readonly reasoningTokens: number;
   readonly cost: number;
 }
 

--- a/apps/desktop/src/sidebar.tsx
+++ b/apps/desktop/src/sidebar.tsx
@@ -14,7 +14,7 @@ import {
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { AppView, SessionRecord, WorkspaceRecord, WorktreeRecord } from "./desktop-state";
-import { ArchiveIcon, ChevronDownIcon, ExtensionIcon, FolderIcon, PinIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
+import { ArchiveIcon, ChevronDownIcon, DashboardIcon, ExtensionIcon, FolderIcon, PinIcon, PlusIcon, RestoreIcon, SettingsIcon, SkillIcon, WorktreeIcon } from "./icons";
 import type { PiDesktopApi } from "./ipc";
 import { formatRelativeTime } from "./string-utils";
 import type { WorkspaceMenuState } from "./hooks/use-workspace-menu";
@@ -227,6 +227,14 @@ export function Sidebar(props: SidebarProps) {
           >
             <FolderIcon />
             <span>Threads</span>
+          </button>
+          <button
+            className={`sidebar__nav-item ${activeView === "dashboard" ? "sidebar__nav-item--active" : ""}`}
+            type="button"
+            onClick={() => onSetActiveView("dashboard")}
+          >
+            <DashboardIcon />
+            <span>Dashboard</span>
           </button>
           <button
             className="sidebar__nav-item"

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -4,6 +4,7 @@
 @import "./styles/topbar.css";
 @import "./styles/model-selector-panel.css";
 @import "./styles/new-thread.css";
+@import "./styles/dashboard.css";
 @import "./styles/main.css";
 @import "./styles/timeline.css";
 @import "./styles/syntax-highlight.css";

--- a/apps/desktop/src/styles/dashboard.css
+++ b/apps/desktop/src/styles/dashboard.css
@@ -1,0 +1,463 @@
+.canvas--dashboard {
+  overflow-y: auto;
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 24px 28px;
+  max-width: 1200px;
+}
+
+.dashboard__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.dashboard__heading h1 {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-weight: var(--font-bold);
+  color: var(--text-strong);
+}
+
+.dashboard__subtitle {
+  color: var(--muted);
+  font-size: var(--text-sm);
+}
+
+.dashboard__controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dashboard__filter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: var(--text-sm);
+}
+
+.dashboard__filter select {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 4px 8px;
+  font-size: var(--text-sm);
+}
+
+.dashboard__refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 5px 10px;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+.dashboard__refresh:hover {
+  background: var(--surface-overlay-hover);
+}
+
+.dashboard__refresh svg {
+  width: 14px;
+  height: 14px;
+}
+
+.dashboard__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dashboard__section-title {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: var(--font-semibold);
+  color: var(--text-strong);
+}
+
+.dashboard__notice {
+  color: var(--muted);
+  font-size: var(--text-sm);
+  padding: 12px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-md);
+}
+
+.dashboard__notice--error {
+  color: var(--error);
+  border-color: var(--danger-tint-border);
+}
+
+.dashboard__kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.kpi-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  background: var(--surface-overlay);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+}
+
+.kpi-card__label {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.kpi-card__value {
+  font-size: var(--text-lg);
+  font-weight: var(--font-bold);
+  color: var(--text-strong);
+}
+
+.chart {
+  padding: 14px 16px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+}
+
+.chart h3 {
+  margin: 0 0 12px;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text);
+}
+
+.chart__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.chart__tabs {
+  display: inline-flex;
+  gap: 2px;
+  background: var(--surface-overlay);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 2px;
+}
+
+.chart__tab {
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font-size: var(--text-xs);
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.chart__tab--active {
+  background: var(--accent-tint-bg);
+  color: var(--text-strong);
+  font-weight: var(--font-semibold);
+}
+
+.chart__nav {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chart__nav-btn {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: var(--text-md);
+  line-height: 1;
+}
+
+.chart__nav-btn:hover:not(:disabled) {
+  background: var(--surface-overlay-hover);
+}
+
+.chart__nav-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.chart__date {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
+.chart__date input[type="date"] {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  padding: 3px 6px;
+  font-size: var(--text-xs);
+}
+
+.chart__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.chart__head h3 {
+  margin: 0;
+}
+
+.chart__clear {
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  font-size: var(--text-xs);
+  padding: 3px 8px;
+  cursor: pointer;
+}
+
+.chart__clear:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.bar-chart {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  height: 150px;
+}
+
+.bar-chart__bar-wrap {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 2px;
+}
+
+.bar-chart__bar {
+  width: 100%;
+  min-height: 2px;
+  border: none;
+  padding: 0;
+  background: var(--accent);
+  border-radius: 2px 2px 0 0;
+  opacity: 0.85;
+  cursor: pointer;
+}
+
+.bar-chart__bar:hover {
+  opacity: 1;
+}
+
+.bar-chart__bar-wrap--selected .bar-chart__bar {
+  background: var(--status-running, var(--accent));
+  opacity: 1;
+  outline: 2px solid var(--line-strong);
+  outline-offset: 1px;
+}
+
+.bar-chart__label {
+  height: 14px;
+  font-size: 10px;
+  color: var(--muted);
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.bar-chart__label--empty {
+  visibility: hidden;
+}
+
+.model-bars {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.model-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.model-bar__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  font-size: var(--text-sm);
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+}
+
+.model-bar__meta {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-family: var(--font-normal, sans-serif);
+}
+
+.model-bar__track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--surface-overlay-muted);
+  overflow: hidden;
+}
+
+.model-bar__fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+}
+
+.kanban {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .kanban {
+    grid-template-columns: 1fr;
+  }
+}
+
+.kanban__column {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 120px;
+}
+
+.kanban__column-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-strong);
+}
+
+.kanban__count {
+  background: var(--surface-overlay);
+  border: 1px solid var(--line);
+  color: var(--muted);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  padding: 1px 8px;
+}
+
+.kanban__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kanban__card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  padding: 10px 12px;
+  background: var(--surface-overlay);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.kanban__card:hover {
+  background: var(--surface-overlay-hover);
+  border-color: var(--line-strong);
+}
+
+.kanban__card-title {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kanban__card-preview {
+  font-size: var(--text-xs);
+  color: var(--muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.kanban__card-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--text-xs);
+  color: var(--muted-subtle, var(--muted));
+}
+
+.kanban__empty {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  padding: 12px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-md);
+  text-align: center;
+}
+
+.dashboard__footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: var(--text-xs);
+  padding-top: 8px;
+  border-top: 1px solid var(--line);
+}
+
+.dashboard__footer svg {
+  width: 14px;
+  height: 14px;
+}


### PR DESCRIPTION
## Summary

Adds a **Dashboard** view to pi-gui (new sidebar entry with grid icon):

- **Thread kanban** — Running / Idle / Archived columns, per-workspace filter, click a card to jump to that thread.
- **Usage analytics** — KPI cards (window tokens / window cost / total cost / cache hit rate), a date-labeled bar chart with **Day / Week / Year** granularity and window navigation (prev/next + date picker), and **period drill-down** showing per-model token/cost breakdown for a selected day/week/year.

## Implementation

- New typed IPC channel `pi-gui:dashboard-usage`; the main process aggregates usage events from pi session JSONL transcripts under `~/.pi/agent/sessions` (day / ISO-week / year buckets, mtime-cached to avoid rescanning).
- Renderer/main/preload boundary stays tight (all data flows through the typed IPC surface); **no new dependencies** — charts are pure CSS/SVG.
- Only `apps/desktop` touched; `pi-sdk-driver` / `session-driver` / `catalogs` untouched.

## Verification

- `pnpm typecheck` (all workspaces)
- `pnpm lint`
- `pnpm --filter @pi-gui/desktop build`
- Manually verified in a packaged local build: kanban rendering, workspace filter, card click-through, day/week/year switching, period drill-down, theme switching.

The full e2e test lane requires Playwright browser setup and runs in CI; the change doesn't alter existing flows (new view + read-only IPC only).
