### PR TITLE
fix(desktop): make GFM tables compact and locally scrollable

### DIFF
--- a/apps/desktop/src/message-markdown.tsx
+++ b/apps/desktop/src/message-markdown.tsx
@@ -13,6 +13,11 @@ const MARKDOWN_COMPONENTS = {
       {children}
     </a>
   ),
+  table: ({ children }: { children?: React.ReactNode }) => (
+    <div className="message__table-scroll">
+      <table>{children}</table>
+    </div>
+  ),
 } as const;
 
 export function MessageMarkdown({ text }: { readonly text: string }) {

--- a/apps/desktop/src/styles/timeline.css
+++ b/apps/desktop/src/styles/timeline.css
@@ -767,6 +767,7 @@
 .message__content {
   color: var(--text-strong);
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 9px;
   line-height: 1.65;
   max-width: 100%;
@@ -849,6 +850,34 @@
 
 .message__content a:hover {
   text-decoration: underline;
+}
+
+.message__table-scroll {
+  width: max-content;
+  max-width: 100%;
+  min-width: 0;
+  justify-self: start;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.message__table-scroll table {
+  width: max-content;
+  border-collapse: collapse;
+  font-size: 0.95em;
+}
+
+.message__table-scroll th,
+.message__table-scroll td {
+  padding: var(--space-1-5) var(--space-2-5);
+  border: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.message__table-scroll th {
+  background: var(--overlay-subtle);
+  font-weight: var(--font-semibold);
 }
 
 /* ---- Reduced motion ----------------------------------------------------- */

--- a/apps/desktop/tests/core/message-markdown.spec.ts
+++ b/apps/desktop/tests/core/message-markdown.spec.ts
@@ -29,6 +29,18 @@ const markdownResponse = [
   "Open the [issue](https://github.com/minghinmatthewlam/pi-gui/issues/19).",
 ].join("\n");
 
+const tableResponse = [
+  "## Table layout proof",
+  "",
+  "| Key | Value |",
+  "| --- | --- |",
+  "| Status | Ready |",
+  "",
+  "| Package | Platform | Architecture | Artifact | Checksum | Distribution channel |",
+  "| --- | --- | --- | --- | --- | --- |",
+  `| desktop | macOS | arm64 | ${"pi-gui-release-artifact-".repeat(4)}.dmg | ${"abcdef0123456789".repeat(4)} | GitHub prerelease with automatic updates |`,
+].join("\n");
+
 test("renders markdown formatting in assistant responses", async () => {
   test.setTimeout(60_000);
   const userDataDir = await makeUserDataDir();
@@ -89,6 +101,74 @@ test("renders markdown formatting in assistant responses", async () => {
         fullPage: true,
       });
     }
+  } finally {
+    await secondRun.close();
+  }
+});
+
+test("keeps compact GFM tables content-sized and scrolls wide tables locally", async () => {
+  test.setTimeout(60_000);
+  const userDataDir = await makeUserDataDir();
+  const workspacePath = await makeWorkspace("message-markdown-tables-workspace");
+  const firstRun = await launchDesktop(userDataDir, {
+    initialWorkspaces: [workspacePath],
+    testMode: "background",
+  });
+
+  let workspaceId = "";
+  let sessionId = "";
+  try {
+    const window = await firstRun.firstWindow();
+    await waitForWorkspaceByPath(window, workspacePath);
+    await createNamedThread(window, "Markdown table proof thread");
+    const state = await getDesktopState(window);
+    workspaceId = state.selectedWorkspaceId;
+    sessionId = state.selectedSessionId;
+  } finally {
+    await firstRun.close();
+  }
+
+  const sessionFilePath = await sessionFilePathFromCatalog(userDataDir, { workspaceId, sessionId });
+  await appendMessagesToSessionFile(sessionFilePath, [
+    { role: "user", text: "Return tables with compact and wide content." },
+    { role: "assistant", text: tableResponse },
+  ]);
+
+  const secondRun = await launchDesktop(userDataDir, { testMode: "background" });
+  try {
+    const window = await secondRun.firstWindow();
+    await waitForWorkspaceByPath(window, workspacePath);
+
+    const messageRow = window.locator(".timeline-item--assistant", { hasText: "Table layout proof" });
+    await expect(messageRow).toBeVisible();
+    const tableScrollers = messageRow.locator(".message__table-scroll");
+    await expect(tableScrollers).toHaveCount(2);
+
+    await expect.poll(() => messageRow.evaluate((element) => {
+      const content = element.querySelector<HTMLElement>(".message__content");
+      const transcript = document.querySelector<HTMLElement>('[data-testid="transcript"]');
+      const scrollers = element.querySelectorAll<HTMLElement>(".message__table-scroll");
+      if (!content || !transcript || scrollers.length !== 2) {
+        throw new Error("Expected message content, transcript, and two table scrollers");
+      }
+
+      const compact = scrollers[0];
+      const wide = scrollers[1];
+      const tolerance = 1;
+      return {
+        compactUsesContentWidth: compact.clientWidth < content.clientWidth - 80,
+        compactNeedsNoHorizontalScroll: compact.scrollWidth <= compact.clientWidth + tolerance,
+        wideStaysWithinContent: wide.getBoundingClientRect().right <= content.getBoundingClientRect().right + tolerance,
+        wideHasLocalHorizontalScroll: wide.scrollWidth > wide.clientWidth + tolerance,
+        transcriptHasNoHorizontalOverflow: transcript.scrollWidth <= transcript.clientWidth + tolerance,
+      };
+    })).toEqual({
+      compactUsesContentWidth: true,
+      compactNeedsNoHorizontalScroll: true,
+      wideStaysWithinContent: true,
+      wideHasLocalHorizontalScroll: true,
+      transcriptHasNoHorizontalOverflow: true,
+    });
   } finally {
     await secondRun.close();
   }


### PR DESCRIPTION
## What changed

- Wrap rendered GFM tables in a dedicated horizontal scroll container.
- Keep compact tables at their intrinsic content width.
- Constrain wide tables to the message column so only the table scrolls, not the transcript.
- Add token-based table borders, spacing, and header styling.
- Add Electron E2E coverage for compact sizing, local overflow, and transcript containment.

## Why

Markdown tables currently inherit the message grid's stretch behavior. Small tables occupy the full reading column, while sufficiently wide tables can enlarge the transcript instead of creating a local scroll surface.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @pi-gui/desktop run test:e2e:runner -- apps/desktop/tests/core/message-markdown.spec.ts` — 2 passed
- `pnpm --filter @pi-gui/desktop run test:e2e:runner -- apps/desktop/tests/core/message-wrapping.spec.ts` — 1 passed
- `pnpm --filter @pi-gui/desktop run test:e2e:core` — 131 passed; one pre-existing virtualized timeline stability test timed out
- Isolated rerun of the timed-out timeline stability test — passed